### PR TITLE
Do not lock the file when loading it using the WaveFileReader

### DIFF
--- a/NAudio/Wave/WaveStreams/WaveFileReader.cs
+++ b/NAudio/Wave/WaveStreams/WaveFileReader.cs
@@ -30,7 +30,7 @@ namespace NAudio.Wave
         /// fix this reader to support it
         /// </remarks>
         public WaveFileReader(String waveFile) :
-            this(File.OpenRead(waveFile), true)
+            this(File.Open(waveFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite), true)
         {            
         }
 


### PR DESCRIPTION
I am currently writing an application that works with WAVE files, where another app continuously adds data to that file.

Today I discovered, that the `WaveFileReader` is calling `File.OpenRead(waveFile)` which is the same as calling `File.Open(waveFile, FileMode.Open, FileAccess.Read, FileShare.Read)`. As you can hereby see, this handler will block the file for writing. The operation is aborted and the system fires an exception, telling you that another process currently uses this file.

The solution here was to replace it by an explicit call of `File.Open()` and adjust the last parameter to be `FileShare.ReadWrite`, saying that other applications are allowed to read and write to that file while it's opened by that handler.

As this is an instance, called `WaveFileReader`, I don't see any problem adding this feature here. This handler can't write anyways and I don't see a reason to deny that.