### PR TITLE
Return IEEE format in WasapiCaptureRT when Extensible with subType=IEEE

### DIFF
--- a/NAudio.Win8/Wave/WaveInputs/WasapiCaptureRT.cs
+++ b/NAudio.Win8/Wave/WaveInputs/WasapiCaptureRT.cs
@@ -62,7 +62,24 @@ namespace NAudio.Wave
         /// </summary>
         public virtual WaveFormat WaveFormat 
         {
-            get { return waveFormat; }
+            get
+            {
+                // for convenience, return a WAVEFORMATEX, instead of the real
+                // WAVEFORMATEXTENSIBLE being used
+                var wfe = waveFormat as WaveFormatExtensible;
+                if (wfe != null)
+                {
+                    try
+                    {
+                        return wfe.ToStandardWaveFormat();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // couldn't convert to a standard format
+                    }
+                }
+                return waveFormat;
+            }
             set { waveFormat = value; }
         }
 


### PR DESCRIPTION
This commit makes WasapiCaptureRT.WaveFormat to try to call ToStandardWaveFormat() on the WaveFormat to reuturn simplified IEEE/PCM format values.

Currently WasapICaptureRT may return Extensible WaveFormat. This needs additional handling in clients to check subType UUIDs in order to determine the format. Additionally, SampleProviderConverter and WaveToSampleProvider also refuse to use Extensible WaveFormat returned by WasapiCaptureRT, even though it is in IEEE format.

The code is taken from WasapiCapture and with it there is a unified logic between the RT and non-RT code.