### PR TITLE
Clean up all code analysis dispose warnings

### DIFF
--- a/NAudio/CoreAudioApi/AudioCaptureClient.cs
+++ b/NAudio/CoreAudioApi/AudioCaptureClient.cs
@@ -72,14 +72,39 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public void Dispose()
         {
-            if (audioCaptureClientInterface != null)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool isDisposed = false;
+
+        /// <summary>
+        /// Release the COM object
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
             {
-                // althugh GC would do this for us, we want it done now
-                // to let us reopen WASAPI
-                Marshal.ReleaseComObject(audioCaptureClientInterface);
-                audioCaptureClientInterface = null;
-                GC.SuppressFinalize(this);
+                if (!isDisposing)
+                {
+                    if (audioCaptureClientInterface != null)
+                    {
+                        // although GC would do this for us, we want it done now
+                        // to let us reopen WASAPI
+                        Marshal.ReleaseComObject(audioCaptureClientInterface);
+                        audioCaptureClientInterface = null;
+                    }
+                }
+
+                isDisposed = true;
             }
         }
+
+#pragma warning disable 1591
+        ~AudioCaptureClient()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
     }
 }

--- a/NAudio/CoreAudioApi/AudioClient.cs
+++ b/NAudio/CoreAudioApi/AudioClient.cs
@@ -300,38 +300,63 @@ namespace NAudio.CoreAudioApi
 
         #region IDisposable Members
 
+        private bool isDisposed = false;
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if(isDisposing)
+                {
+                    if (audioClockClient != null)
+                    {
+                        audioClockClient.Dispose();
+                        audioClockClient = null;
+                    }
+                    if (audioRenderClient != null)
+                    {
+                        audioRenderClient.Dispose();
+                        audioRenderClient = null;
+                    }
+                    if (audioCaptureClient != null)
+                    {
+                        audioCaptureClient.Dispose();
+                        audioCaptureClient = null;
+                    }
+                    if (audioStreamVolume != null)
+                    {
+                        audioStreamVolume.Dispose();
+                        audioStreamVolume = null;
+                    }
+                }
+
+                if (audioClientInterface != null)
+                {
+                    Marshal.ReleaseComObject(audioClientInterface);
+                    audioClientInterface = null;
+                }
+
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose
         /// </summary>
         public void Dispose()
         {
-            if (audioClientInterface != null)
-            {
-                if (audioClockClient != null)
-                {
-                    audioClockClient.Dispose();
-                    audioClockClient = null;
-                }
-                if (audioRenderClient != null)
-                {
-                    audioRenderClient.Dispose();
-                    audioRenderClient = null;
-                }
-                if (audioCaptureClient != null)
-                {
-                    audioCaptureClient.Dispose();
-                    audioCaptureClient = null;
-                }
-                if (audioStreamVolume != null)
-                {
-                    audioStreamVolume.Dispose();
-                    audioStreamVolume = null;
-                }
-                Marshal.ReleaseComObject(audioClientInterface);
-                audioClientInterface = null;
-                GC.SuppressFinalize(this);
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+#pragma warning disable 1591
+        ~AudioClient()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
 
         #endregion
     }

--- a/NAudio/CoreAudioApi/AudioClockClient.cs
+++ b/NAudio/CoreAudioApi/AudioClockClient.cs
@@ -107,21 +107,40 @@ namespace NAudio.CoreAudioApi
         }
 
         #region IDisposable Members
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (audioClockClientInterface != null)
+                {
+                    // althugh GC would do this for us, we want it done now
+                    // to let us reopen WASAPI
+                    Marshal.ReleaseComObject(audioClockClientInterface);
+                    audioClockClientInterface = null;
+                }
 
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose
         /// </summary>
         public void Dispose()
         {
-            if (audioClockClientInterface != null)
-            {
-                // althugh GC would do this for us, we want it done now
-                // to let us reopen WASAPI
-                Marshal.ReleaseComObject(audioClockClientInterface);
-                audioClockClientInterface = null;
-                GC.SuppressFinalize(this);
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+#pragma warning disable 1591
+        ~AudioClockClient()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
 
         #endregion
     }

--- a/NAudio/CoreAudioApi/AudioEndpointVolume.cs
+++ b/NAudio/CoreAudioApi/AudioEndpointVolume.cs
@@ -171,7 +171,7 @@ namespace NAudio.CoreAudioApi
             callBack = new AudioEndpointVolumeCallback(this);
             Marshal.ThrowExceptionForHR(audioEndPointVolume.RegisterControlChangeNotify(callBack));
         }
-        
+
         internal void FireNotification(AudioVolumeNotificationData notificationData)
         {
             AudioEndpointVolumeNotificationDelegate del = OnVolumeNotification;
@@ -181,27 +181,38 @@ namespace NAudio.CoreAudioApi
             }
         }
         #region IDisposable Members
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (callBack != null)
+                {
+                    audioEndPointVolume.UnregisterControlChangeNotify(callBack);
+                    callBack = null;
+                }
 
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose
         /// </summary>
         public void Dispose()
         {
-            if (callBack != null)
-            {
-                Marshal.ThrowExceptionForHR(audioEndPointVolume.UnregisterControlChangeNotify(callBack));
-                callBack = null;
-            }
+            Dispose(true);
             GC.SuppressFinalize(this);
-
         }
-        
+
         /// <summary>
         /// Finalizer
         /// </summary>
         ~AudioEndpointVolume()
         {
-            Dispose();
+            Dispose(false);
         }
 
         #endregion

--- a/NAudio/CoreAudioApi/AudioRenderClient.cs
+++ b/NAudio/CoreAudioApi/AudioRenderClient.cs
@@ -33,24 +33,47 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         /// <param name="numFramesWritten">Number of frames written</param>
         /// <param name="bufferFlags">Buffer flags</param>
-        public void ReleaseBuffer(int numFramesWritten,AudioClientBufferFlags bufferFlags)
+        public void ReleaseBuffer(int numFramesWritten, AudioClientBufferFlags bufferFlags)
         {
             Marshal.ThrowExceptionForHR(audioRenderClientInterface.ReleaseBuffer(numFramesWritten, bufferFlags));
         }
 
+        private bool isDisposed = false;
+
         /// <summary>
         /// Release the COM object
         /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (audioRenderClientInterface != null)
+                {
+                    // althugh GC would do this for us, we want it done now
+                    // to let us reopen WASAPI
+                    Marshal.ReleaseComObject(audioRenderClientInterface);
+                    audioRenderClientInterface = null;
+                }
+
+                isDisposed = true;
+            }
+
+        }
+        /// <summary>
+        /// Dispose
+        /// </summary>
         public void Dispose()
         {
-            if (audioRenderClientInterface != null)
-            {
-                // althugh GC would do this for us, we want it done now
-                // to let us reopen WASAPI
-                Marshal.ReleaseComObject(audioRenderClientInterface);
-                audioRenderClientInterface = null;
-                GC.SuppressFinalize(this);
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~AudioRenderClient()
+        {
+            Dispose(false);
         }
     }
 }

--- a/NAudio/CoreAudioApi/AudioSessionControl.cs
+++ b/NAudio/CoreAudioApi/AudioSessionControl.cs
@@ -40,24 +40,37 @@ namespace NAudio.CoreAudioApi
 
         #region IDisposable Members
 
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (audioSessionEventCallback != null)
+                {
+                    Marshal.ThrowExceptionForHR(audioSessionControlInterface.UnregisterAudioSessionNotification(audioSessionEventCallback));
+                }
+
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose
         /// </summary>
         public void Dispose()
         {
-            if (audioSessionEventCallback != null)
-            {
-                Marshal.ThrowExceptionForHR(audioSessionControlInterface.UnregisterAudioSessionNotification(audioSessionEventCallback));
-            }
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
-        
+
         /// <summary>
         /// Finalizer
         /// </summary>
         ~AudioSessionControl()
         {
-            Dispose();
+            Dispose(false);
         }
 
         #endregion

--- a/NAudio/CoreAudioApi/AudioSessionManager.cs
+++ b/NAudio/CoreAudioApi/AudioSessionManager.cs
@@ -15,7 +15,7 @@ namespace NAudio.CoreAudioApi
     /// Designed to manage audio sessions and in particuar the
     /// SimpleAudioVolume interface to adjust a session volume
     /// </summary>
-    public class AudioSessionManager
+    public class AudioSessionManager : IDisposable
     {
         private readonly IAudioSessionManager audioSessionInterface;
         private readonly IAudioSessionManager2 audioSessionInterface2;
@@ -31,7 +31,7 @@ namespace NAudio.CoreAudioApi
         /// <param name="sender"></param>
         /// <param name="newSession"></param>
         public delegate void SessionCreatedDelegate(object sender, IAudioSessionControl newSession);
-        
+
         /// <summary>
         /// Occurs when audio session has been added (for example run another program that use audio playback).
         /// </summary>
@@ -120,16 +120,6 @@ namespace NAudio.CoreAudioApi
             }
         }
 
-        /// <summary>
-        /// Dispose.
-        /// </summary>
-        public void Dispose()
-        {
-            UnregisterNotifications();
-
-            GC.SuppressFinalize(this);
-        }
-
         private void UnregisterNotifications()
         {
             if (sessions != null)
@@ -139,12 +129,40 @@ namespace NAudio.CoreAudioApi
                 Marshal.ThrowExceptionForHR(audioSessionInterface2.UnregisterSessionNotification(audioSessionNotification));
         }
 
+        private bool isDisposed = false;
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (isDisposing)
+                {
+                    if (audioSessionControl != null) audioSessionControl.Dispose();
+                }
+
+                UnregisterNotifications();
+
+                isDisposed = true;
+            }
+        }
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         /// <summary>
         /// Finalizer.
         /// </summary>
         ~AudioSessionManager()
         {
-            Dispose();
+            Dispose(false);
         }
     }
 }

--- a/NAudio/CoreAudioApi/SimpleAudioVolume.cs
+++ b/NAudio/CoreAudioApi/SimpleAudioVolume.cs
@@ -12,7 +12,7 @@ namespace NAudio.CoreAudioApi
     /// <summary>
     /// Windows CoreAudio SimpleAudioVolume
     /// </summary>
-    public class SimpleAudioVolume : IDisposable
+    public class SimpleAudioVolume
     {
         private readonly ISimpleAudioVolume simpleAudioVolume;
 
@@ -24,26 +24,6 @@ namespace NAudio.CoreAudioApi
         {
             simpleAudioVolume = realSimpleVolume;
         }
-
-        #region IDisposable Members
-
-        /// <summary>
-        /// Dispose
-        /// </summary>
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-        
-        /// <summary>
-        /// Finalizer
-        /// </summary>
-        ~SimpleAudioVolume()
-        {
-            Dispose();
-        }
-
-        #endregion
 
         /// <summary>
         /// Allows the user to adjust the volume from

--- a/NAudio/Dmo/DmoOutputDataBuffer.cs
+++ b/NAudio/Dmo/DmoOutputDataBuffer.cs
@@ -38,7 +38,6 @@ namespace NAudio.Dmo
             {
                 ((MediaBuffer)pBuffer).Dispose();
                 pBuffer = null;
-                GC.SuppressFinalize(this);
             }
         }
 

--- a/NAudio/Dmo/MediaBuffer.cs
+++ b/NAudio/Dmo/MediaBuffer.cs
@@ -26,17 +26,30 @@ namespace NAudio.Dmo
             this.maxLength = maxLength;
         }
 
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose and free memory for buffer
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if(!isDisposed)
+            {
+                if (buffer != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(buffer);
+                    buffer = IntPtr.Zero;
+                }
+
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose and free memory for buffer
         /// </summary>
         public void Dispose()
         {
-            if (buffer != IntPtr.Zero)
-            {
-                Marshal.FreeCoTaskMem(buffer);
-                buffer = IntPtr.Zero;
-                GC.SuppressFinalize(this);
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -44,7 +57,7 @@ namespace NAudio.Dmo
         /// </summary>
         ~MediaBuffer()
         {
-            Dispose();
+            Dispose(false);
         }
 
         #region IMediaBuffer Members

--- a/NAudio/Dmo/MediaObject.cs
+++ b/NAudio/Dmo/MediaObject.cs
@@ -474,18 +474,40 @@ namespace NAudio.Dmo
 
         #region IDisposable Members
 
+        bool isDisposed = false;
+        /// <summary>
+        /// Experimental code, not currently being called
+        /// Not sure if it is necessary anyway
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (mediaObject != null)
+                {
+                    Marshal.ReleaseComObject(mediaObject);
+                    mediaObject = null;
+                }
+                
+                isDisposed = false;
+            }
+        }
         /// <summary>
         /// Experimental code, not currently being called
         /// Not sure if it is necessary anyway
         /// </summary>
         public void Dispose()
         {
-            if (mediaObject != null)
-            {
-                Marshal.ReleaseComObject(mediaObject);
-                mediaObject = null;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+#pragma warning disable 1591
+        ~MediaObject()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
 
         #endregion
     }

--- a/NAudio/Dmo/ResamplerMediaObject.cs
+++ b/NAudio/Dmo/ResamplerMediaObject.cs
@@ -53,6 +53,44 @@ namespace NAudio.Dmo
 
         #region IDisposable Members
 
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose code - experimental at the moment
+        /// Was added trying to track down why Resampler crashes NUnit
+        /// This code not currently being called by ResamplerDmoStream
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (isDisposing)
+                {
+                    if (mediaObject != null)
+                    {
+                        mediaObject.Dispose();
+                        mediaObject = null;
+                    }
+                }
+
+                if (propertyStoreInterface != null)
+                {
+                    Marshal.ReleaseComObject(propertyStoreInterface);
+                    propertyStoreInterface = null;
+                }
+                if (resamplerPropsInterface != null)
+                {
+                    Marshal.ReleaseComObject(resamplerPropsInterface);
+                    resamplerPropsInterface = null;
+                }
+                if (mediaComObject != null)
+                {
+                    Marshal.ReleaseComObject(mediaComObject);
+                    mediaComObject = null;
+                }
+
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose code - experimental at the moment
         /// Was added trying to track down why Resampler crashes NUnit
@@ -60,27 +98,16 @@ namespace NAudio.Dmo
         /// </summary>
         public void Dispose()
         {
-            if(propertyStoreInterface != null)
-            {
-                Marshal.ReleaseComObject(propertyStoreInterface);
-                propertyStoreInterface = null;
-            }
-            if(resamplerPropsInterface != null)
-            {
-                Marshal.ReleaseComObject(resamplerPropsInterface);
-                resamplerPropsInterface = null;
-            }
-            if (mediaObject != null)
-            {
-                mediaObject.Dispose();
-                mediaObject = null;
-            }
-            if (mediaComObject != null)
-            {
-                Marshal.ReleaseComObject(mediaComObject);
-                mediaComObject = null;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+#pragma warning disable 1591
+        ~DmoResampler()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
 
         #endregion
     }

--- a/NAudio/Dmo/WindowsMediaMp3Decoder.cs
+++ b/NAudio/Dmo/WindowsMediaMp3Decoder.cs
@@ -55,6 +55,39 @@ namespace NAudio.Dmo
 
         #region IDisposable Members
 
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose code - experimental at the moment
+        /// Was added trying to track down why Resampler crashes NUnit
+        /// This code not currently being called by ResamplerDmoStream
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (isDisposing)
+                {
+                    if (mediaObject != null)
+                    {
+                        mediaObject.Dispose();
+                        mediaObject = null;
+                    }
+                }
+
+                if (propertyStoreInterface != null)
+                {
+                    Marshal.ReleaseComObject(propertyStoreInterface);
+                    propertyStoreInterface = null;
+                }
+                if (mediaComObject != null)
+                {
+                    Marshal.ReleaseComObject(mediaComObject);
+                    mediaComObject = null;
+                }
+
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Dispose code - experimental at the moment
         /// Was added trying to track down why Resampler crashes NUnit
@@ -62,27 +95,16 @@ namespace NAudio.Dmo
         /// </summary>
         public void Dispose()
         {
-            if(propertyStoreInterface != null)
-            {
-                Marshal.ReleaseComObject(propertyStoreInterface);
-                propertyStoreInterface = null;
-            }
-            /*if(resamplerPropsInterface != null)
-            {
-                Marshal.ReleaseComObject(resamplerPropsInterface);
-                resamplerPropsInterface = null;
-            }*/
-            if (mediaObject != null)
-            {
-                mediaObject.Dispose();
-                mediaObject = null;
-            }
-            if (mediaComObject != null)
-            {
-                Marshal.ReleaseComObject(mediaComObject);
-                mediaComObject = null;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+#pragma warning disable 1591
+        ~WindowsMediaMp3Decoder()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
 
         #endregion
     }

--- a/NAudio/FileFormats/Map/CakewalkMapFile.cs
+++ b/NAudio/FileFormats/Map/CakewalkMapFile.cs
@@ -30,8 +30,12 @@ namespace NAudio.FileFormats.Map
         /// <param name="filename">Path of the .map file</param>
         public CakewalkMapFile(string filename)
         {
-            using (var reader = new BinaryReader(File.OpenRead(filename),Encoding.Unicode))
+            BinaryReader reader = null;
+            Stream file = File.OpenRead(filename);
+            try
             {
+                reader = new BinaryReader(file, Encoding.Unicode);
+
                 drumMappings = new List<CakewalkDrumMapping>();
                 ReadMapHeader(reader);
                 for (int n = 0; n < mapEntryCount; n++)
@@ -47,6 +51,13 @@ namespace NAudio.FileFormats.Map
                     return;
                 ReadOutputsSection3(reader);
                 System.Diagnostics.Debug.Assert(reader.BaseStream.Position == reader.BaseStream.Length);
+            }
+            finally
+            {
+                if (reader != null)
+                    reader.Close();
+                else
+                    file.Dispose();
             }
         }
 
@@ -104,7 +115,7 @@ namespace NAudio.FileFormats.Map
                 if (name[nameLength] == 0)
                     break;
             }
-            mapName = new string(name,0,nameLength);
+            mapName = new string(name, 0, nameLength);
             reader.ReadBytes(98); // unknown
         }
 
@@ -127,7 +138,7 @@ namespace NAudio.FileFormats.Map
                 reader.ReadBytes(24); // data
             }
         }
-        
+
         private void ReadOutputsSection3(BinaryReader reader)
         {
             outputs3Header = MapBlockHeader.Read(reader);

--- a/NAudio/FileFormats/Mp3/DmoMp3FrameDecompressor.cs
+++ b/NAudio/FileFormats/Mp3/DmoMp3FrameDecompressor.cs
@@ -91,22 +91,42 @@ namespace NAudio.FileFormats.Mp3
             reposition = true;
         }
 
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose of this obejct and clean up resources
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (isDisposing)
+                {
+                    if (inputMediaBuffer != null)
+                    {
+                        inputMediaBuffer.Dispose();
+                        inputMediaBuffer = null;
+                    }
+
+                    outputBuffer.Dispose();
+
+                    if (mp3Decoder != null)
+                    {
+                        mp3Decoder.Dispose();
+                        mp3Decoder = null;
+                    }
+                }
+
+                isDisposed = true;
+            }
+        }
+
         /// <summary>
         /// Dispose of this obejct and clean up resources
         /// </summary>
         public void Dispose()
         {
-            if (inputMediaBuffer != null)
-            {
-                inputMediaBuffer.Dispose();
-                inputMediaBuffer = null;
-            }
-            outputBuffer.Dispose();
-            if (mp3Decoder!= null)
-            {
-                mp3Decoder.Dispose();
-                mp3Decoder = null;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/NAudio/FileFormats/Mp3/Id3v2Tag.cs
+++ b/NAudio/FileFormats/Mp3/Id3v2Tag.cs
@@ -39,7 +39,10 @@ namespace NAudio.Wave
         /// <returns>A new ID3v2 tag</returns>
         public static Id3v2Tag Create(IEnumerable<KeyValuePair<string, string>> tags)
         {
-            return Id3v2Tag.ReadTag(CreateId3v2TagStream(tags));
+            using(Stream tagStream = CreateId3v2TagStream(tags))
+            {
+                return Id3v2Tag.ReadTag(tagStream);
+            }
         }
 
         /// <summary>
@@ -163,13 +166,22 @@ namespace NAudio.Wave
             byte[] header = CreateId3v2TagHeader(frames);
 
             MemoryStream ms = new MemoryStream();
-            ms.Write(header, 0, header.Length);
-            foreach (byte[] frame in frames)
+            try
             {
-                ms.Write(frame, 0, frame.Length);
-            }
+                ms.Write(header, 0, header.Length);
+                foreach (byte[] frame in frames)
+                {
+                    ms.Write(frame, 0, frame.Length);
+                }
 
-            ms.Position = 0;
+                ms.Position = 0;
+            }
+            catch
+            {
+                ms.Dispose();
+
+                throw;
+            }
             return ms;
         }
 

--- a/NAudio/FileFormats/Mp3/Mp3FrameDecompressor.cs
+++ b/NAudio/FileFormats/Mp3/Mp3FrameDecompressor.cs
@@ -68,19 +68,29 @@ namespace NAudio.Wave
         {
             conversionStream.Reposition();
         }
+        /// <summary>
+        /// Disposes of this MP3 frame decompressor
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!disposed)
+            {
+                if (isDisposing)
+                {
+                    if (conversionStream != null)
+                        conversionStream.Dispose();
+                }
 
+                disposed = true;
+            }
+        }
         /// <summary>
         /// Disposes of this MP3 frame decompressor
         /// </summary>
         public void Dispose()
         {
-            if (!disposed)
-            {
-                disposed = true;
-				if(conversionStream != null)
-					conversionStream.Dispose();
-                GC.SuppressFinalize(this);
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -89,7 +99,7 @@ namespace NAudio.Wave
         ~AcmMp3FrameDecompressor()
         {
             System.Diagnostics.Debug.Assert(false, "AcmMp3FrameDecompressor Dispose was not called");
-            Dispose();
+            Dispose(false);
         }
     }
 }

--- a/NAudio/FileFormats/SoundFont/SoundFont.cs
+++ b/NAudio/FileFormats/SoundFont/SoundFont.cs
@@ -17,7 +17,8 @@ namespace NAudio.SoundFont
 	    /// Loads a SoundFont from a file
 	    /// </summary>
 	    /// <param name="fileName">Filename of the SoundFont</param>
-	    public SoundFont(string fileName) : 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public SoundFont(string fileName) : 
             this(new FileStream(fileName,FileMode.Open,FileAccess.Read))
 	    {
 	    }

--- a/NAudio/Gui/Fader.cs
+++ b/NAudio/Gui/Fader.cs
@@ -30,24 +30,30 @@ namespace NAudio.Gui
             // Required for Windows.Forms Class Composition Designer support
             InitializeComponent();
 
-            this.SetStyle(ControlStyles.DoubleBuffer | 
+            this.SetStyle(ControlStyles.DoubleBuffer |
                 ControlStyles.AllPaintingInWmPaint |
-                ControlStyles.UserPaint,true);
+                ControlStyles.UserPaint, true);
         }
 
         /// <summary> 
         /// Clean up any resources being used.
         /// </summary>
-        protected override void Dispose( bool disposing )
+        protected override void Dispose(bool disposing)
         {
-            if( disposing )
+            try
             {
-                if(components != null)
+                if (disposing)
                 {
-                    components.Dispose();
+                    if (components != null)
+                    {
+                        components.Dispose();
+                    }
                 }
             }
-            base.Dispose( disposing );
+            finally
+            {
+                base.Dispose(disposing);
+            }            
         }
 
         private readonly int SliderHeight = 30;
@@ -56,25 +62,23 @@ namespace NAudio.Gui
 
         private void DrawSlider(Graphics g)
         {
-            Brush block = new SolidBrush(Color.White);
-            Pen centreLine = new Pen(Color.Black);
-            sliderRectangle.X = (this.Width - SliderWidth) / 2;
-            sliderRectangle.Width = SliderWidth;
-            sliderRectangle.Y = (int) ((this.Height - SliderHeight) * percent);
-            sliderRectangle.Height = SliderHeight;
+            using (Brush block = new SolidBrush(Color.White))
+            using (Pen centreLine = new Pen(Color.Black))
+            {
+                sliderRectangle.X = (this.Width - SliderWidth) / 2;
+                sliderRectangle.Width = SliderWidth;
+                sliderRectangle.Y = (int)((this.Height - SliderHeight) * percent);
+                sliderRectangle.Height = SliderHeight;
 
-            g.FillRectangle(block,sliderRectangle);
-            g.DrawLine(centreLine,sliderRectangle.Left,sliderRectangle.Top + sliderRectangle.Height/2,sliderRectangle.Right,sliderRectangle.Top + sliderRectangle.Height/2);
-            block.Dispose();
-            centreLine.Dispose();
+                g.FillRectangle(block, sliderRectangle);
+                g.DrawLine(centreLine, sliderRectangle.Left, sliderRectangle.Top + sliderRectangle.Height / 2, sliderRectangle.Right, sliderRectangle.Top + sliderRectangle.Height / 2);
+            }
 
             /*sliderRectangle.X = (this.Width - SliderWidth) / 2;
             sliderRectangle.Width = SliderWidth;
             sliderRectangle.Y = (int)((this.Height - SliderHeight) * percent);
             sliderRectangle.Height = SliderHeight;
             g.DrawImage(Images.Fader1,sliderRectangle);*/
-
-            
         }
 
 
@@ -84,15 +88,16 @@ namespace NAudio.Gui
         protected override void OnPaint(PaintEventArgs e)
         {
             Graphics g = e.Graphics;
-            if(this.Orientation == Orientation.Vertical)
+            if (this.Orientation == Orientation.Vertical)
             {
-                Brush groove = new SolidBrush(Color.Black);
-                g.FillRectangle(groove, this.Width / 2, SliderHeight / 2, 2, this.Height - SliderHeight);
-                groove.Dispose();
+                using (Brush groove = new SolidBrush(Color.Black))
+                {
+                    g.FillRectangle(groove, this.Width / 2, SliderHeight / 2, 2, this.Height - SliderHeight);
+                }
                 DrawSlider(g);
             }
-            
-            base.OnPaint (e);
+
+            base.OnPaint(e);
         }
 
         private bool dragging;
@@ -103,13 +108,13 @@ namespace NAudio.Gui
         /// </summary>
         protected override void OnMouseDown(MouseEventArgs e)
         {
-            if(sliderRectangle.Contains(e.X,e.Y))
+            if (sliderRectangle.Contains(e.X, e.Y))
             {
                 dragging = true;
                 dragY = e.Y - sliderRectangle.Y;
             }
             // TODO: are we over the fader
-            base.OnMouseDown (e);
+            base.OnMouseDown(e);
         }
 
         /// <summary>
@@ -117,24 +122,24 @@ namespace NAudio.Gui
         /// </summary>
         protected override void OnMouseMove(MouseEventArgs e)
         {
-            if(dragging)
+            if (dragging)
             {
                 int sliderTop = e.Y - dragY;
-                if(sliderTop < 0)
+                if (sliderTop < 0)
                 {
                     this.percent = 0;
                 }
-                else if(sliderTop > this.Height - SliderHeight)
+                else if (sliderTop > this.Height - SliderHeight)
                 {
                     this.percent = 1;
                 }
                 else
                 {
-                    percent = (float) sliderTop / (float) (this.Height - SliderHeight);					
+                    percent = (float)sliderTop / (float)(this.Height - SliderHeight);
                 }
                 this.Invalidate();
             }
-            base.OnMouseMove (e);
+            base.OnMouseMove(e);
         }
 
         /// <summary>
@@ -143,7 +148,7 @@ namespace NAudio.Gui
         protected override void OnMouseUp(MouseEventArgs e)
         {
             dragging = false;
-            base.OnMouseUp (e);
+            base.OnMouseUp(e);
         }
 
 
@@ -185,11 +190,11 @@ namespace NAudio.Gui
         {
             get
             {
-                return (int) (percent * (maximum-minimum)) + minimum;
+                return (int)(percent * (maximum - minimum)) + minimum;
             }
             set
             {
-                percent = (float) (value-minimum) / (maximum-minimum);
+                percent = (float)(value - minimum) / (maximum - minimum);
             }
         }
 

--- a/NAudio/Gui/PanSlider.cs
+++ b/NAudio/Gui/PanSlider.cs
@@ -68,29 +68,32 @@ namespace NAudio.Gui
         /// </summary>
 		protected override void OnPaint(PaintEventArgs pe)
 		{
-			StringFormat format = new StringFormat();
-			format.LineAlignment = StringAlignment.Center;
-			format.Alignment = StringAlignment.Center;
-			string panValue;
-			if(pan == 0.0)
-			{
-				pe.Graphics.FillRectangle(Brushes.Orange,(this.Width/2) - 1  ,1,3,this.Height-2);
-				panValue = "C";
-			}
-			else if(pan > 0)
-			{
-				pe.Graphics.FillRectangle(Brushes.Orange,(this.Width/2),1,(int) ((this.Width/2) * pan),this.Height-2);
-				panValue = String.Format("{0:F0}%R",pan*100);
-			}
-			else
-			{
-				pe.Graphics.FillRectangle(Brushes.Orange,(int)((this.Width/2) * (pan+1)),1,(int) ((this.Width/2) * (0-pan)),this.Height-2);
-				panValue = String.Format("{0:F0}%L",pan*-100);
-			}
-			pe.Graphics.DrawRectangle(Pens.Black,0,0,this.Width-1,this.Height-1);
+            using (StringFormat format = new StringFormat())
+            {
+                format.LineAlignment = StringAlignment.Center;
+                format.Alignment = StringAlignment.Center;
+                string panValue;
+                if (pan == 0.0)
+                {
+                    pe.Graphics.FillRectangle(Brushes.Orange, (this.Width / 2) - 1, 1, 3, this.Height - 2);
+                    panValue = "C";
+                }
+                else if (pan > 0)
+                {
+                    pe.Graphics.FillRectangle(Brushes.Orange, (this.Width / 2), 1, (int)((this.Width / 2) * pan), this.Height - 2);
+                    panValue = String.Format("{0:F0}%R", pan * 100);
+                }
+                else
+                {
+                    pe.Graphics.FillRectangle(Brushes.Orange, (int)((this.Width / 2) * (pan + 1)), 1, (int)((this.Width / 2) * (0 - pan)), this.Height - 2);
+                    panValue = String.Format("{0:F0}%L", pan * -100);
+                }
+                pe.Graphics.DrawRectangle(Pens.Black, 0, 0, this.Width - 1, this.Height - 1);
 
-			pe.Graphics.DrawString(panValue,this.Font,
-				Brushes.Black,this.ClientRectangle,format);
+                pe.Graphics.DrawString(panValue, this.Font,
+                    Brushes.Black, this.ClientRectangle, format);
+            }
+
 			// Calling the base class OnPaint
 			//base.OnPaint(pe);
 		}

--- a/NAudio/Gui/Pot.cs
+++ b/NAudio/Gui/Pot.cs
@@ -118,21 +118,23 @@ namespace NAudio.Gui
         protected override void OnPaint(PaintEventArgs e)
         {
             int diameter = Math.Min(this.Width-4,this.Height-4);
-                        
-            Pen potPen = new Pen(ForeColor,3.0f);
-            potPen.LineJoin = System.Drawing.Drawing2D.LineJoin.Round;
-            System.Drawing.Drawing2D.GraphicsState state = e.Graphics.Save();
-            //e.Graphics.TranslateTransform(diameter / 2f, diameter / 2f);
-            e.Graphics.TranslateTransform(this.Width / 2, this.Height / 2);
-            e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
-            e.Graphics.DrawArc(potPen, new Rectangle(diameter / -2, diameter / -2, diameter, diameter), 135, 270);
-            
-            double percent = (value - minimum) / (maximum - minimum);
-            double degrees = 135 + (percent * 270);
-            double x = (diameter / 2.0) * Math.Cos(Math.PI * degrees / 180);
-            double y = (diameter / 2.0) * Math.Sin(Math.PI * degrees / 180);
-            e.Graphics.DrawLine(potPen, 0, 0, (float) x, (float) y);
-            e.Graphics.Restore(state);
+
+            using (Pen potPen = new Pen(ForeColor, 3.0f))
+            {
+                potPen.LineJoin = System.Drawing.Drawing2D.LineJoin.Round;
+                System.Drawing.Drawing2D.GraphicsState state = e.Graphics.Save();
+                //e.Graphics.TranslateTransform(diameter / 2f, diameter / 2f);
+                e.Graphics.TranslateTransform(this.Width / 2, this.Height / 2);
+                e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+                e.Graphics.DrawArc(potPen, new Rectangle(diameter / -2, diameter / -2, diameter, diameter), 135, 270);
+
+                double percent = (value - minimum) / (maximum - minimum);
+                double degrees = 135 + (percent * 270);
+                double x = (diameter / 2.0) * Math.Cos(Math.PI * degrees / 180);
+                double y = (diameter / 2.0) * Math.Sin(Math.PI * degrees / 180);
+                e.Graphics.DrawLine(potPen, 0, 0, (float)x, (float)y);
+                e.Graphics.Restore(state);
+            }
             base.OnPaint(e);
         }
 

--- a/NAudio/Gui/VolumeSlider.cs
+++ b/NAudio/Gui/VolumeSlider.cs
@@ -68,23 +68,25 @@ namespace NAudio.Gui
         /// </summary>
         protected override void OnPaint(PaintEventArgs pe)
         {
-            StringFormat format = new StringFormat();
-            format.LineAlignment = StringAlignment.Center;
-            format.Alignment = StringAlignment.Center;
-
-            pe.Graphics.DrawRectangle(Pens.Black, 0, 0, this.Width - 1, this.Height - 1);
-            float db = 20 * (float)Math.Log10(Volume);
-            float percent = 1 - (db / MinDb);
-
-            pe.Graphics.FillRectangle(Brushes.LightGreen, 1, 1, (int)((this.Width - 2) * percent), this.Height - 2);
-            string dbValue = String.Format("{0:F2} dB", db);
-            /*if(Double.IsNegativeInfinity(db))
+            using (StringFormat format = new StringFormat())
             {
-                dbValue = "-\x221e db"; // -8 dB
-            }*/
+                format.LineAlignment = StringAlignment.Center;
+                format.Alignment = StringAlignment.Center;
 
-            pe.Graphics.DrawString(dbValue, this.Font,
-                Brushes.Black, this.ClientRectangle, format);
+                pe.Graphics.DrawRectangle(Pens.Black, 0, 0, this.Width - 1, this.Height - 1);
+                float db = 20 * (float)Math.Log10(Volume);
+                float percent = 1 - (db / MinDb);
+
+                pe.Graphics.FillRectangle(Brushes.LightGreen, 1, 1, (int)((this.Width - 2) * percent), this.Height - 2);
+                string dbValue = String.Format("{0:F2} dB", db);
+                /*if(Double.IsNegativeInfinity(db))
+                {
+                    dbValue = "-\x221e db"; // -8 dB
+                }*/
+
+                pe.Graphics.DrawString(dbValue, this.Font,
+                    Brushes.Black, this.ClientRectangle, format);
+            }
             // Calling the base class OnPaint
             //base.OnPaint(pe);
         }

--- a/NAudio/Midi/MidiFile.cs
+++ b/NAudio/Midi/MidiFile.cs
@@ -39,12 +39,13 @@ namespace NAudio.Midi
         /// </summary>
         /// <param name="filename">Name of MIDI file</param>
         /// <param name="strictChecking">If true will error on non-paired note events</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public MidiFile(string filename, bool strictChecking)
         {
             this.strictChecking = strictChecking;
-            
-            var br = new BinaryReader(File.OpenRead(filename));
-            using(br) 
+
+            using (Stream file = File.OpenRead(filename))
+            using(var br = new BinaryReader(file)) 
             {
                 string chunkHeader = Encoding.UTF8.GetString(br.ReadBytes(4));
                 if(chunkHeader != "MThd") 
@@ -223,13 +224,15 @@ namespace NAudio.Midi
         /// </summary>
         /// <param name="filename">Filename to export to</param>
         /// <param name="events">Events to export</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public static void Export(string filename, MidiEventCollection events)
         {
             if (events.MidiFileType == 0 && events.Tracks > 1)
             {
                 throw new ArgumentException("Can't export more than one track to a type 0 file");
             }
-            using (var writer = new BinaryWriter(File.Create(filename)))
+            using (Stream file = File.Create(filename))
+            using (var writer = new BinaryWriter(file))
             {
                 writer.Write(Encoding.UTF8.GetBytes("MThd"));
                 writer.Write(SwapUInt32((uint)6)); // chunk size

--- a/NAudio/Midi/MidiIn.cs
+++ b/NAudio/Midi/MidiIn.cs
@@ -56,7 +56,6 @@ namespace NAudio.Midi
         /// </summary>
         public void Dispose() 
         {
-            GC.KeepAlive(callback);
             Dispose(true);
             GC.SuppressFinalize(this);
         }
@@ -144,7 +143,9 @@ namespace NAudio.Midi
         {
             if(!this.disposed) 
             {
-                //if(disposing) Components.Dispose();
+                if (disposing)
+                    GC.KeepAlive(callback);
+
                 MidiInterop.midiInClose(hMidiIn);
             }
             disposed = true;

--- a/NAudio/Midi/MidiOut.cs
+++ b/NAudio/Midi/MidiOut.cs
@@ -59,7 +59,6 @@ namespace NAudio.Midi
         /// </summary>
         public void Dispose() 
         {
-            GC.KeepAlive(callback);
             Dispose(true);
             GC.SuppressFinalize(this);
         }
@@ -118,7 +117,9 @@ namespace NAudio.Midi
         {
             if(!this.disposed) 
             {
-                //if(disposing) Components.Dispose();
+                if (disposing)
+                    GC.KeepAlive(callback);
+
                 MidiInterop.midiOutClose(hMidiOut);
             }
             disposed = true;

--- a/NAudio/Utils/IgnoreDisposeStream.cs
+++ b/NAudio/Utils/IgnoreDisposeStream.cs
@@ -125,10 +125,17 @@ namespace NAudio.Utils
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            if (!IgnoreDispose)
+            try
             {
-                SourceStream.Dispose();
-                SourceStream = null;
+                if (!IgnoreDispose)
+                {
+                    SourceStream.Dispose();
+                    SourceStream = null;
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
             }
         }
     }

--- a/NAudio/Wave/Compression/AcmStream.cs
+++ b/NAudio/Wave/Compression/AcmStream.cs
@@ -219,12 +219,8 @@ namespace NAudio.Wave.Compression
 
             if (streamHandle != IntPtr.Zero)
             {
-                MmResult result = AcmInterop.acmStreamClose(streamHandle, 0);
+                AcmInterop.acmStreamClose(streamHandle, 0);
                 streamHandle = IntPtr.Zero;
-                if (result != MmResult.NoError)
-                {
-                    throw new MmException(result, "acmStreamClose");
-                }
 
             }
             // Set large fields to null.

--- a/NAudio/Wave/WaveInputs/WasapiLoopbackCapture.cs
+++ b/NAudio/Wave/WaveInputs/WasapiLoopbackCapture.cs
@@ -34,8 +34,10 @@ namespace NAudio.Wave
         /// <returns>The default audio loopback capture device</returns>
         public static MMDevice GetDefaultLoopbackCaptureDevice()
         {
-            MMDeviceEnumerator devices = new MMDeviceEnumerator();
-            return devices.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+            using(MMDeviceEnumerator devices = new MMDeviceEnumerator())
+            {
+                return devices.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+            }
         }
 
         /// <summary>

--- a/NAudio/Wave/WaveInputs/WaveInEvent.cs
+++ b/NAudio/Wave/WaveInputs/WaveInEvent.cs
@@ -199,20 +199,6 @@ namespace NAudio.Wave
         /// WaveFormat we are recording in
         /// </summary>
         public WaveFormat WaveFormat { get; set; }
-        
-        /// <summary>
-        /// Dispose pattern
-        /// </summary>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (recording)
-                    StopRecording();
-                
-                CloseWaveInDevice();
-            }
-        }
 
         private void CloseWaveInDevice()
         {
@@ -249,6 +235,22 @@ namespace NAudio.Wave
         }
 
         /// <summary>
+        /// Dispose pattern
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (recording)
+                    StopRecording();
+
+                CloseWaveInDevice();
+
+                if (callbackEvent != null) callbackEvent.Close();
+            }
+        }
+
+        /// <summary>
         /// Dispose method
         /// </summary>
         public void Dispose()
@@ -256,5 +258,13 @@ namespace NAudio.Wave
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+
+#pragma warning disable 1591
+        ~WaveInEvent()
+        {
+            Dispose(false);
+        }
+#pragma warning restore 1591
+
     }
 }

--- a/NAudio/Wave/WaveOutputs/AsioOut.cs
+++ b/NAudio/Wave/WaveOutputs/AsioOut.cs
@@ -83,7 +83,7 @@ namespace NAudio.Wave
         /// </summary>
         ~AsioOut()
         {
-            Dispose();
+            Dispose(false);
         }
 
         /// <summary>
@@ -91,14 +91,29 @@ namespace NAudio.Wave
         /// </summary>
         public void Dispose()
         {
-            if (driver != null)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool isDisposed = false;
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if(!isDisposed)
             {
-                if (playbackState != PlaybackState.Stopped)
+                if (driver != null)
                 {
-                    driver.Stop();
+                    if (playbackState != PlaybackState.Stopped)
+                    {
+                        driver.Stop();
+                    }
+                    driver.ReleaseDriver();
+                    driver = null;
                 }
-                driver.ReleaseDriver();
-                driver = null;
+
+                isDisposed = true;
             }
         }
 

--- a/NAudio/Wave/WaveOutputs/DirectSoundOut.cs
+++ b/NAudio/Wave/WaveOutputs/DirectSoundOut.cs
@@ -119,13 +119,33 @@ namespace NAudio.Wave
             this.syncContext = SynchronizationContext.Current;
         }
 
+        private bool isDisposed = false;
         /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="DirectSoundOut"/> is reclaimed by garbage collection.
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        ~DirectSoundOut()
+        protected virtual void Dispose(bool isDisposing)
         {
-            Dispose();
+            if (!isDisposed)
+            {
+                if (isDisposing)
+                {
+                    Stop();
+
+                    if (frameEventWaitHandle1 != null) frameEventWaitHandle1.Close();
+                    if (frameEventWaitHandle2 != null) frameEventWaitHandle2.Close();
+                    if (endEventWaitHandle != null) endEventWaitHandle.Close();
+                }
+                
+                isDisposed = true;
+            }
+        }
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -362,15 +382,6 @@ namespace NAudio.Wave
                 //int intVol = (int)((value - 1) * 10000.0f);
                 //secondaryBuffer.SetVolume(intVol);
             }
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            Stop();
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/NAudio/Wave/WaveOutputs/MediaFoundationEncoder.cs
+++ b/NAudio/Wave/WaveOutputs/MediaFoundationEncoder.cs
@@ -24,7 +24,7 @@ namespace NAudio.Wave
         {
             return GetOutputMediaTypes(audioSubtype)
                 .Where(mt => mt.SampleRate == sampleRate && mt.ChannelCount == channels)
-                .Select(mt => mt.AverageBytesPerSecond*8)
+                .Select(mt => mt.AverageBytesPerSecond * 8)
                 .Distinct()
                 .OrderBy(br => br)
                 .ToArray();
@@ -135,7 +135,7 @@ namespace NAudio.Wave
         {
             return GetOutputMediaTypes(audioSubtype)
                 .Where(mt => mt.SampleRate == inputFormat.SampleRate && mt.ChannelCount == inputFormat.Channels)
-                .Select(mt => new { MediaType = mt, Delta = Math.Abs(desiredBitRate - mt.AverageBytesPerSecond * 8) } )
+                .Select(mt => new { MediaType = mt, Delta = Math.Abs(desiredBitRate - mt.AverageBytesPerSecond * 8) })
                 .OrderBy(mt => mt.Delta)
                 .Select(mt => mt.MediaType)
                 .FirstOrDefault();
@@ -277,9 +277,14 @@ namespace NAudio.Wave
         /// Disposes this instance
         /// </summary>
         /// <param name="disposing"></param>
-        protected void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            Marshal.ReleaseComObject(outputMediaType.MediaFoundationObject);
+            if (!disposed)
+            {
+                Marshal.ReleaseComObject(outputMediaType.MediaFoundationObject);
+
+                disposed = true;
+            }
         }
 
         /// <summary>
@@ -287,11 +292,7 @@ namespace NAudio.Wave
         /// </summary>
         public void Dispose()
         {
-            if (!disposed)
-            {
-                disposed = true;
-                Dispose(true);
-            }
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
 

--- a/NAudio/Wave/WaveOutputs/WaveOut.cs
+++ b/NAudio/Wave/WaveOutputs/WaveOut.cs
@@ -323,15 +323,15 @@ namespace NAudio.Wave
         /// </summary>
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
         /// Closes the WaveOut device and disposes of buffers
         /// </summary>
         /// <param name="disposing">True if called from <see>Dispose</see></param>
-        protected void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             Stop();
 

--- a/NAudio/Wave/WaveOutputs/WaveOutEvent.cs
+++ b/NAudio/Wave/WaveOutputs/WaveOutEvent.cs
@@ -295,15 +295,15 @@ namespace NAudio.Wave
         /// </summary>
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
         /// Closes the WaveOut device and disposes of buffers
         /// </summary>
         /// <param name="disposing">True if called from <see>Dispose</see></param>
-        protected void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             Stop();
 

--- a/NAudio/Wave/WaveProviders/WaveRecorder.cs
+++ b/NAudio/Wave/WaveProviders/WaveRecorder.cs
@@ -42,16 +42,33 @@ namespace NAudio.Wave
             get { return source.WaveFormat; }
         }
 
+        private bool isDisposed = false;
+        /// <summary>
+        /// Closes the WAV file
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (!isDisposed)
+            {
+                if (isDisposing)
+                {
+                    if (writer != null)
+                    {
+                        writer.Dispose();
+                        writer = null;
+                    }
+                }
+
+                isDisposed = true;
+            }
+        }
         /// <summary>
         /// Closes the WAV file
         /// </summary>
         public void Dispose()
         {
-            if (writer != null)
-            {
-                writer.Dispose();
-                writer = null;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/NAudio/Wave/WaveStreams/AiffFileReader.cs
+++ b/NAudio/Wave/WaveStreams/AiffFileReader.cs
@@ -25,21 +25,37 @@ namespace NAudio.Wave
         /// This supports basic reading of uncompressed PCM AIF files,
         /// with 8, 16, 24 and 32 bit PCM data.
         /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         public AiffFileReader(String aiffFile) :
-            this(File.OpenRead(aiffFile))
+            this(File.OpenRead(aiffFile), true)
         {
-            ownInput = true;
+
         }
 
         /// <summary>
         /// Creates an Aiff File Reader based on an input stream
         /// </summary>
         /// <param name="inputStream">The input stream containing a AIF file including header</param>
-        public AiffFileReader(Stream inputStream)
+        public AiffFileReader(Stream inputStream) :
+            this(inputStream, false)
         {
-            this.waveStream = inputStream;
-            ReadAiffHeader(waveStream, out waveFormat, out dataPosition, out dataChunkLength, chunks);
+
+        }
+
+        private AiffFileReader(Stream inputStream, bool ownsInput)
+        {
+            try
+            {
+                this.waveStream = inputStream;
+                ReadAiffHeader(waveStream, out waveFormat, out dataPosition, out dataChunkLength, chunks);
+            }
+            catch
+            {
+                if(ownsInput) inputStream.Dispose();
+            }
+
             Position = 0;
+            ownInput = ownsInput;
         }
 
         /// <summary>

--- a/NAudio/Wave/WaveStreams/CueList.cs
+++ b/NAudio/Wave/WaveStreams/CueList.cs
@@ -186,6 +186,7 @@ namespace NAudio.Wave
         /// Gets the cues as the concatenated cue and list RIFF chunks.
         /// </summary>
         /// <returns>RIFF chunks containing the cue data</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         internal byte[] GetRIFFChunks()
         {
             if (this.Count == 0)

--- a/NAudio/Wave/WaveStreams/ResamplerDmoStream.cs
+++ b/NAudio/Wave/WaveStreams/ResamplerDmoStream.cs
@@ -182,18 +182,24 @@ namespace NAudio.Wave
         /// <param name="disposing">True if disposing (not from finalizer)</param>
         protected override void Dispose(bool disposing)
         {
-            if (inputMediaBuffer != null)
+            try
             {
-                inputMediaBuffer.Dispose();
-                inputMediaBuffer = null;
+                if (inputMediaBuffer != null)
+                {
+                    inputMediaBuffer.Dispose();
+                    inputMediaBuffer = null;
+                }
+                outputBuffer.Dispose();
+                if (dmoResampler != null)
+                {
+                    dmoResampler.Dispose();
+                    dmoResampler = null;
+                }
             }
-            outputBuffer.Dispose();
-            if (dmoResampler != null)
+            finally
             {
-                //resampler.Dispose(); s
-                dmoResampler = null;
+                base.Dispose(disposing);
             }
-            base.Dispose(disposing);
         }
     }
 }

--- a/NAudio/Wave/WaveStreams/WaveFileReader.cs
+++ b/NAudio/Wave/WaveStreams/WaveFileReader.cs
@@ -29,6 +29,7 @@ namespace NAudio.Wave
         /// this class, email it to the NAudio project and we will probably
         /// fix this reader to support it
         /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         public WaveFileReader(String waveFile) :
             this(File.OpenRead(waveFile), true)
         {            
@@ -43,12 +44,13 @@ namespace NAudio.Wave
         {
         }
 
-        private WaveFileReader(Stream inputStream, bool ownInput)
+        private WaveFileReader(Stream inputStream, bool ownsInput)
         {
-            this.waveStream = inputStream;
-            var chunkReader = new WaveFileChunkReader();
             try
             {
+                this.waveStream = inputStream;
+                var chunkReader = new WaveFileChunkReader();
+
                 chunkReader.ReadWaveHeader(inputStream);
                 this.waveFormat = chunkReader.WaveFormat;
                 this.dataPosition = chunkReader.DataChunkPosition;
@@ -57,16 +59,12 @@ namespace NAudio.Wave
             }
             catch
             {
-                if (ownInput)
-                {
-                    inputStream.Dispose();
-                }
-
+                if (ownsInput) inputStream.Dispose();
                 throw;
             }
 
             Position = 0;
-            this.ownInput = ownInput;
+            this.ownInput = ownsInput;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR cleans up all code analysis dispose warnings ensuring proper resource cleanup so streams and handles are not left open.