### PR TITLE
Add an exception free way of determining if there is a default audio end...

### DIFF
--- a/NAudio/CoreAudioApi/Interfaces/IMMDeviceEnumerator.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IMMDeviceEnumerator.cs
@@ -12,6 +12,7 @@ namespace NAudio.CoreAudioApi.Interfaces
         int EnumAudioEndpoints(DataFlow dataFlow, DeviceState stateMask,
             out IMMDeviceCollection devices);
         
+        [PreserveSig]
         int GetDefaultAudioEndpoint(DataFlow dataFlow, Role role, out IMMDevice endpoint);
         
         int GetDevice(string id, out IMMDevice deviceName);

--- a/NAudio/CoreAudioApi/MMDeviceEnumerator.cs
+++ b/NAudio/CoreAudioApi/MMDeviceEnumerator.cs
@@ -75,6 +75,30 @@ namespace NAudio.CoreAudioApi
         }
 
         /// <summary>
+        /// Check to see if a default audio end point exists without needing an exception.
+        /// </summary>
+        /// <param name="dataFlow">Data Flow</param>
+        /// <param name="role">Role</param>
+        /// <returns>True if one exists, and false if one does not exist.</returns>
+        public bool HasDefaultAudioEndpoint(DataFlow dataFlow, Role role)
+        {
+            const int E_NOTFOUND = unchecked((int)0x80070490);
+            IMMDevice device = null;
+            int hresult = ((IMMDeviceEnumerator)realEnumerator).GetDefaultAudioEndpoint(dataFlow, role, out device);
+            if (hresult == 0x0)
+            {
+                Marshal.ReleaseComObject(device);
+                return true;
+            }
+            if (hresult == E_NOTFOUND)
+            {
+                return false;
+            }
+            Marshal.ThrowExceptionForHR(hresult);
+            return false;
+        }
+
+        /// <summary>
         /// Get device by ID
         /// </summary>
         /// <param name="id">Device ID</param>


### PR DESCRIPTION
... point device.

Simple idea, my main development box happens to be a Xeon workstation without a default audio device. (It does get one when I RDP in from my MacBook Pro of course, but I don't do that all of the time.)
So, let's expose a way without an exception to determine if there is indeed a default audio endpoint.

Without the `[PreserveSig]` .Net threw the exception for us.

Bill
