### PR TITLE
Added MidiFile constructor overload that takes an input Stream object.

### DIFF
--- a/NAudio/Midi/MidiFile.cs
+++ b/NAudio/Midi/MidiFile.cs
@@ -39,12 +39,27 @@ namespace NAudio.Midi
         /// </summary>
         /// <param name="filename">Name of MIDI file</param>
         /// <param name="strictChecking">If true will error on non-paired note events</param>
-        public MidiFile(string filename, bool strictChecking)
+        public MidiFile(string filename, bool strictChecking) :
+            this(File.OpenRead(filename), strictChecking, true)
+        {
+        }
+
+        /// <summary>
+        /// Opens a MIDI file stream for reading
+        /// </summary>
+        /// <param name="inputStream">The input stream containing a MIDI file</param>
+        /// <param name="strictChecking">If true will error on non-paired note events</param>
+        public MidiFile(Stream inputStream, bool strictChecking) :
+            this(inputStream, strictChecking, false)
+        {
+        }
+
+        private MidiFile(Stream inputStream, bool strictChecking, bool ownInputStream)
         {
             this.strictChecking = strictChecking;
             
-            var br = new BinaryReader(File.OpenRead(filename));
-            using(br) 
+            var br = new BinaryReader(inputStream);
+            try 
             {
                 string chunkHeader = Encoding.UTF8.GetString(br.ReadBytes(4));
                 if(chunkHeader != "MThd") 
@@ -140,6 +155,11 @@ namespace NAudio.Midi
                         throw new FormatException(String.Format("Read too far {0}+{1}!={2}", chunkSize, startPos, br.BaseStream.Position));
                     }
                 }
+            }
+            finally
+            {
+                if (ownInputStream)
+                    br.Close();
             }
         }
 


### PR DESCRIPTION
Added a MidiFile constructor overload to be able to read MIDI file events from an input stream.
The implementation is similar to those of AiffFileReader and Mp3FileReader with one difference. Unlike AiffFileReader or Mp3FileReader, MidiFile doesn't implement IDisposable so I couldn't dispose the stream in Dispose method and didn't want to introduce dependency on IDisposable for the sake of backward compatibility. So I added a private constructor with ownInputStream parameter which is checked in "finally" clause - I had to replace "using" clause with "try/finally" because of that. 