### PR TITLE
Change WaveOut and WaveOutEvent default DeviceNumber to -1

### DIFF
--- a/NAudio/Wave/WaveOutputs/WaveOut.cs
+++ b/NAudio/Wave/WaveOutputs/WaveOut.cs
@@ -66,9 +66,10 @@ namespace NAudio.Wave
         /// <summary>
         /// Gets or sets the device number
         /// Should be set before a call to Init
-        /// This must be between 0 and <see>DeviceCount</see> - 1.
+        /// This must be between -1 and <see>DeviceCount</see> - 1.
+        /// -1 means stick to default device even default device is changed
         /// </summary>
-        public int DeviceNumber { get; set; }
+        public int DeviceNumber { get; set; } = -1;
 
 
         /// <summary>

--- a/NAudio/Wave/WaveOutputs/WaveOutEvent.cs
+++ b/NAudio/Wave/WaveOutputs/WaveOutEvent.cs
@@ -40,9 +40,10 @@ namespace NAudio.Wave
         /// <summary>
         /// Gets or sets the device number
         /// Should be set before a call to Init
-        /// This must be between 0 and <see>DeviceCount</see> - 1.
+        /// This must be between -1 and <see>DeviceCount</see> - 1.
+        /// -1 means stick to default device even default device is changed
         /// </summary>
-        public int DeviceNumber { get; set; }
+        public int DeviceNumber { get; set; } = -1;
 
         /// <summary>
         /// Opens a WaveOut device


### PR DESCRIPTION
Setting DeviceNumber to 0 means current default device at that time. The sound will come out from same device if the default device changed while playing. If we set DeviceNumber to -1, the output device will always stick to the default device automatically.

Although this wasen't mention in waveOutOpen [document](https://msdn.microsoft.com/zh-tw/library/windows/desktop/dd743866(v=vs.85).aspx). Some other projects had already set DeviceNumber to -1. https://www.codeproject.com/Articles/866347/Streaming-Audio-to-the-WaveOut-Device 
`waveOutOpen(out hwo, -1, wFmt, woDone, rFrames, CALLBACK_FUNCTION);`