### PR TITLE
Add sample-exact seeking to Mp3FileReader

### DIFF
--- a/NAudio/Wave/WaveStreams/Mp3FileReader.cs
+++ b/NAudio/Wave/WaveStreams/Mp3FileReader.cs
@@ -330,7 +330,7 @@ namespace NAudio.Wave
                     Mp3Index mp3Index = null;
                     for (int index = 0; index < tableOfContents.Count; index++)
                     {
-                        if (tableOfContents[index].SamplePosition >= samplePosition)
+                        if (tableOfContents[index].SamplePosition + tableOfContents[index].SampleCount > samplePosition)
                         {
                             mp3Index = tableOfContents[index];
                             tocIndex = index;

--- a/NAudio/Wave/WaveStreams/Mp3FileReader.cs
+++ b/NAudio/Wave/WaveStreams/Mp3FileReader.cs
@@ -425,8 +425,8 @@ namespace NAudio.Wave
                         Array.Copy(decompressBuffer, decompressBufferOffset, sampleBuffer, offset, toCopy);
                         if ((toCopy + decompressBufferOffset) < decompressed)
                         {
-                            decompressBufferOffset = toCopy;
-                            decompressLeftovers = decompressed - toCopy;
+                            decompressBufferOffset = toCopy + decompressBufferOffset;
+                            decompressLeftovers = decompressed - decompressBufferOffset;
                         }
                         else
                         {

--- a/NAudio/Wave/WaveStreams/Mp3FileReader.cs
+++ b/NAudio/Wave/WaveStreams/Mp3FileReader.cs
@@ -47,6 +47,8 @@ namespace NAudio.Wave
         private int decompressLeftovers;
         private bool repositionedFlag;
 
+        private long position; // decompressed data position tracker
+
         private readonly object repositionLock = new object();
 
         /// <summary>Supports opening a MP3 file</summary>
@@ -314,14 +316,7 @@ namespace NAudio.Wave
         {
             get
             {
-                if (tocIndex >= tableOfContents.Count)
-                {
-                    return this.Length;
-                }
-                else
-                {
-                    return (tableOfContents[tocIndex].SamplePosition * this.bytesPerSample) + decompressBufferOffset;
-                }
+                return position;
             }
             set
             {
@@ -361,6 +356,8 @@ namespace NAudio.Wave
                         // we are repositioning to the end of the data
                         mp3Stream.Position = mp3DataLength + dataStartPosition;
                     }
+
+                    position = value;
                 }
             }
         }
@@ -459,6 +456,7 @@ namespace NAudio.Wave
                 }
             }
             Debug.Assert(bytesRead <= numBytes, "MP3 File Reader read too much");
+            position += bytesRead;
             return bytesRead;
         }
 


### PR DESCRIPTION
This changeset adds frame-exact seek capabilities to the Mp3FileReader as explained in [this blogpost](http://mark-dot-net.blogspot.co.at/2010/11/state-of-mp3-playback-support-in-naudio.html). It also fixes frame-granular repositioning, position reporting, and handles the decoder warmup to return correct data blocks after a seek (instead of starting attenuated when the overlap of the previous frame is missing). There's comments in the code explaining the most important changes. Now all of that works as expected, but because of these changes, external code written to work around these issues may now lead to wrong results (but that's just a side note, it does not concern NAudio itself).

Btw thanks for this nice library, I've been using it a lot and now I can finally contribute something back :)