### PR TITLE
Reduces Wave32to16Stream allocations

### DIFF
--- a/NAudio/Wave/WaveStreams/Wave32To16Stream.cs
+++ b/NAudio/Wave/WaveStreams/Wave32To16Stream.cs
@@ -1,4 +1,5 @@
 using System;
+using NAudio.Utils;
 
 namespace NAudio.Wave
 {
@@ -19,7 +20,7 @@ namespace NAudio.Wave
         /// The <see cref="Read"/> method reuses the same buffer to prevent
         /// unnecessary allocations.
         /// </summary>
-        private byte[] sourceBuffer = new byte[0];
+        private byte[] sourceBuffer;
 
         /// <summary>
         /// Creates a new Wave32To16Stream
@@ -110,8 +111,7 @@ namespace NAudio.Wave
             lock (lockObject)
             {
                 int count = numBytes*2;
-                if (sourceBuffer.Length < count)
-                    sourceBuffer = new byte[count];
+                sourceBuffer = BufferHelpers.Ensure(sourceBuffer, count);
                 int bytesRead = sourceStream.Read(sourceBuffer, 0, count);
                 Convert32To16(destBuffer, offset, sourceBuffer, bytesRead);
                 position += (bytesRead/2);

--- a/NAudio/Wave/WaveStreams/Wave32To16Stream.cs
+++ b/NAudio/Wave/WaveStreams/Wave32To16Stream.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace NAudio.Wave
 {
@@ -16,6 +14,12 @@ namespace NAudio.Wave
         private bool clip;
         private float volume;
         private readonly object lockObject = new object();
+
+        /// <summary>
+        /// The <see cref="Read"/> method reuses the same buffer to prevent
+        /// unnecessary allocations.
+        /// </summary>
+        private byte[] sourceBuffer = new byte[0];
 
         /// <summary>
         /// Creates a new Wave32To16Stream
@@ -105,8 +109,10 @@ namespace NAudio.Wave
         {
             lock (lockObject)
             {
-                byte[] sourceBuffer = new byte[numBytes*2];
-                int bytesRead = sourceStream.Read(sourceBuffer, 0, numBytes*2);
+                int count = numBytes*2;
+                if (sourceBuffer.Length < count)
+                    sourceBuffer = new byte[count];
+                int bytesRead = sourceStream.Read(sourceBuffer, 0, count);
                 Convert32To16(destBuffer, offset, sourceBuffer, bytesRead);
                 position += (bytesRead/2);
                 return bytesRead/2;


### PR DESCRIPTION
The Read method from Wave32to16Stream was allocating a new large array at each call, which caused constant garbage collections.