### PR TITLE
Implemented IDisposable into MMDevice and added releasing of COM object to AudioEndpointVolume Dispose

### DIFF
--- a/NAudio/CoreAudioApi/AudioEndpointVolume.cs
+++ b/NAudio/CoreAudioApi/AudioEndpointVolume.cs
@@ -210,7 +210,6 @@ namespace NAudio.CoreAudioApi
             }
             Marshal.ReleaseComObject(audioEndPointVolume);
             GC.SuppressFinalize(this);
-
         }
         
         /// <summary>

--- a/NAudio/CoreAudioApi/AudioEndpointVolume.cs
+++ b/NAudio/CoreAudioApi/AudioEndpointVolume.cs
@@ -208,6 +208,7 @@ namespace NAudio.CoreAudioApi
                 Marshal.ThrowExceptionForHR(audioEndPointVolume.UnregisterControlChangeNotify(callBack));
                 callBack = null;
             }
+            Marshal.ReleaseComObject(audioEndPointVolume);
             GC.SuppressFinalize(this);
 
         }

--- a/NAudio/CoreAudioApi/MMDevice.cs
+++ b/NAudio/CoreAudioApi/MMDevice.cs
@@ -31,7 +31,7 @@ namespace NAudio.CoreAudioApi
     /// <summary>
     /// MM Device
     /// </summary>
-    public class MMDevice
+    public class MMDevice : IDisposable
     {
         #region Variables
         private readonly IMMDevice deviceInterface;
@@ -275,5 +275,22 @@ namespace NAudio.CoreAudioApi
             return FriendlyName;
         }
 
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        public void Dispose()
+        {
+            this.audioEndpointVolume?.Dispose();
+            this.audioSessionManager?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+        
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~MMDevice()
+        {
+            Dispose();
+        }
     }
 }


### PR DESCRIPTION
Should help with #200 as the unused AudioEndpointVolume COM objects can be easily removed if the MMDevice instance is no longer being used to prevent memory leaks.