### PR TITLE
Dispose of locally created stream in WaveFileReader when there is an exception thrown in the constructor

### DIFF
--- a/NAudio/Wave/WaveStreams/WaveFileReader.cs
+++ b/NAudio/Wave/WaveStreams/WaveFileReader.cs
@@ -30,25 +30,43 @@ namespace NAudio.Wave
         /// fix this reader to support it
         /// </remarks>
         public WaveFileReader(String waveFile) :
-            this(File.OpenRead(waveFile))
-        {
-            ownInput = true;
+            this(File.OpenRead(waveFile), true)
+        {            
         }
 
         /// <summary>
         /// Creates a Wave File Reader based on an input stream
         /// </summary>
         /// <param name="inputStream">The input stream containing a WAV file including header</param>
-        public WaveFileReader(Stream inputStream)
+        public WaveFileReader(Stream inputStream) :
+           this(inputStream, false)
+        {
+        }
+
+        private WaveFileReader(Stream inputStream, bool ownInput)
         {
             this.waveStream = inputStream;
             var chunkReader = new WaveFileChunkReader();
-            chunkReader.ReadWaveHeader(inputStream);
-            this.waveFormat = chunkReader.WaveFormat;
-            this.dataPosition = chunkReader.DataChunkPosition;
-            this.dataChunkLength = chunkReader.DataChunkLength;
-            this.chunks = chunkReader.RiffChunks;            
+            try
+            {
+                chunkReader.ReadWaveHeader(inputStream);
+                this.waveFormat = chunkReader.WaveFormat;
+                this.dataPosition = chunkReader.DataChunkPosition;
+                this.dataChunkLength = chunkReader.DataChunkLength;
+                this.chunks = chunkReader.RiffChunks;
+            }
+            catch
+            {
+                if (ownInput)
+                {
+                    inputStream.Dispose();
+                }
+
+                throw;
+            }
+
             Position = 0;
+            this.ownInput = ownInput;
         }
 
         /// <summary>

--- a/NAudioTests/WaveStreams/WaveFileReaderTests.cs
+++ b/NAudioTests/WaveStreams/WaveFileReaderTests.cs
@@ -153,5 +153,27 @@ namespace NAudioTests.WaveStreams
                 }
             }
         }
+
+        [Test]
+        [Category("UnitTest")]
+        public void DisposeOfStreamWhenConstructedFromFilePath()
+        {
+            string tempFilePath = System.IO.Path.GetTempFileName();
+            System.IO.File.WriteAllText(tempFilePath, "Some test content");
+            try
+            {
+                WaveFileReader waveReader = new WaveFileReader(tempFilePath);
+
+                Assert.Fail("Expected exception System.FormatException was not thrown for file missing a header.");
+            }
+            catch(FormatException ex)
+            {
+                Assert.IsNotNull(ex);
+            }
+            finally
+            {
+                System.IO.File.Delete(tempFilePath);
+            }
+        }
     }
 }


### PR DESCRIPTION
When creating a WaveFileReader the ChunkedReader can throw exceptions.  This is OK when a stream is passed in because the WaveFileReader does not own the stream.  But when a file path is passed in the WaveFileReader does own the stream, and does not properly dispose of it (dispose is not called on objects that failed to construct) leaving it locked by the process running NAudio.  This fixes that behavior.