### PR TITLE
Replace SynchronizationContext with Dispatcher for WPF applications

### DIFF
--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -67,11 +67,13 @@
     <DocumentationFile>bin\Release\NAudio.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Codecs\ALawDecoder.cs" />


### PR DESCRIPTION
To make NAudio WaveIn work for our WPF with FunctionCalllback I needed to replace the SynchronizationContext with Dispatcher for WPF applications.
My solution is based on this article:
http://stackoverflow.com/questions/1949789/using-synchronizationcontext-for-sending-events-back-to-the-ui-for-winforms-or-w

The static variable Application.Current is null for non-WPF applications. I tested the waveIn recorder demo in NAudioDemo to verify that this code runs for WinForms applications.

Best Regards
Thor Stenbæk
DIPS ASA

