### PR TITLE
Add StreamMediaFoundationReader support for windows 7

### DIFF
--- a/NAudio/MediaFoundation/MediaFoundationHelpers.cs
+++ b/NAudio/MediaFoundation/MediaFoundationHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using NAudio.Wave;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace NAudio.MediaFoundation
 {
@@ -143,7 +144,18 @@ namespace NAudio.MediaFoundation
         public static IMFByteStream CreateByteStream(object stream)
         {
             IMFByteStream byteStream;
+#if NETFX_CORE
             MediaFoundationInterop.MFCreateMFByteStreamOnStreamEx(stream, out byteStream);
+#else
+            if (stream is IStream)
+            {
+                MediaFoundationInterop.MFCreateMFByteStreamOnStream(stream as IStream, out byteStream);
+            }
+            else
+            {
+                throw new ArgumentException("Stream must be IStream in desktop apps");
+            }
+#endif
             return byteStream;
         }
 

--- a/NAudio/MediaFoundation/MediaFoundationInterop.cs
+++ b/NAudio/MediaFoundation/MediaFoundationInterop.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using NAudio.Wave;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace NAudio.MediaFoundation
 {
@@ -64,13 +65,23 @@ namespace NAudio.MediaFoundation
         public static extern void MFCreateSinkWriterFromURL([In, MarshalAs(UnmanagedType.LPWStr)] string pwszOutputURL,
                                                            [In] IMFByteStream pByteStream, [In] IMFAttributes pAttributes, [Out] out IMFSinkWriter ppSinkWriter);
 
+
+#if NETFX_CORE
         /// <summary>
         /// Creates a Microsoft Media Foundation byte stream that wraps an IRandomAccessStream object.
         /// </summary>
         [DllImport("mfplat.dll", ExactSpelling = true, PreserveSig = false)]
         public static extern void MFCreateMFByteStreamOnStreamEx([MarshalAs(UnmanagedType.IUnknown)] object punkStream, out IMFByteStream ppByteStream);
 
-#if !NETFX_CORE  
+#else
+        /// <summary>
+        /// Creates a Microsoft Media Foundation byte stream that wraps an IRandomAccessStream object.
+        /// </summary>
+        [DllImport("mfplat.dll", ExactSpelling = true, PreserveSig = false)]
+        public static extern void MFCreateMFByteStreamOnStream([In] IStream punkStream, out IMFByteStream ppByteStream);
+#endif
+
+#if !NETFX_CORE
         /// <summary>
         /// Gets a list of Microsoft Media Foundation transforms (MFTs) that match specified search criteria. 
         /// </summary>
@@ -100,7 +111,7 @@ namespace NAudio.MediaFoundation
             [Out, MarshalAs(UnmanagedType.Interface)] out IMFAttributes ppMFAttributes,
             [In] int cInitialSize);
 
-#if !NETFX_CORE  
+#if !NETFX_CORE
         /// <summary>
         /// Gets a list of output formats from an audio encoder.
         /// </summary>


### PR DESCRIPTION
When trying to use StreamMediaFoundationReader on windows 7. A exception will occur due to MFCreateMFByteStreamOnStreamEx(https://msdn.microsoft.com/en-us/library/windows/desktop/hh162754(v=vs.85).aspx) support only windows 8 and above. So I added another MediaFoundation api MFCreateMFByteStreamOnStream(https://msdn.microsoft.com/zh-tw/library/windows/desktop/dd388095(v=vs.85).aspx) into MediaFoundationInterop and use define in MediaFoundationApi.CreateByteStream to seperate RT and desktop apps Implemention.