### PR TITLE
Expose IAudioStreamVolume from WsapiOut, and AudioClient.

### DIFF
--- a/NAudio/CoreAudioApi/AudioClient.cs
+++ b/NAudio/CoreAudioApi/AudioClient.cs
@@ -15,6 +15,7 @@ namespace NAudio.CoreAudioApi
         private AudioRenderClient audioRenderClient;
         private AudioCaptureClient audioCaptureClient;
         private AudioClockClient audioClockClient;
+        private AudioStreamVolume audioStreamVolume;
 
         internal AudioClient(IAudioClient audioClientInterface)
         {
@@ -132,9 +133,26 @@ namespace NAudio.CoreAudioApi
 
         // TODO: GetService:
         // IID_IAudioSessionControl
-        // IID_IAudioStreamVolume
         // IID_IChannelAudioVolume
         // IID_ISimpleAudioVolume
+
+        /// <summary>
+        /// Returns the AudioStreamVolume service for this AudioClient.
+        /// </summary>
+        public AudioStreamVolume AudioStreamVolume
+        {
+            get
+            {
+                if (audioStreamVolume == null)
+                {
+                    object audioStreamVolumeInterface;
+                    var audioStreamVolumeGuid = new Guid("93014887-242D-4068-8A15-CF5E93B90FE3");
+                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(audioStreamVolumeGuid, out audioStreamVolumeInterface));
+                    audioStreamVolume = new AudioStreamVolume((IAudioStreamVolume)audioStreamVolumeInterface);
+                }
+                return audioStreamVolume;
+            }
+        }
 
         /// <summary>
         /// Gets the AudioClockClient service
@@ -291,6 +309,11 @@ namespace NAudio.CoreAudioApi
                 {
                     audioCaptureClient.Dispose();
                     audioCaptureClient = null;
+                }
+                if (audioStreamVolume != null)
+                {
+                    audioStreamVolume.Dispose();
+                    audioStreamVolume = null;
                 }
                 Marshal.ReleaseComObject(audioClientInterface);
                 audioClientInterface = null;

--- a/NAudio/CoreAudioApi/AudioClient.cs
+++ b/NAudio/CoreAudioApi/AudioClient.cs
@@ -16,6 +16,7 @@ namespace NAudio.CoreAudioApi
         private AudioCaptureClient audioCaptureClient;
         private AudioClockClient audioClockClient;
         private AudioStreamVolume audioStreamVolume;
+        private AudioClientShareMode shareMode;
 
         internal AudioClient(IAudioClient audioClientInterface)
         {
@@ -58,6 +59,7 @@ namespace NAudio.CoreAudioApi
             WaveFormat waveFormat,
             Guid audioSessionGuid)
         {
+            this.shareMode = shareMode;
             int hresult = audioClientInterface.Initialize(shareMode, streamFlags, bufferDuration, periodicity, waveFormat, ref audioSessionGuid);
             Marshal.ThrowExceptionForHR(hresult);
             // may have changed the mix format so reset it
@@ -139,10 +141,20 @@ namespace NAudio.CoreAudioApi
         /// <summary>
         /// Returns the AudioStreamVolume service for this AudioClient.
         /// </summary>
+        /// <remarks>
+        /// This returns the AudioStreamVolume object ONLY for shared audio streams.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// This is thrown when an exclusive audio stream is being used.
+        /// </exception>
         public AudioStreamVolume AudioStreamVolume
         {
             get
             {
+                if (shareMode == AudioClientShareMode.Exclusive)
+                {
+                    throw new InvalidOperationException("AudioStreamVolume is ONLY supported for shared audio streams.");
+                }
                 if (audioStreamVolume == null)
                 {
                     object audioStreamVolumeInterface;

--- a/NAudio/CoreAudioApi/AudioStreamVolume.cs
+++ b/NAudio/CoreAudioApi/AudioStreamVolume.cs
@@ -1,0 +1,170 @@
+﻿using NAudio.CoreAudioApi.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi
+{
+    /// <summary>
+    /// Manages the AudioStreamVolume for the <see cref="AudioClient"/>.
+    /// </summary>
+    public class AudioStreamVolume : IDisposable
+    {
+        IAudioStreamVolume audioStreamVolumeInterface;
+
+        internal AudioStreamVolume(IAudioStreamVolume audioStreamVolumeInterface)
+        {
+            this.audioStreamVolumeInterface = audioStreamVolumeInterface;
+        }
+
+        /// <summary>
+        /// Verify that the channel index is valid.
+        /// </summary>
+        /// <param name="channelIndex"></param>
+        /// <param name="parameter"></param>
+        private void CheckChannelIndex(int channelIndex, string parameter)
+        {
+            int channelCount = ChannelCount;
+            if (channelIndex >= channelCount)
+            {
+                throw new ArgumentOutOfRangeException(parameter, "You must supply a valid channel index < current count of channels: " + channelCount.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Return the current stream volumes for all channels
+        /// </summary>
+        /// <returns>An array of volume levels between 0.0 and 1.0 for each channel in the audio stream.</returns>
+        public float[] GetAllVolumes()
+        {
+            uint channels;
+            float[] levels;
+            Marshal.ThrowExceptionForHR(audioStreamVolumeInterface.GetChannelCount(out channels));
+            levels = new float[channels];
+            Marshal.ThrowExceptionForHR(audioStreamVolumeInterface.GetAllVolumes(channels, levels));
+            return levels;
+        }
+
+        /// <summary>
+        /// Returns the current number of channels in this audio stream.
+        /// </summary>
+        public int ChannelCount
+        {
+            get
+            {
+                uint channels;
+                Marshal.ThrowExceptionForHR(audioStreamVolumeInterface.GetChannelCount(out channels));
+                unchecked
+                {
+                    return (int)channels;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Return the current volume for the requested channel.
+        /// </summary>
+        /// <param name="channelIndex">The 0 based index into the channels.</param>
+        /// <returns>The volume level for the channel between 0.0 and 1.0.</returns>
+        public float GetChannelVolume(int channelIndex)
+        {
+            CheckChannelIndex(channelIndex, "channelIndex");
+
+            uint index;
+            float level;
+            unchecked 
+            {
+                index = (uint)channelIndex;
+            }
+            Marshal.ThrowExceptionForHR(audioStreamVolumeInterface.GetChannelVolume(index, out level));
+            return level;
+        }
+
+        /// <summary>
+        /// Set the volume level for each channel of the audio stream.
+        /// </summary>
+        /// <param name="levels">An array of volume levels (between 0.0 and 1.0) one for each channel.</param>
+        /// <remarks>
+        /// A volume level MUST be supplied for reach channel in the audio stream.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="levels"/> does not contain <see cref="ChannelCount"/> elements.
+        /// </exception>
+        public void SetAllVolumes(float[] levels)
+        {
+            // Make friendly Net exceptions for common problems:
+            int channelCount = ChannelCount;
+            if (levels == null)
+            {
+                throw new ArgumentNullException("levels");
+            }
+            if (levels.Length != channelCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    "levels",
+                    String.Format(CultureInfo.InvariantCulture, "SetAllVolumes MUST be supplied with a volume level for ALL channels. The AudioStream has {0} channels and you supplied {1} channels.",
+                                  channelCount, levels.Length));
+            }
+            for (int i = 0; i < levels.Length; i++)
+            {
+                float level = levels[i];
+                if (level < 0.0f) throw new ArgumentOutOfRangeException("levels", "All volumes must be between 0.0 and 1.0. Invalid volume at index: " + i.ToString());
+                if (level > 1.0f) throw new ArgumentOutOfRangeException("levels", "All volumes must be between 0.0 and 1.0. Invalid volume at index: " + i.ToString());
+            }
+            unchecked
+            {
+                Marshal.ThrowExceptionForHR(audioStreamVolumeInterface.SetAllVoumes((uint)channelCount, levels));
+            }
+        }
+
+        /// <summary>
+        /// Sets the volume level for one channel in the audio stream.
+        /// </summary>
+        /// <param name="index">The 0-based index into the channels to adjust the volume of.</param>
+        /// <param name="level">The volume level between 0.0 and 1.0 for this channel of the audio stream.</param>
+        public void SetChannelVolume(int index, float level)
+        {
+            CheckChannelIndex(index, "index");
+
+            if (level < 0.0f) throw new ArgumentOutOfRangeException("level", "Volume must be between 0.0 and 1.0");
+            if (level > 1.0f) throw new ArgumentOutOfRangeException("level", "Volume must be between 0.0 and 1.0");
+            unchecked
+            {
+                Marshal.ThrowExceptionForHR(audioStreamVolumeInterface.SetChannelVolume((uint)index, level));
+            }
+        }
+
+        #region IDisposable Members
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Release/cleanup objects during Dispose/finalization.
+        /// </summary>
+        /// <param name="disposing">True if disposing and false if being finalized.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (audioStreamVolumeInterface != null)
+                {
+                    // although GC would do this for us, we want it done now
+                    Marshal.ReleaseComObject(audioStreamVolumeInterface);
+                    audioStreamVolumeInterface = null;
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/NAudio/CoreAudioApi/Interfaces/IAudioStreamVolume.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IAudioStreamVolume.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi.Interfaces
+{
+    [Guid("93014887-242D-4068-8A15-CF5E93B90FE3"),
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IAudioStreamVolume
+    {
+        [PreserveSig]
+        int GetChannelCount(
+            [Out] out uint dwCount);
+
+        [PreserveSig]
+        int SetChannelVolume(
+            [In] uint dwIndex,
+            [In] float fLevel);
+
+        [PreserveSig]
+        int GetChannelVolume(
+            [In] uint dwIndex,
+            [Out] out float fLevel);
+
+        [PreserveSig]
+        int SetAllVoumes(
+            [In] uint dwCount,
+            [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4, SizeParamIndex=0)] float[] fVolumes);
+
+        [PreserveSig]
+        int GetAllVolumes(
+          [In]   uint dwCount,
+          [MarshalAs(UnmanagedType.LPArray)]  float []pfVolumes);
+    }
+}

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -99,6 +99,7 @@
     <Compile Include="CoreAudioApi\AudioSessionEventsCallback.cs" />
     <Compile Include="CoreAudioApi\AudioSessionManager.cs" />
     <Compile Include="CoreAudioApi\AudioStreamCategory.cs" />
+    <Compile Include="CoreAudioApi\AudioStreamVolume.cs" />
     <Compile Include="CoreAudioApi\AudioVolumeNotificationData.cs" />
     <Compile Include="CoreAudioApi\Interfaces\AudioVolumeNotificationDataStruct.cs" />
     <Compile Include="CoreAudioApi\Interfaces\ErrorCodes.cs" />
@@ -110,6 +111,7 @@
     <Compile Include="CoreAudioApi\Interfaces\IAudioSessionEvents.cs" />
     <Compile Include="CoreAudioApi\Interfaces\IAudioSessionEventsHandler.cs" />
     <Compile Include="CoreAudioApi\Interfaces\IAudioSessionManager.cs" />
+    <Compile Include="CoreAudioApi\Interfaces\IAudioStreamVolume.cs" />
     <Compile Include="CoreAudioApi\Interfaces\ISimpleAudioVolume.cs" />
     <Compile Include="CoreAudioApi\MMDeviceCollection.cs" />
     <Compile Include="CoreAudioApi\PropertyKeys.cs" />

--- a/NAudio/Wave/WaveOutputs/WasapiOut.cs
+++ b/NAudio/Wave/WaveOutputs/WasapiOut.cs
@@ -406,6 +406,27 @@ namespace NAudio.Wave
             }
         }
 
+        /// <summary>
+        /// Retrieve the AudioStreamVolume object for this audio stream
+        /// </summary>
+        /// <remarks>
+        /// This returns the AudioStreamVolume object ONLY for shared audio streams.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// This is thrown when an exclusive audio stream is being used.
+        /// </exception>
+        public AudioStreamVolume AudioStreamVolume
+        {
+            get 
+            {
+                if (shareMode == AudioClientShareMode.Exclusive)
+                {
+                    throw new InvalidOperationException("AudioStreamVolume is ONLY supported for shared audio streams.");
+                }
+                return audioClient.AudioStreamVolume;  
+            }
+        }
+
         #endregion
 
         #region IDisposable Members


### PR DESCRIPTION
This exposes `IAudioStreamVolume` from `AudioClient/WsapiOut` as `AudioStreamVolume` object.

`IAudioStreamVolume` is claimed to work on Vista or later.

I wasn't quite sure how to go about writing up a test for this. Thoughts? I tested all of the methods by creating a sample app that played 3 MP3 files simultaneously at different `IAudioStreamVolumes`.
As well as testing the `GetAllVolumes` and `SetAllVolumes` worked correctly.

Fyi,
Bill
