### PR TITLE
Fix issue I had with exclusive WasapiOut to a 7.1 sound card.

### DIFF
--- a/NAudio/Wave/WaveFormats/WaveFormatExtensible.cs
+++ b/NAudio/Wave/WaveFormats/WaveFormatExtensible.cs
@@ -33,10 +33,7 @@ namespace NAudio.Wave
             waveFormatTag = WaveFormatEncoding.Extensible;
             extraSize = 22;
             wValidBitsPerSample = (short) bits;
-            for (int n = 0; n < channels; n++)
-            {
-                dwChannelMask |= (1 << n);
-            }
+            dwChannelMask = channelMaskForChannels(channels);
             if (bits == 32)
             {
                 // KSDATAFORMAT_SUBTYPE_IEEE_FLOAT
@@ -95,6 +92,31 @@ namespace NAudio.Wave
                 dwChannelMask,
                 subFormat,
                 extraSize);
+        }
+
+        /// <summary>
+        /// Picks a channel mask for a specified number of channels.
+        /// </summary>
+        /// <param name="channels">Number of channels.</param>
+        /// <returns>Channel Mask</returns>
+        private static int channelMaskForChannels(int channels)
+        {
+            if (channels == 8 && System.Environment.OSVersion.Version.Major >= 6)
+            {
+                // For 8 channels, the below logic would return 0xFF (KSAUDIO_SPEAKER_7POINT1) which is
+                // not supported in Vista and later. Using 0x63F (KSAUDIO_SPEAKER_7POINT1_SURROUND) instead.
+                // https://msdn.microsoft.com/en-us/library/windows/hardware/ff536440(v=vs.85).aspx
+                return 0x63F;
+            }
+            else
+            {
+                int channelMask = 0;
+                for (int n = 0; n < channels; n++)
+                {
+                    channelMask |= (1 << n);
+                }
+                return channelMask;
+            }
         }
     }
 }


### PR DESCRIPTION
When trying to use WasapiOut in exclusive mode with my 7.1 sound card, it would revert to the "Last Last Last Chance (Thanks WASAPI)" case and use 2 channel 16-bit output, which isn't what I wanted.

Furthermore, I found that any 8 channel WaveFormatExtensible that I created was rejected by IsFormatSupported().  I tried different sample rates and different bitrates, but nothing worked.

Eventually I found that you can ask the device what format to use via the PKEY_AudioEngine_DeviceFormat property.  So I added code to WasapiOut to do that, and it worked!  This led me to the discovery that it wanted a dwChannelMask of 0x63F instead of 0xFF.

So I fixed both problems.  I'm not 100% sure these fixes are completely correct (because I have very little experience with these APIs), but either fix is sufficient to fix my specific problem.  I'd love if one or both could be incorporated into NAudio.