### PR TITLE
Function WriteBigEndian needs an offset of 3

### DIFF
--- a/NAudio/FileFormats/Mp3/XingHeader.cs
+++ b/NAudio/FileFormats/Mp3/XingHeader.cs
@@ -48,7 +48,7 @@ namespace NAudio.Wave
             byte[] littleEndian = BitConverter.GetBytes(value);
             for (int n = 0; n < 4; n++)
             {
-                buffer[offset + 4 - n] = littleEndian[n];
+                buffer[offset + 3 - n] = littleEndian[n];
             }
         }
 


### PR DESCRIPTION
WriteBigEndian was wrong.
If I want to reach the last of 4 bytes,
I must add 3.