### PR TITLE
AudioFileReader NullReferenceException fix in Dispose

### DIFF
--- a/NAudio/Wave/WaveStreams/AudioFileReader.cs
+++ b/NAudio/Wave/WaveStreams/AudioFileReader.cs
@@ -156,8 +156,10 @@ namespace NAudio.Wave
         {
             if (disposing)
             {
-                readerStream.Dispose();
-                readerStream = null;
+                if (readerStream != null) {
+                    readerStream.Dispose();
+                    readerStream = null;
+                }
             }
             base.Dispose(disposing);
         }

--- a/NAudioTests/NAudioTests.csproj
+++ b/NAudioTests/NAudioTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Wasapi\MMDeviceEnumeratorTests.cs" />
     <Compile Include="WaveFormats\AdpcmWaveFormatTests.cs" />
     <Compile Include="WaveIn\WaveInDevicesTests.cs" />
+    <Compile Include="WaveStreams\AudioFileReaderTests.cs" />
     <Compile Include="WaveStreams\BlockAlignmentReductionStreamTests.cs" />
     <Compile Include="WaveStreams\BufferedWaveProviderTests.cs" />
     <Compile Include="WaveStreams\CircularBufferTests.cs" />

--- a/NAudioTests/WaveStreams/AudioFileReaderTests.cs
+++ b/NAudioTests/WaveStreams/AudioFileReaderTests.cs
@@ -1,0 +1,18 @@
+﻿using NAudio.Wave;
+using NUnit.Framework;
+
+namespace NAudioTests.WaveStreams
+{
+    [TestFixture]
+    public class AudioFileReaderTests
+    {
+        [Test]
+        [Category("IntegrationTest")]
+        public void CanBeDisposedMoreThanOnce()
+        {
+            var reader = new AudioFileReader(@"..\..\..\SampleData\Drums\closed-hat-trimmed.wav");
+            reader.Dispose();
+            Assert.DoesNotThrow(() => reader.Dispose());
+        }
+    }
+}


### PR DESCRIPTION
Here is a fix to an extremely trivial oversight where AudioFileReader wasn't setting its internal stream to null after disposing it, causing further disposes to throw.  Included is a simple integration test using sample wav data provided in the repo.