### PR TITLE
Add Loopback flag with EventCallback

### DIFF
--- a/NAudio/CoreAudioApi/AudioSessionControl.cs
+++ b/NAudio/CoreAudioApi/AudioSessionControl.cs
@@ -48,6 +48,7 @@ namespace NAudio.CoreAudioApi
             if (audioSessionEventCallback != null)
             {
                 Marshal.ThrowExceptionForHR(audioSessionControlInterface.UnregisterAudioSessionNotification(audioSessionEventCallback));
+                audioSessionEventCallback = null;
             }
             GC.SuppressFinalize(this);
         }
@@ -241,6 +242,7 @@ namespace NAudio.CoreAudioApi
             if (audioSessionEventCallback != null)
             {
                 Marshal.ThrowExceptionForHR(audioSessionControlInterface.UnregisterAudioSessionNotification(audioSessionEventCallback));
+                audioSessionEventCallback = null;
             }
         }
     }

--- a/NAudio/Wave/WaveInputs/WasapiCapture.cs
+++ b/NAudio/Wave/WaveInputs/WasapiCapture.cs
@@ -161,13 +161,13 @@ namespace NAudio.CoreAudioApi
                 if (ShareMode == AudioClientShareMode.Shared)
                 {
                     // With EventCallBack and Shared, both latencies must be set to 0
-                    audioClient.Initialize(ShareMode, AudioClientStreamFlags.EventCallback, requestedDuration, 0,
+                    audioClient.Initialize(ShareMode, AudioClientStreamFlags.EventCallback | streamFlags, requestedDuration, 0,
                         waveFormat, Guid.Empty);
                 }
                 else
                 {
                     // With EventCallBack and Exclusive, both latencies must equals
-                    audioClient.Initialize(ShareMode, AudioClientStreamFlags.EventCallback, requestedDuration, requestedDuration,
+                    audioClient.Initialize(ShareMode, AudioClientStreamFlags.EventCallback | streamFlags, requestedDuration, requestedDuration,
                                         waveFormat, Guid.Empty);
                 }
 


### PR DESCRIPTION
1. When using WasapiLoopbackCapture, it is necessary to add AudioClientStreamFlags.Loopback flag.
But, in the class WasapiCapture, if EventCallback is used, then this flag is not added.
2. Also #64 has been fixed