### PR TITLE
Update StreamMediaFoundationReader to work with Mono / Unity

### DIFF
--- a/NAudio/CoreAudioApi/PropVariant.cs
+++ b/NAudio/CoreAudioApi/PropVariant.cs
@@ -55,7 +55,7 @@ namespace NAudio.CoreAudioApi.Interfaces
         [FieldOffset(8)] private short boolVal;
         [FieldOffset(8)] private int scode;
         //CY cyVal;
-        [FieldOffset(8)] private DateTime date;
+        [FieldOffset(8)] private double date;
         [FieldOffset(8)] private System.Runtime.InteropServices.ComTypes.FILETIME filetime;
         //CLSID* puuid;
         //CLIPDATA* pclipdata;

--- a/NAudio/MediaFoundation/IMFMediaBuffer.cs
+++ b/NAudio/MediaFoundation/IMFMediaBuffer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace NAudio.MediaFoundation
@@ -13,22 +14,27 @@ namespace NAudio.MediaFoundation
         /// <summary>
         /// Gives the caller access to the memory in the buffer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void Lock(out IntPtr ppbBuffer, out int pcbMaxLength, out int pcbCurrentLength);
         /// <summary>
         /// Unlocks a buffer that was previously locked.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void Unlock();
         /// <summary>
         /// Retrieves the length of the valid data in the buffer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetCurrentLength(out int pcbCurrentLength);
         /// <summary>
         /// Sets the length of the valid data in the buffer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetCurrentLength(int cbCurrentLength);
         /// <summary>
         /// Retrieves the allocated size of the buffer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetMaxLength(out int pcbMaxLength);
     }
 }

--- a/NAudio/MediaFoundation/IMFMediaType.cs
+++ b/NAudio/MediaFoundation/IMFMediaType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -14,183 +15,217 @@ namespace NAudio.MediaFoundation
         /// <summary>
         /// Retrieves the value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, Out] IntPtr pValue);
 
         /// <summary>
         /// Retrieves the data type of the value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetItemType([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int pType);
 
         /// <summary>
         /// Queries whether a stored attribute value equals a specified PROPVARIANT.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void CompareItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, IntPtr value, [MarshalAs(UnmanagedType.Bool)] out bool pbResult);
 
         /// <summary>
         /// Compares the attributes on this object with the attributes on another object.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void Compare([MarshalAs(UnmanagedType.Interface)] IMFAttributes pTheirs, int matchType, [MarshalAs(UnmanagedType.Bool)] out bool pbResult);
 
         /// <summary>
         /// Retrieves a UINT32 value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetUINT32([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int punValue);
 
         /// <summary>
         /// Retrieves a UINT64 value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetUINT64([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out long punValue);
 
         /// <summary>
         /// Retrieves a double value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetDouble([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out double pfValue);
 
         /// <summary>
         /// Retrieves a GUID value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetGUID([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out Guid pguidValue);
 
         /// <summary>
         /// Retrieves the length of a string value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetStringLength([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int pcchLength);
 
         /// <summary>
         /// Retrieves a wide-character string associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetString([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszValue, int cchBufSize,
                        out int pcchLength);
 
         /// <summary>
         /// Retrieves a wide-character string associated with a key. This method allocates the memory for the string.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetAllocatedString([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [MarshalAs(UnmanagedType.LPWStr)] out string ppwszValue,
                                 out int pcchLength);
 
         /// <summary>
         /// Retrieves the length of a byte array associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetBlobSize([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int pcbBlobSize);
 
         /// <summary>
         /// Retrieves a byte array associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetBlob([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [Out, MarshalAs(UnmanagedType.LPArray)] byte[] pBuf, int cbBufSize,
                      out int pcbBlobSize);
 
         /// <summary>
         /// Retrieves a byte array associated with a key. This method allocates the memory for the array.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetAllocatedBlob([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out IntPtr ip, out int pcbSize);
 
         /// <summary>
         /// Retrieves an interface pointer associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetUnknown([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPStruct)] Guid riid,
                         [MarshalAs(UnmanagedType.IUnknown)] out object ppv);
 
         /// <summary>
         /// Associates an attribute value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, IntPtr value);
 
         /// <summary>
         /// Removes a key/value pair from the object's attribute list.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void DeleteItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey);
 
         /// <summary>
         /// Removes all key/value pairs from the object's attribute list.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void DeleteAllItems();
 
         /// <summary>
         /// Associates a UINT32 value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetUINT32([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, int unValue);
 
         /// <summary>
         /// Associates a UINT64 value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetUINT64([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, long unValue);
 
         /// <summary>
         /// Associates a double value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetDouble([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, double fValue);
 
         /// <summary>
         /// Associates a GUID value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetGUID([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPStruct)] Guid guidValue);
 
         /// <summary>
         /// Associates a wide-character string with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetString([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPWStr)] string wszValue);
 
         /// <summary>
         /// Associates a byte array with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetBlob([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] pBuf,
                      int cbBufSize);
 
         /// <summary>
         /// Associates an IUnknown pointer with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetUnknown([MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.IUnknown)] object pUnknown);
 
         /// <summary>
         /// Locks the attribute store so that no other thread can access it.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void LockStore();
 
         /// <summary>
         /// Unlocks the attribute store.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void UnlockStore();
 
         /// <summary>
         /// Retrieves the number of attributes that are set on this object.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetCount(out int pcItems);
 
         /// <summary>
         /// Retrieves an attribute at the specified index.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetItemByIndex(int unIndex, out Guid pGuidKey, [In, Out] IntPtr pValue);
 
         /// <summary>
         /// Copies all of the attributes from this object into another attribute store.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void CopyAllItems([In, MarshalAs(UnmanagedType.Interface)] IMFAttributes pDest);
 
         /// <summary>
         /// Retrieves the major type of the format.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetMajorType(out Guid pguidMajorType);
 
         /// <summary>
         /// Queries whether the media type is a compressed format.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void IsCompressedFormat([MarshalAs(UnmanagedType.Bool)] out bool pfCompressed);
 
         /// <summary>
         /// Compares two media types and determines whether they are identical.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         [PreserveSig]
         int IsEqual([In, MarshalAs(UnmanagedType.Interface)] IMFMediaType pIMediaType, ref int pdwFlags);
-        
+
         /// <summary>
         /// Retrieves an alternative representation of the media type.
         /// </summary>
-        
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetRepresentation([In] Guid guidRepresentation, ref IntPtr ppvRepresentation);
-        
+
         /// <summary>
         /// Frees memory that was allocated by the GetRepresentation method.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void FreeRepresentation([In] Guid guidRepresentation, [In] IntPtr pvRepresentation);
     }
 }

--- a/NAudio/MediaFoundation/IMFSample.cs
+++ b/NAudio/MediaFoundation/IMFSample.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -13,226 +14,270 @@ namespace NAudio.MediaFoundation
         /// <summary>
         /// Retrieves the value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, Out] IntPtr pValue);
 
         /// <summary>
         /// Retrieves the data type of the value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetItemType([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int pType);
 
         /// <summary>
         /// Queries whether a stored attribute value equals a specified PROPVARIANT.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void CompareItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, IntPtr value, [MarshalAs(UnmanagedType.Bool)] out bool pbResult);
 
         /// <summary>
         /// Compares the attributes on this object with the attributes on another object.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void Compare([MarshalAs(UnmanagedType.Interface)] IMFAttributes pTheirs, int matchType, [MarshalAs(UnmanagedType.Bool)] out bool pbResult);
 
         /// <summary>
         /// Retrieves a UINT32 value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetUINT32([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int punValue);
 
         /// <summary>
         /// Retrieves a UINT64 value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetUINT64([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out long punValue);
 
         /// <summary>
         /// Retrieves a double value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetDouble([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out double pfValue);
 
         /// <summary>
         /// Retrieves a GUID value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetGUID([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out Guid pguidValue);
 
         /// <summary>
         /// Retrieves the length of a string value associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetStringLength([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int pcchLength);
 
         /// <summary>
         /// Retrieves a wide-character string associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetString([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszValue, int cchBufSize,
                        out int pcchLength);
 
         /// <summary>
         /// Retrieves a wide-character string associated with a key. This method allocates the memory for the string.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetAllocatedString([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [MarshalAs(UnmanagedType.LPWStr)] out string ppwszValue,
                                 out int pcchLength);
 
         /// <summary>
         /// Retrieves the length of a byte array associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetBlobSize([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out int pcbBlobSize);
 
         /// <summary>
         /// Retrieves a byte array associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetBlob([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [Out, MarshalAs(UnmanagedType.LPArray)] byte[] pBuf, int cbBufSize,
                      out int pcbBlobSize);
 
         /// <summary>
         /// Retrieves a byte array associated with a key. This method allocates the memory for the array.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetAllocatedBlob([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, out IntPtr ip, out int pcbSize);
 
         /// <summary>
         /// Retrieves an interface pointer associated with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetUnknown([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPStruct)] Guid riid,
                         [MarshalAs(UnmanagedType.IUnknown)] out object ppv);
 
         /// <summary>
         /// Associates an attribute value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, IntPtr value);
 
         /// <summary>
         /// Removes a key/value pair from the object's attribute list.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void DeleteItem([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey);
 
         /// <summary>
         /// Removes all key/value pairs from the object's attribute list.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void DeleteAllItems();
 
         /// <summary>
         /// Associates a UINT32 value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetUINT32([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, int unValue);
 
         /// <summary>
         /// Associates a UINT64 value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetUINT64([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, long unValue);
 
         /// <summary>
         /// Associates a double value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetDouble([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, double fValue);
 
         /// <summary>
         /// Associates a GUID value with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetGUID([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPStruct)] Guid guidValue);
 
         /// <summary>
         /// Associates a wide-character string with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetString([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPWStr)] string wszValue);
 
         /// <summary>
         /// Associates a byte array with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetBlob([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] pBuf,
                      int cbBufSize);
 
         /// <summary>
         /// Associates an IUnknown pointer with a key.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void SetUnknown([MarshalAs(UnmanagedType.LPStruct)] Guid guidKey, [In, MarshalAs(UnmanagedType.IUnknown)] object pUnknown);
 
         /// <summary>
         /// Locks the attribute store so that no other thread can access it.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void LockStore();
 
         /// <summary>
         /// Unlocks the attribute store.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void UnlockStore();
 
         /// <summary>
         /// Retrieves the number of attributes that are set on this object.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetCount(out int pcItems);
 
         /// <summary>
         /// Retrieves an attribute at the specified index.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void GetItemByIndex(int unIndex, out Guid pGuidKey, [In, Out] IntPtr pValue);
 
         /// <summary>
         /// Copies all of the attributes from this object into another attribute store.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         new void CopyAllItems([In, MarshalAs(UnmanagedType.Interface)] IMFAttributes pDest);
 
         /// <summary>
         /// Retrieves flags associated with the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetSampleFlags(out int pdwSampleFlags);
 
         /// <summary>
         /// Sets flags associated with the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetSampleFlags(int dwSampleFlags);
 
         /// <summary>
         /// Retrieves the presentation time of the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetSampleTime(out long phnsSampletime);
 
         /// <summary>
         /// Sets the presentation time of the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetSampleTime(long hnsSampleTime);
 
         /// <summary>
         /// Retrieves the duration of the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetSampleDuration(out long phnsSampleDuration);
 
         /// <summary>
         /// Sets the duration of the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetSampleDuration(long hnsSampleDuration);
 
         /// <summary>
         /// Retrieves the number of buffers in the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetBufferCount(out int pdwBufferCount);
 
         /// <summary>
         /// Retrieves a buffer from the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetBufferByIndex(int dwIndex, out IMFMediaBuffer ppBuffer);
 
         /// <summary>
         /// Converts a sample with multiple buffers into a sample with a single buffer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void ConvertToContiguousBuffer(out IMFMediaBuffer ppBuffer);
 
         /// <summary>
         ///  Adds a buffer to the end of the list of buffers in the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void AddBuffer(IMFMediaBuffer pBuffer);
 
         /// <summary>
         /// Removes a buffer at a specified index from the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void RemoveBufferByIndex(int dwIndex);
-        
+
         /// <summary>
         /// Removes all buffers from the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void RemoveAllBuffers();
-        
+
         /// <summary>
         /// Retrieves the total length of the valid data in all of the buffers in the sample.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetTotalLength(out int pcbTotalLength);
 
         /// <summary>
         /// Copies the sample data to a buffer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void CopyToBuffer(IMFMediaBuffer pBuffer);
     }
 }

--- a/NAudio/MediaFoundation/IMFSourceReader.cs
+++ b/NAudio/MediaFoundation/IMFSourceReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace NAudio.MediaFoundation
@@ -13,46 +14,56 @@ namespace NAudio.MediaFoundation
         /// <summary>
         /// Queries whether a stream is selected.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetStreamSelection([In] int dwStreamIndex, [Out, MarshalAs(UnmanagedType.Bool)] out bool pSelected);
         /// <summary>
         /// Selects or deselects one or more streams.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetStreamSelection([In] int dwStreamIndex, [In, MarshalAs(UnmanagedType.Bool)] bool pSelected);
         /// <summary>
         /// Gets a format that is supported natively by the media source.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetNativeMediaType([In] int dwStreamIndex, [In] int dwMediaTypeIndex, [Out] out IMFMediaType ppMediaType);
         /// <summary>
         /// Gets the current media type for a stream.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetCurrentMediaType([In] int dwStreamIndex, [Out] out IMFMediaType ppMediaType);
         /// <summary>
         /// Sets the media type for a stream.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetCurrentMediaType([In] int dwStreamIndex, IntPtr pdwReserved, [In] IMFMediaType pMediaType);
         /// <summary>
         /// Seeks to a new position in the media source.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void SetCurrentPosition([In, MarshalAs(UnmanagedType.LPStruct)] Guid guidTimeFormat, [In] IntPtr varPosition);
         /// <summary>
         /// Reads the next sample from the media source.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void ReadSample([In] int dwStreamIndex, [In] int dwControlFlags, [Out] out int pdwActualStreamIndex, [Out] out MF_SOURCE_READER_FLAG pdwStreamFlags,
                         [Out] out UInt64 pllTimestamp, [Out] out IMFSample ppSample);
         /// <summary>
         /// Flushes one or more streams.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void Flush([In] int dwStreamIndex);
 
         /// <summary>
         /// Queries the underlying media source or decoder for an interface.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetServiceForStream([In] int dwStreamIndex, [In, MarshalAs(UnmanagedType.LPStruct)] Guid guidService,
                                  [In, MarshalAs(UnmanagedType.LPStruct)] Guid riid, [Out] out IntPtr ppvObject);
 
         /// <summary>
         /// Gets an attribute from the underlying media source.
         /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         [PreserveSig]
         int GetPresentationAttribute([In] int dwStreamIndex, [In, MarshalAs(UnmanagedType.LPStruct)] Guid guidAttribute, [Out] IntPtr pvarAttribute);
     }

--- a/NAudio/MediaFoundation/MediaFoundationHelpers.cs
+++ b/NAudio/MediaFoundation/MediaFoundationHelpers.cs
@@ -76,8 +76,8 @@ namespace NAudio.MediaFoundation
         /// </summary>
         public static IMFMediaType CreateMediaType()
         {
-            IMFMediaType mediaType;
-            MediaFoundationInterop.MFCreateMediaType(out mediaType);
+            IMFMediaType mediaType = null;
+            MediaFoundationInterop.MFCreateMediaType(ref mediaType);
             return mediaType;
         }
 
@@ -154,8 +154,8 @@ namespace NAudio.MediaFoundation
         /// <returns>A media foundation source reader</returns>
         public static IMFSourceReader CreateSourceReaderFromByteStream(IMFByteStream byteStream)
         {
-            IMFSourceReader reader;
-            MediaFoundationInterop.MFCreateSourceReaderFromByteStream(byteStream, null, out reader);
+            IMFSourceReader reader = null;
+            MediaFoundationInterop.MFCreateSourceReaderFromByteStream(byteStream, null, ref reader);
             return reader;
         }
     }

--- a/NAudio/MediaFoundation/MediaFoundationInterop.cs
+++ b/NAudio/MediaFoundation/MediaFoundationInterop.cs
@@ -29,8 +29,8 @@ namespace NAudio.MediaFoundation
         /// Creates an empty media type.
         /// </summary>
         [DllImport("mfplat.dll", ExactSpelling = true, PreserveSig = false)]
-        internal static extern void MFCreateMediaType(out IMFMediaType ppMFType);
-        
+        internal static extern void MFCreateMediaType([In, Out, MarshalAs(UnmanagedType.Interface)] ref IMFMediaType ppMFType);
+
         /// <summary>
         /// Initializes a media type from a WAVEFORMATEX structure. 
         /// </summary>
@@ -55,7 +55,7 @@ namespace NAudio.MediaFoundation
         /// Creates the source reader from a byte stream.
         /// </summary>
         [DllImport("mfreadwrite.dll", ExactSpelling = true, PreserveSig = false)]
-        public static extern void MFCreateSourceReaderFromByteStream([In] IMFByteStream pByteStream, [In] IMFAttributes pAttributes, [Out, MarshalAs(UnmanagedType.Interface)] out IMFSourceReader ppSourceReader);
+        public static extern void MFCreateSourceReaderFromByteStream([In, MarshalAs(UnmanagedType.Interface)] IMFByteStream pByteStream, [In] IMFAttributes pAttributes, [In, Out, MarshalAs(UnmanagedType.Interface)] ref IMFSourceReader ppSourceReader);
 
         /// <summary>
         /// Creates the sink writer from a URL or byte stream.
@@ -68,7 +68,7 @@ namespace NAudio.MediaFoundation
         /// Creates a Microsoft Media Foundation byte stream that wraps an IRandomAccessStream object.
         /// </summary>
         [DllImport("mfplat.dll", ExactSpelling = true, PreserveSig = false)]
-        public static extern void MFCreateMFByteStreamOnStreamEx([MarshalAs(UnmanagedType.IUnknown)] object punkStream, out IMFByteStream ppByteStream);
+        public static extern void MFCreateMFByteStreamOnStreamEx([MarshalAs(UnmanagedType.IUnknown)] object punkStream, [Out, MarshalAs(UnmanagedType.Interface)] out IMFByteStream ppByteStream);
 
 #if !NETFX_CORE  
         /// <summary>

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Wave\WaveStreams\AiffFileReader.cs" />
     <Compile Include="Wave\WaveStreams\AudioFileReader.cs" />
     <Compile Include="Wave\WaveStreams\BlockAlignReductionStream.cs" />
+    <Compile Include="Wave\WaveStreams\ComStream.cs" />
     <Compile Include="Wave\WaveStreams\CueList.cs" />
     <Compile Include="Wave\WaveStreams\CueWaveFileReader.cs" />
     <Compile Include="Wave\WaveStreams\ISampleNotifier.cs" />
@@ -479,6 +480,7 @@
     <Compile Include="Wave\WaveStreams\ResamplerDmoStream.cs" />
     <Compile Include="Wave\WaveStreams\RiffChunk.cs" />
     <Compile Include="Wave\WaveStreams\SimpleCompressorStream.cs" />
+    <Compile Include="Wave\WaveStreams\StreamMediaFoundationReader.cs" />
     <Compile Include="Wave\WaveStreams\Wave32To16Stream.cs" />
     <Compile Include="Wave\WaveStreams\WaveChannel32.cs" />
     <Compile Include="Wave\SampleProviders\SampleChannel.cs" />

--- a/NAudio/Wave/WaveStreams/ComStream.cs
+++ b/NAudio/Wave/WaveStreams/ComStream.cs
@@ -5,29 +5,62 @@ using System.Runtime.InteropServices.ComTypes;
 
 namespace NAudio.Wave
 {
+    /// <summary>
+    /// ComStream Class
+    /// </summary>
+    /// <seealso cref="System.IO.Stream" />
+    /// <seealso cref="System.Runtime.InteropServices.ComTypes.IStream" />
     public class ComStream : Stream, IStream
     {
+        /// <summary>
+        /// The stream
+        /// </summary>
         private Stream stream;
 
+        /// <summary>
+        /// When overridden in a derived class, gets a value indicating whether the current stream supports reading.
+        /// </summary>
         public override bool CanRead => stream.CanRead;
 
+        /// <summary>
+        /// When overridden in a derived class, gets a value indicating whether the current stream supports seeking.
+        /// </summary>
         public override bool CanSeek => stream.CanSeek;
 
+        /// <summary>
+        /// When overridden in a derived class, gets a value indicating whether the current stream supports writing.
+        /// </summary>
         public override bool CanWrite => stream.CanWrite;
 
+        /// <summary>
+        /// When overridden in a derived class, gets the length in bytes of the stream.
+        /// </summary>
         public override long Length => stream.Length;
 
+        /// <summary>
+        /// When overridden in a derived class, gets or sets the position within the current stream.
+        /// </summary>
         public override long Position
         {
             get { return stream.Position; }
             set { stream.Position = value; }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComStream"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
         public ComStream(Stream stream)
             : this(stream, true)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComStream"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="synchronizeStream">if set to <c>true</c> [synchronize stream].</param>
+        /// <exception cref="System.ArgumentNullException">stream</exception>
         internal ComStream(Stream stream, bool synchronizeStream)
         {
             if (stream == null)
@@ -37,24 +70,52 @@ namespace NAudio.Wave
             this.stream = stream;
         }
 
+        /// <summary>
+        /// Creates a new stream object with its own seek pointer that references the same bytes as the original stream.
+        /// </summary>
+        /// <param name="ppstm">When this method returns, contains the new stream object. This parameter is passed uninitialized.</param>
         void IStream.Clone(out IStream ppstm)
         {
             ppstm = null;
         }
 
+        /// <summary>
+        /// Ensures that any changes made to a stream object that is open in transacted mode are reflected in the parent storage.
+        /// </summary>
+        /// <param name="grfCommitFlags">A value that controls how the changes for the stream object are committed.</param>
         void IStream.Commit(int grfCommitFlags)
         {
             stream.Flush();
         }
 
+        /// <summary>
+        /// Copies a specified number of bytes from the current seek pointer in the stream to the current seek pointer in another stream.
+        /// </summary>
+        /// <param name="pstm">A reference to the destination stream.</param>
+        /// <param name="cb">The number of bytes to copy from the source stream.</param>
+        /// <param name="pcbRead">On successful return, contains the actual number of bytes read from the source.</param>
+        /// <param name="pcbWritten">On successful return, contains the actual number of bytes written to the destination.</param>
         void IStream.CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten)
         {
         }
 
+        /// <summary>
+        /// Restricts access to a specified range of bytes in the stream.
+        /// </summary>
+        /// <param name="libOffset">The byte offset for the beginning of the range.</param>
+        /// <param name="cb">The length of the range, in bytes, to restrict.</param>
+        /// <param name="dwLockType">The requested restrictions on accessing the range.</param>
         void IStream.LockRegion(long libOffset, long cb, int dwLockType)
         {
         }
 
+        /// <summary>
+        /// Reads a specified number of bytes from the stream object into memory starting at the current seek pointer.
+        /// </summary>
+        /// <param name="pv">When this method returns, contains the data read from the stream. This parameter is passed uninitialized.</param>
+        /// <param name="cb">The number of bytes to read from the stream object.</param>
+        /// <param name="pcbRead">A pointer to a ULONG variable that receives the actual number of bytes read from the stream object.</param>
+        /// <exception cref="System.InvalidOperationException">Stream is not readable.</exception>
         void IStream.Read(byte[] pv, int cb, IntPtr pcbRead)
         {
             if (!CanRead)
@@ -64,10 +125,19 @@ namespace NAudio.Wave
                 Marshal.WriteInt32(pcbRead, val);
         }
 
+        /// <summary>
+        /// Discards all changes that have been made to a transacted stream since the last <see cref="M:System.Runtime.InteropServices.ComTypes.IStream.Commit(System.Int32)" /> call.
+        /// </summary>
         void IStream.Revert()
         {
         }
 
+        /// <summary>
+        /// Changes the seek pointer to a new location relative to the beginning of the stream, to the end of the stream, or to the current seek pointer.
+        /// </summary>
+        /// <param name="dlibMove">The displacement to add to <paramref name="dwOrigin" />.</param>
+        /// <param name="dwOrigin">The origin of the seek. The origin can be the beginning of the file, the current seek pointer, or the end of the file.</param>
+        /// <param name="plibNewPosition">On successful return, contains the offset of the seek pointer from the beginning of the stream.</param>
         void IStream.Seek(long dlibMove, int dwOrigin, IntPtr plibNewPosition)
         {
             SeekOrigin origin = (SeekOrigin) dwOrigin;
@@ -76,11 +146,21 @@ namespace NAudio.Wave
                 Marshal.WriteInt64(plibNewPosition, val);
         }
 
+        /// <summary>
+        /// Changes the size of the stream object.
+        /// </summary>
+        /// <param name="libNewSize">The new size of the stream as a number of bytes.</param>
         void IStream.SetSize(long libNewSize)
         {
             SetLength(libNewSize);
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="T:System.Runtime.InteropServices.STATSTG" /> structure for this stream.
+        /// </summary>
+        /// <param name="pstatstg">When this method returns, contains a STATSTG structure that describes this stream object. This parameter is passed uninitialized.</param>
+        /// <param name="grfStatFlag">Members in the STATSTG structure that this method does not return, thus saving some memory allocation operations.</param>
+        /// <exception cref="System.ObjectDisposedException">Stream</exception>
         void IStream.Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag)
         {
             const int STGM_READ = 0x00000000;
@@ -101,10 +181,23 @@ namespace NAudio.Wave
             pstatstg = tmp;
         }
 
+        /// <summary>
+        /// Removes the access restriction on a range of bytes previously restricted with the <see cref="M:System.Runtime.InteropServices.ComTypes.IStream.LockRegion(System.Int64,System.Int64,System.Int32)" /> method.
+        /// </summary>
+        /// <param name="libOffset">The byte offset for the beginning of the range.</param>
+        /// <param name="cb">The length, in bytes, of the range to restrict.</param>
+        /// <param name="dwLockType">The access restrictions previously placed on the range.</param>
         void IStream.UnlockRegion(long libOffset, long cb, int dwLockType)
         {
         }
 
+        /// <summary>
+        /// Writes a specified number of bytes into the stream object starting at the current seek pointer.
+        /// </summary>
+        /// <param name="pv">The buffer to write this stream to.</param>
+        /// <param name="cb">The number of bytes to write to the stream.</param>
+        /// <param name="pcbWritten">On successful return, contains the actual number of bytes written to the stream object. If the caller sets this pointer to <see cref="F:System.IntPtr.Zero" />, this method does not provide the actual number of bytes written.</param>
+        /// <exception cref="System.InvalidOperationException">Stream is not writeable.</exception>
         void IStream.Write(byte[] pv, int cb, IntPtr pcbWritten)
         {
             if (!CanWrite)
@@ -114,31 +207,65 @@ namespace NAudio.Wave
                 Marshal.WriteInt32(pcbWritten, cb);
         }
 
+        /// <summary>
+        /// When overridden in a derived class, clears all buffers for this stream and causes any buffered data to be written to the underlying device.
+        /// </summary>
         public override void Flush()
         {
             stream.Flush();
         }
 
+        /// <summary>
+        /// When overridden in a derived class, reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
+        /// </summary>
+        /// <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between <paramref name="offset" /> and (<paramref name="offset" /> + <paramref name="count" /> - 1) replaced by the bytes read from the current source.</param>
+        /// <param name="offset">The zero-based byte offset in <paramref name="buffer" /> at which to begin storing the data read from the current stream.</param>
+        /// <param name="count">The maximum number of bytes to be read from the current stream.</param>
+        /// <returns>
+        /// The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
+        /// </returns>
         public override int Read(byte[] buffer, int offset, int count)
         {
             return stream.Read(buffer, offset, count);
         }
 
+        /// <summary>
+        /// When overridden in a derived class, sets the position within the current stream.
+        /// </summary>
+        /// <param name="offset">A byte offset relative to the <paramref name="origin" /> parameter.</param>
+        /// <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position.</param>
+        /// <returns>
+        /// The new position within the current stream.
+        /// </returns>
         public override long Seek(long offset, SeekOrigin origin)
         {
             return stream.Seek(offset, origin);
         }
 
+        /// <summary>
+        /// When overridden in a derived class, sets the length of the current stream.
+        /// </summary>
+        /// <param name="value">The desired length of the current stream in bytes.</param>
         public override void SetLength(long value)
         {
             stream.SetLength(value);
         }
 
+        /// <summary>
+        /// When overridden in a derived class, writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
+        /// </summary>
+        /// <param name="buffer">An array of bytes. This method copies <paramref name="count" /> bytes from <paramref name="buffer" /> to the current stream.</param>
+        /// <param name="offset">The zero-based byte offset in <paramref name="buffer" /> at which to begin copying bytes to the current stream.</param>
+        /// <param name="count">The number of bytes to be written to the current stream.</param>
         public override void Write(byte[] buffer, int offset, int count)
         {
             stream.Write(buffer, offset, count);
         }
 
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="T:System.IO.Stream" /> and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
@@ -148,6 +275,9 @@ namespace NAudio.Wave
             stream = null;
         }
 
+        /// <summary>
+        /// Closes the current stream and releases any resources (such as sockets and file handles) associated with the current stream.
+        /// </summary>
         public override void Close()
         {
             base.Close();

--- a/NAudio/Wave/WaveStreams/StreamMediaFoundationReader.cs
+++ b/NAudio/Wave/WaveStreams/StreamMediaFoundationReader.cs
@@ -4,19 +4,33 @@ using NAudio.MediaFoundation;
 
 namespace NAudio.Wave
 {
+    /// <summary>
+    /// Class for reading a stream that Media Foundation can play
+    /// Will only work in Windows Vista and above
+    /// Automatically converts to PCM
+    /// If it is a video file with multiple audio streams, it will pick out the first audio stream
+    /// </summary>
     public class StreamMediaFoundationReader : MediaFoundationReader
     {
         private readonly Stream stream;
 
+        /// <summary>
+        /// Creates a new MediaFoundationReader based on the supplied file
+        /// </summary>
+        /// <param name="stream">Stream</param>
+        /// <param name="settings">Advanced settings</param>
         public StreamMediaFoundationReader(Stream stream, MediaFoundationReaderSettings settings = null)
         {
             this.stream = stream;
             Init(settings);
         }
 
+        /// <summary>
+        /// Creates the reader (overridable by )
+        /// </summary>
         protected override IMFSourceReader CreateReader(MediaFoundationReaderSettings settings)
         {
-            var ppSourceReader = MediaFoundationApi.CreateSourceReaderFromByteStream(MediaFoundationApi.CreateByteStream(new ComStream(stream)));
+            var ppSourceReader = MediaFoundationApi.CreateSourceReaderFromByteStream(MediaFoundationApi.CreateByteStream(new ComStream(stream, false)));
 
             ppSourceReader.SetStreamSelection(-2, false);
             ppSourceReader.SetStreamSelection(-3, true);


### PR DESCRIPTION
I wanted to be able to use this feature with a unity standalone windows app. I finished adding it to the project with comments and made the changes needed to make it work with Mono's stricter interop requirements. This should continue to work for everything else, but now also works with current versions of Unity if you build it against a .net 3.5 target.
