### PR TITLE
use correct waveformat for stereo to mono float conversion

### DIFF
--- a/NAudio/Wave/SampleProviders/StereoToMonoSampleProvider.cs
+++ b/NAudio/Wave/SampleProviders/StereoToMonoSampleProvider.cs
@@ -23,7 +23,13 @@ namespace NAudio.Wave.SampleProviders
                 throw new ArgumentException("Source must be stereo");
             }
             this.sourceProvider = sourceProvider;
-            WaveFormat = new WaveFormat(sourceProvider.WaveFormat.SampleRate, 1);
+            WaveFormat = WaveFormat.CreateCustomFormat(
+                sourceProvider.WaveFormat.Encoding,
+                sourceProvider.WaveFormat.SampleRate,
+                1,
+                sourceProvider.WaveFormat.AverageBytesPerSecond/2,
+                sourceProvider.WaveFormat.BitsPerSample/8,
+                sourceProvider.WaveFormat.BitsPerSample);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi @markheath,

first, thanks for this great project.
I tried to convert some .mp3 files from stereo to mono and got an exception (SampleToWaveProvider ctor "Must be already floating point").
The waveformat construction in StereoToMonoSampleProvider looked a bit suspicious, after fixing that it works for me. Since I'm by no means an audio expert, I'd like to have a second pair of eyes check this before merging.

Kind regards Phil