### PR TITLE
IAudioEndpointVolumeCallback fix and IAudioEndpointVolume source GUID…

### DIFF
--- a/NAudio/CoreAudioApi/AudioEndpointVolume.cs
+++ b/NAudio/CoreAudioApi/AudioEndpointVolume.cs
@@ -38,6 +38,22 @@ namespace NAudio.CoreAudioApi
         private readonly EEndpointHardwareSupport hardwareSupport;
         private AudioEndpointVolumeCallback callBack;
 
+        private Guid notificationGuid = Guid.Empty;
+
+        /// <summary>
+        /// GUID to pass to AudioEndpointVolumeCallback
+        /// </summary>
+        public Guid NotificationGuid {
+            get
+            {
+                return notificationGuid;
+            }
+            set
+            {
+                notificationGuid = value;
+            }
+        }
+
         /// <summary>
         /// On Volume Notification
         /// </summary>
@@ -100,7 +116,7 @@ namespace NAudio.CoreAudioApi
             }
             set
             {
-                Marshal.ThrowExceptionForHR(audioEndPointVolume.SetMasterVolumeLevel(value, Guid.Empty));
+                Marshal.ThrowExceptionForHR(audioEndPointVolume.SetMasterVolumeLevel(value, ref notificationGuid));
             }
         }
 
@@ -117,7 +133,7 @@ namespace NAudio.CoreAudioApi
             }
             set
             {
-                Marshal.ThrowExceptionForHR(audioEndPointVolume.SetMasterVolumeLevelScalar(value, Guid.Empty));
+                Marshal.ThrowExceptionForHR(audioEndPointVolume.SetMasterVolumeLevelScalar(value, ref notificationGuid));
             }
         }
 
@@ -134,7 +150,7 @@ namespace NAudio.CoreAudioApi
             }
             set
             {
-                Marshal.ThrowExceptionForHR(audioEndPointVolume.SetMute(value, Guid.Empty));
+                Marshal.ThrowExceptionForHR(audioEndPointVolume.SetMute(value, ref notificationGuid));
             }
         }
 
@@ -143,7 +159,7 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public void VolumeStepUp()
         {
-            Marshal.ThrowExceptionForHR(audioEndPointVolume.VolumeStepUp(Guid.Empty));
+            Marshal.ThrowExceptionForHR(audioEndPointVolume.VolumeStepUp(ref notificationGuid));
         }
 
         /// <summary>
@@ -151,7 +167,7 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public void VolumeStepDown()
         {
-            Marshal.ThrowExceptionForHR(audioEndPointVolume.VolumeStepDown(Guid.Empty));
+            Marshal.ThrowExceptionForHR(audioEndPointVolume.VolumeStepDown(ref notificationGuid));
         }
 
         /// <summary>

--- a/NAudio/CoreAudioApi/AudioEndpointVolumeCallback.cs
+++ b/NAudio/CoreAudioApi/AudioEndpointVolumeCallback.cs
@@ -66,7 +66,7 @@ namespace NAudio.CoreAudioApi
             }
 
             //Create combined structure and Fire Event in parent class.
-            var notificationData = new AudioVolumeNotificationData(data.guidEventContext, data.bMuted, data.fMasterVolume, voldata);
+            var notificationData = new AudioVolumeNotificationData(data.guidEventContext, data.bMuted, data.fMasterVolume, voldata, data.guidEventContext);
             parent.FireNotification(notificationData);
         }
     }

--- a/NAudio/CoreAudioApi/AudioEndpointVolumeChannel.cs
+++ b/NAudio/CoreAudioApi/AudioEndpointVolumeChannel.cs
@@ -34,6 +34,23 @@ namespace NAudio.CoreAudioApi
         private readonly uint channel;
         private readonly IAudioEndpointVolume audioEndpointVolume;
 
+        private Guid notificationGuid = Guid.Empty;
+
+        /// <summary>
+        /// GUID to pass to AudioEndpointVolumeCallback
+        /// </summary>
+        public Guid NotificationGuid
+        {
+            get
+            {
+                return notificationGuid;
+            }
+            set
+            {
+                notificationGuid = value;
+            }
+        }
+
         internal AudioEndpointVolumeChannel(IAudioEndpointVolume parent, int channel)
         {
             this.channel = (uint)channel;
@@ -53,7 +70,7 @@ namespace NAudio.CoreAudioApi
             }
             set
             {
-                Marshal.ThrowExceptionForHR(audioEndpointVolume.SetChannelVolumeLevel(channel, value,Guid.Empty));
+                Marshal.ThrowExceptionForHR(audioEndpointVolume.SetChannelVolumeLevel(channel, value, ref this.notificationGuid));
             }
         }
 
@@ -70,7 +87,7 @@ namespace NAudio.CoreAudioApi
             }
             set
             {
-                Marshal.ThrowExceptionForHR(audioEndpointVolume.SetChannelVolumeLevelScalar(channel, value, Guid.Empty));
+                Marshal.ThrowExceptionForHR(audioEndpointVolume.SetChannelVolumeLevelScalar(channel, value, ref this.notificationGuid));
             }
         }
 

--- a/NAudio/CoreAudioApi/AudioVolumeNotificationData.cs
+++ b/NAudio/CoreAudioApi/AudioVolumeNotificationData.cs
@@ -33,6 +33,7 @@ namespace NAudio.CoreAudioApi
         private readonly float masterVolume;
         private readonly int channels;
         private readonly float[] channelVolume;
+        private readonly Guid guid;
 
         /// <summary>
         /// Event Context
@@ -48,6 +49,14 @@ namespace NAudio.CoreAudioApi
         public bool Muted
         {
             get { return muted; }
+        }
+
+        /// <summary>
+        /// Guid that raised the event
+        /// </summary>
+        public Guid Guid
+        {
+            get { return guid; }
         }
 
         /// <summary>
@@ -81,13 +90,15 @@ namespace NAudio.CoreAudioApi
         /// <param name="muted"></param>
         /// <param name="masterVolume"></param>
         /// <param name="channelVolume"></param>
-        public AudioVolumeNotificationData(Guid eventContext, bool muted, float masterVolume, float[] channelVolume)
+        /// <param name="guid"></param>
+        public AudioVolumeNotificationData(Guid eventContext, bool muted, float masterVolume, float[] channelVolume, Guid guid)
         {
             this.eventContext = eventContext;
             this.muted = muted;
             this.masterVolume = masterVolume;
             channels = channelVolume.Length;
             this.channelVolume = channelVolume;
+            this.guid = guid;
         }
     }
 }

--- a/NAudio/CoreAudioApi/Interfaces/IAudioEndpointVolume.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IAudioEndpointVolume.cs
@@ -33,19 +33,19 @@ namespace NAudio.CoreAudioApi.Interfaces
         int RegisterControlChangeNotify(IAudioEndpointVolumeCallback pNotify);
         int UnregisterControlChangeNotify(IAudioEndpointVolumeCallback pNotify);
         int GetChannelCount(out int pnChannelCount);
-        int SetMasterVolumeLevel(float fLevelDB, Guid pguidEventContext);
-        int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
+        int SetMasterVolumeLevel(float fLevelDB, ref Guid pguidEventContext);
+        int SetMasterVolumeLevelScalar(float fLevel, ref Guid pguidEventContext);
         int GetMasterVolumeLevel(out float pfLevelDB);
         int GetMasterVolumeLevelScalar(out float pfLevel);
-        int SetChannelVolumeLevel(uint nChannel, float fLevelDB, Guid pguidEventContext);
-        int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, Guid pguidEventContext);
+        int SetChannelVolumeLevel(uint nChannel, float fLevelDB, ref Guid pguidEventContext);
+        int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, ref Guid pguidEventContext);
         int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
         int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
-        int SetMute([MarshalAs(UnmanagedType.Bool)] Boolean bMute, Guid pguidEventContext);
+        int SetMute([MarshalAs(UnmanagedType.Bool)] Boolean bMute, ref Guid pguidEventContext);
         int GetMute(out bool pbMute);
         int GetVolumeStepInfo(out uint pnStep, out uint pnStepCount);
-        int VolumeStepUp(Guid pguidEventContext);
-        int VolumeStepDown(Guid pguidEventContext);
+        int VolumeStepUp(ref Guid pguidEventContext);
+        int VolumeStepDown(ref Guid pguidEventContext);
         int QueryHardwareSupport(out uint pdwHardwareSupportMask);
         int GetVolumeRange(out float pflVolumeMindB, out float pflVolumeMaxdB, out float pflVolumeIncrementdB);
     }


### PR DESCRIPTION
Two fixes in CoreAudioApi/AudioVolume modules:

1. Definition of IAudioEndpointVolume incorrect - throws a COM access violation if GUID pguidEventContext ever set (apparently always set to GUID.Zero as currently used so this problem never came to light). Correct parameter should be passed ref. See https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/cb3de43e-3abb-4428-b58a-dc3e5f29db30/vista-master-volume-control-with-c?forum=windowspro-audiodevelopment

2. Support for setting custom pguidEventContext GUID when changing endpoint volumes via new property notificationGuid on AudioEndpointVolume and AudioEndpointVolumeChannel. And support for reading the volume event GUID from AudioVolumeNotificationData.

This then enables volume change callbacks to differentiate the source of volume changes and prevent volume change feedback loops.

From MSDN "In its implementation of the OnNotify method, a client can inspect the event-context GUID from that call to discover whether it or another client is the source of the volume-change event."

See https://msdn.microsoft.com/en-us/library/windows/desktop/dd370799(v=vs.85).aspx