### PR TITLE
Restore compatibility with .NET Portable.

### DIFF
--- a/NAudio.nuspec
+++ b/NAudio.nuspec
@@ -13,6 +13,8 @@
     <tags>C# .NET audio sound</tags>
   </metadata>
   <files>
+    <file src="NAudio\bin\Release\NAudio.dll" target="lib" /> 
+    <file src="NAudio\bin\Release\NAudio.xml" target="lib" /> 
     <file src="NAudio\bin\Release\NAudio.dll" target="lib\net35" /> 
     <file src="NAudio\bin\Release\NAudio.xml" target="lib\net35" /> 
     <file src="NAudio.Win8\bin\Release\NAudio.Win8.dll" target="lib\windows8" /> 


### PR DESCRIPTION
Some .NET profiles (including .NET Portable variants) can't use NAudio after version 1.5, because of the explicit target frameworks used in recent versions.
Contents of the NuGet package's `lib` directories are:
```
+ naudio
  + 1.8.0
    + lib
      + net35
        + NAudio.dll
      + windows8
        + NAudio.dll
```
both containing their build of NAudio.dll.

Version 1.5 had the following lib folder layout:
```
+ naudio
  + 1.5.0
    + lib
      + NAudio.dll
```
That "default" assembly worked for non-enforced target frameworks (i.e. .NET Standard, which supersedes .NET Framework 3.5).

This change copies the `3.5` assembly as the default target framework, allowing `.NET Portable` and `.NET Standard` projects to import it successfully:
```
+ naudio
  + <new version>
    + lib
      + NAudio.dll   <== Copy of 3.5, useable by different .NET profiles.
      + net35
        + NAudio.dll
      + windows8
        + NAudio.dll
```