### PR TITLE
EndOfStreamException handling and added GitHub link in readme

### DIFF
--- a/NAudio/Wave/WaveStreams/RawSourceWaveStream.cs
+++ b/NAudio/Wave/WaveStreams/RawSourceWaveStream.cs
@@ -61,7 +61,14 @@ namespace NAudio.Wave
         /// </summary>
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return sourceStream.Read(buffer, offset, count);
+            try
+            {
+                return sourceStream.Read(buffer, offset, count);
+            }
+            catch (EndOfStreamException)
+            {
+                return 0;
+            }
         }
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 NAudio is an open source .NET audio library written by Mark Heath (mark.heath@gmail.com)
 For more information, visit http://naudio.codeplex.com
-NAudio is now being hosted on GitHub http://github.com/naudio
+NAudio is now being hosted on GitHub http://github.com/naudio/NAudio
 
 THANKS
 ======

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,6 @@
 NAudio is an open source .NET audio library written by Mark Heath (mark.heath@gmail.com)
 For more information, visit http://naudio.codeplex.com
+NAudio is now being hosted on GitHub http://github.com/naudio
 
 THANKS
 ======


### PR DESCRIPTION
added End of Stream error handling to return 0. and added link to GitHub in readme
(I had set up a clone of CodePlex and made a pull request before learning that the project had moved to GitHub, because the readme pointed to CodePlex)