### PR TITLE
Allow for poorly formatted Chunk Identifiers in WAV header by seeking…

### DIFF
--- a/AudioFileInspector/Properties/AssemblyInfo.cs
+++ b/AudioFileInspector/Properties/AssemblyInfo.cs
@@ -29,8 +29,8 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.1.7.0")]
-[assembly: AssemblyFileVersion("0.1.7.0")]
+[assembly: AssemblyVersion("0.1.8.0")]
+[assembly: AssemblyFileVersion("0.1.8.0")]
 
 // build 1 - 1 Nov 2006
 // initial version - moved out of WavePlayer

--- a/NAudio/CoreAudioApi/Interfaces/Blob.cs
+++ b/NAudio/CoreAudioApi/Interfaces/Blob.cs
@@ -27,9 +27,18 @@ using System.Runtime.InteropServices;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {
-    internal struct Blob
+    /// <summary>
+    /// Representation of binary large object container.
+    /// </summary>
+    public struct Blob
     {
+        /// <summary>
+        /// Length of binary object.
+        /// </summary>
         public int Length;
+        /// <summary>
+        /// Pointer to buffer storing data.
+        /// </summary>
         public IntPtr Data;
 
         //Code Should Compile at warning level4 without any warnings, 

--- a/NAudio/CoreAudioApi/Interfaces/StorageAccessMode.cs
+++ b/NAudio/CoreAudioApi/Interfaces/StorageAccessMode.cs
@@ -7,10 +7,19 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// <summary>
     /// MMDevice STGM enumeration
     /// </summary>
-    enum StorageAccessMode
+    public enum StorageAccessMode
     {
+        /// <summary>
+        /// Read-only access mode.
+        /// </summary>
         Read,
+        /// <summary>
+        /// Write-only access mode.
+        /// </summary>
         Write,
+        /// <summary>
+        /// Read-write access mode.
+        /// </summary>
         ReadWrite
     }
 }

--- a/NAudio/CoreAudioApi/MMDevice.cs
+++ b/NAudio/CoreAudioApi/MMDevice.cs
@@ -49,10 +49,15 @@ namespace NAudio.CoreAudioApi
         #endregion
 
         #region Init
-        private void GetPropertyInformation()
+        /// <summary>
+        /// Initializes the device's property store.
+        /// </summary>
+        /// <param name="stgmAccess">The storage-access mode to open store for.</param>
+        /// <remarks>Administrative client is required for Write and ReadWrite modes.</remarks>
+        public void GetPropertyInformation(StorageAccessMode stgmAccess = StorageAccessMode.Read)
         {
             IPropertyStore propstore;
-            Marshal.ThrowExceptionForHR(deviceInterface.OpenPropertyStore(StorageAccessMode.Read, out propstore));
+            Marshal.ThrowExceptionForHR(deviceInterface.OpenPropertyStore(stgmAccess, out propstore));
             propertyStore = new PropertyStore(propstore);
         }
 

--- a/NAudio/CoreAudioApi/PropVariant.cs
+++ b/NAudio/CoreAudioApi/PropVariant.cs
@@ -35,35 +35,98 @@ namespace NAudio.CoreAudioApi.Interfaces
     [StructLayout(LayoutKind.Explicit)]
     public struct PropVariant
     {
-        [FieldOffset(0)] private short vt;
-        [FieldOffset(2)] private short wReserved1;
-        [FieldOffset(4)] private short wReserved2;
-        [FieldOffset(6)] private short wReserved3;
-        [FieldOffset(8)] private sbyte cVal;
-        [FieldOffset(8)] private byte bVal;
-        [FieldOffset(8)] private short iVal;
-        [FieldOffset(8)] private ushort uiVal;
-        [FieldOffset(8)] private int lVal;
-        [FieldOffset(8)] private uint ulVal;
-        [FieldOffset(8)] private int intVal;
-        [FieldOffset(8)] private uint uintVal;
-        [FieldOffset(8)] private long hVal;
-        [FieldOffset(8)] private long uhVal;
-        [FieldOffset(8)] private float fltVal;
-        [FieldOffset(8)] private double dblVal;
+        /// <summary>
+        /// Value type tag.
+        /// </summary>
+        [FieldOffset(0)] public short vt;
+        /// <summary>
+        /// Reserved1.
+        /// </summary>
+        [FieldOffset(2)] public short wReserved1;
+        /// <summary>
+        /// Reserved2.
+        /// </summary>
+        [FieldOffset(4)] public short wReserved2;
+        /// <summary>
+        /// Reserved3.
+        /// </summary>
+        [FieldOffset(6)] public short wReserved3;
+        /// <summary>
+        /// cVal.
+        /// </summary>
+        [FieldOffset(8)] public sbyte cVal;
+        /// <summary>
+        /// bVal.
+        /// </summary>
+        [FieldOffset(8)] public byte bVal;
+        /// <summary>
+        /// iVal.
+        /// </summary>
+        [FieldOffset(8)] public short iVal;
+        /// <summary>
+        /// uiVal.
+        /// </summary>
+        [FieldOffset(8)] public ushort uiVal;
+        /// <summary>
+        /// lVal.
+        /// </summary>
+        [FieldOffset(8)] public int lVal;
+        /// <summary>
+        /// ulVal.
+        /// </summary>
+        [FieldOffset(8)] public uint ulVal;
+        /// <summary>
+        /// intVal.
+        /// </summary>
+        [FieldOffset(8)] public int intVal;
+        /// <summary>
+        /// uintVal.
+        /// </summary>
+        [FieldOffset(8)] public uint uintVal;
+        /// <summary>
+        /// hVal.
+        /// </summary>
+        [FieldOffset(8)] public long hVal;
+        /// <summary>
+        /// uhVal.
+        /// </summary>
+        [FieldOffset(8)] public long uhVal;
+        /// <summary>
+        /// fltVal.
+        /// </summary>
+        [FieldOffset(8)] public float fltVal;
+        /// <summary>
+        /// dblVal.
+        /// </summary>
+        [FieldOffset(8)] public double dblVal;
         //VARIANT_BOOL boolVal;
-        [FieldOffset(8)] private short boolVal;
-        [FieldOffset(8)] private int scode;
+        /// <summary>
+        /// boolVal.
+        /// </summary>
+        [FieldOffset(8)] public short boolVal;
+        /// <summary>
+        /// scode.
+        /// </summary>
+        [FieldOffset(8)] public int scode;
         //CY cyVal;
         //[FieldOffset(8)] private DateTime date; - can cause issues with invalid value
-        [FieldOffset(8)] private System.Runtime.InteropServices.ComTypes.FILETIME filetime;
+        /// <summary>
+        /// Date time.
+        /// </summary>
+        [FieldOffset(8)] public System.Runtime.InteropServices.ComTypes.FILETIME filetime;
         //CLSID* puuid;
         //CLIPDATA* pclipdata;
         //BSTR bstrVal;
         //BSTRBLOB bstrblobVal;
-        [FieldOffset(8)] private Blob blobVal;
+        /// <summary>
+        /// Binary large object.
+        /// </summary>
+        [FieldOffset(8)] public Blob blobVal;
         //LPSTR pszVal;
-        [FieldOffset(8)] private IntPtr pointerValue; //LPWSTR 
+        /// <summary>
+        /// Pointer value.
+        /// </summary>
+        [FieldOffset(8)] public IntPtr pointerValue; //LPWSTR 
         //IUnknown* punkVal;
         /*IDispatch* pdispVal;
         IStream* pStream;

--- a/NAudio/CoreAudioApi/PropertyKeys.cs
+++ b/NAudio/CoreAudioApi/PropertyKeys.cs
@@ -84,5 +84,17 @@ namespace NAudio.CoreAudioApi
         /// PKEY _Device_IconPath
         /// </summary>
         public static readonly PropertyKey PKEY_Device_IconPath = new PropertyKey(new Guid(unchecked((int)0x259abffc), unchecked((short)0x50a7), 0x47ce, 0xaf, 0x8, 0x68, 0xc9, 0xa7, 0xd7, 0x33, 0x66), 12);
+        /// <summary>
+        /// Device description property.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_DeviceDesc = new PropertyKey(new Guid(unchecked((int)0xa45c254e), unchecked((short)0xdf1c), 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0), 2);
+        /// <summary>
+        /// Id of controller device for endpoint device property.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_ControllerDeviceId = new PropertyKey(new Guid(unchecked((int)0xb3f8fa53), unchecked((short)0x0004), 0x438e, 0x90, 0x03, 0x51, 0xa4, 0x6e, 0x13, 0x9b, 0xfc), 2);
+        /// <summary>
+        /// Device interface key property.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_InterfaceKey = new PropertyKey(new Guid(unchecked((int)0x233164c8), unchecked((short)0x1b2c), 0x4c7d, 0xbc, 0x68, 0xb6, 0x71, 0x68, 0x7a, 0x25, 0x67), 1);
     }
 }

--- a/NAudio/CoreAudioApi/PropertyStore.cs
+++ b/NAudio/CoreAudioApi/PropertyStore.cs
@@ -129,6 +129,24 @@ namespace NAudio.CoreAudioApi
         }
 
         /// <summary>
+        /// Sets property value at specified key.
+        /// </summary>
+        /// <param name="key">Key of property to set.</param>
+        /// <param name="value">Value to write.</param>
+        public void SetValue(PropertyKey key, PropVariant value)
+        {
+            Marshal.ThrowExceptionForHR(storeInterface.SetValue(ref key, ref value));
+        }
+
+        /// <summary>
+        /// Saves a property change.
+        /// </summary>
+        public void Commit()
+        {
+            Marshal.ThrowExceptionForHR(storeInterface.Commit());
+        }
+
+        /// <summary>
         /// Creates a new property store
         /// </summary>
         /// <param name="store">IPropertyStore COM interface</param>

--- a/NAudio/FileFormats/SoundFont/SampleDataChunk.cs
+++ b/NAudio/FileFormats/SoundFont/SampleDataChunk.cs
@@ -6,23 +6,47 @@ namespace NAudio.SoundFont
 	class SampleDataChunk 
 	{
 		private byte[] sampleData;
-		public SampleDataChunk(RiffChunk chunk) 
+        private byte[] sampleData24;
+
+        public SampleDataChunk(RiffChunk chunk) 
 		{
 			string header = chunk.ReadChunkID();
-			if(header != "sdta") 
-			{
-				throw new InvalidDataException(String.Format("Not a sample data chunk ({0})",header));
-			}
-			sampleData = chunk.GetData();
+            if (header != "sdta")
+            {
+                throw new InvalidDataException(String.Format("Not a sample data chunk ({0})", header));
+            }
+
+            var smplChunk = chunk.GetNextSubChunk();
+            sampleData = smplChunk.GetData();
+
+            var sm24Chunk = chunk.GetNextSubChunk();
+            if (sm24Chunk?.ChunkID == "sm24" && sm24Chunk.ChunkSize == smplChunk.ChunkSize / 2)
+            {
+                sampleData24 = sm24Chunk.GetData();
+            }
+            else
+            {
+                //ignore if next subchunk is not a sm24 chunk or the size is not exactly half of smpl data
+            }
 		}
 
-		public byte[] SampleData
+        public bool Is24Bit => sampleData24 != null;
+
+        public byte[] SampleData
 		{
 			get
 			{
 				return sampleData;
 			}
 		}
-	}
+
+        public byte[] SampleData24bit
+        {
+            get
+            {
+                return sampleData24;
+            }
+        }
+    }
 
 } // end of namespace

--- a/NAudio/FileFormats/SoundFont/SoundFont.cs
+++ b/NAudio/FileFormats/SoundFont/SoundFont.cs
@@ -118,10 +118,32 @@ namespace NAudio.SoundFont
 			}
 		}
 
-		/// <summary>
-		/// <see cref="Object.ToString"/>
+        /// <summary>
+		/// The 24 bit portion of Sample Data
 		/// </summary>
-		public override string ToString() 
+		public byte[] SampleData24
+        {
+            get
+            {
+                return sampleData.SampleData24bit;
+            }
+        }
+
+        /// <summary>
+        /// Does this SoundFont contain 24 bit samples?
+        /// </summary>
+        public bool Is24Bit
+        {
+            get
+            {
+                return sampleData.Is24Bit;
+            }
+        }
+
+        /// <summary>
+        /// <see cref="Object.ToString"/>
+        /// </summary>
+        public override string ToString() 
 		{
 			return String.Format("Info Chunk:\r\n{0}\r\nPresets Chunk:\r\n{1}",
 									info,presetsChunk);

--- a/NAudio/Midi/TextEvent.cs
+++ b/NAudio/Midi/TextEvent.cs
@@ -9,7 +9,7 @@ namespace NAudio.Midi
     /// </summary>
     public class TextEvent : MetaEvent 
     {
-        private string text;
+        private byte[] data;
         
         /// <summary>
         /// Reads a new text event from a MIDI stream
@@ -18,8 +18,7 @@ namespace NAudio.Midi
         /// <param name="length">The data length</param>
         public TextEvent(BinaryReader br,int length) 
         {
-            Encoding byteEncoding = NAudio.Utils.ByteEncoding.Instance;
-            text = byteEncoding.GetString(br.ReadBytes(length));
+            data = br.ReadBytes(length);
         }
 
         /// <summary>
@@ -32,7 +31,7 @@ namespace NAudio.Midi
         public TextEvent(string text, MetaEventType metaEventType, long absoluteTime)
             : base(metaEventType, text.Length, absoluteTime)
         {
-            this.text = text;
+            Text = text;
         }
 
         /// <summary>
@@ -47,12 +46,30 @@ namespace NAudio.Midi
         {
             get 
             { 
-                return text; 
+                Encoding byteEncoding = NAudio.Utils.ByteEncoding.Instance;
+                return byteEncoding.GetString(data); 
             }
             set
             {
-                text = value;
-                metaDataLength = text.Length;
+                Encoding byteEncoding = NAudio.Utils.ByteEncoding.Instance;
+                data = byteEncoding.GetBytes(value);
+                metaDataLength = data.Length;
+            }
+        }
+        
+        /// <summary>
+        /// The raw contents of this text event
+        /// </summary>
+        public byte[] Data
+        {
+            get
+            {
+                return data;
+            }
+            set
+            {
+                data = value;
+                metaDataLength = data.Length;
             }
         }
 
@@ -62,7 +79,7 @@ namespace NAudio.Midi
         /// <returns>A string describing this event</returns>
         public override string ToString() 
         {
-            return String.Format("{0} {1}",base.ToString(),text);
+            return String.Format("{0} {1}",base.ToString(),Text);
         }
 
         /// <summary>
@@ -73,9 +90,7 @@ namespace NAudio.Midi
         public override void Export(ref long absoluteTime, BinaryWriter writer)
         {
             base.Export(ref absoluteTime, writer);
-            Encoding byteEncoding = NAudio.Utils.ByteEncoding.Instance;
-            byte[] encoded = byteEncoding.GetBytes(text);
-            writer.Write(encoded);
+            writer.Write(data);
         }
     }
 }

--- a/NAudio/Properties/AssemblyInfo.cs
+++ b/NAudio/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.8.3.0")]
-[assembly: AssemblyFileVersion("1.8.3.0")]
+[assembly: AssemblyVersion("1.8.5.0")]
+[assembly: AssemblyFileVersion("1.8.5.0")]

--- a/NAudio/Properties/AssemblyInfo.cs
+++ b/NAudio/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.8.1.0")]
-[assembly: AssemblyFileVersion("1.8.1.0")]
+[assembly: AssemblyVersion("1.8.3.0")]
+[assembly: AssemblyFileVersion("1.8.3.0")]

--- a/NAudio/Utils/ChunkIdentifier.cs
+++ b/NAudio/Utils/ChunkIdentifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -20,6 +21,20 @@ namespace NAudio.Utils
             var bytes = Encoding.UTF8.GetBytes(s);
             if (bytes.Length != 4) throw new ArgumentException("Must encode to exactly four bytes");
             return BitConverter.ToInt32(bytes, 0);
+        }
+
+        private static readonly string[] KnownWAVChunkIds = new string[] { "fmt ", "data", "fact", "cue ", "plst", "list", "labl", "ltxt", "note", "smpl", "inst" };
+
+        /// <summary>
+        /// List of all standard chunk identifiers
+        /// </summary>
+        /// <returns>IEnumerable:int of known chunk identifiers</returns>
+        public static IEnumerable<int> KnownChunkIdentifiers()
+        {
+            foreach (var sId in KnownWAVChunkIds)
+            {
+                yield return ChunkIdentifierToInt32(sId);
+            }
         }
     }
 }

--- a/NAudio/Wave/WaveOutputs/AsioOut.cs
+++ b/NAudio/Wave/WaveOutputs/AsioOut.cs
@@ -74,7 +74,7 @@ namespace NAudio.Wave
             {
                 throw new ArgumentException(String.Format("Invalid device number. Must be in the range [0,{0}]", names.Length));
             }
-            InitFromName(this.driverName);
+            InitFromName(names[driverIndex]);
         }
 
         /// <summary>

--- a/NAudio/Wave/WaveStreams/AudioFileReader.cs
+++ b/NAudio/Wave/WaveStreams/AudioFileReader.cs
@@ -57,7 +57,7 @@ namespace NAudio.Wave
             {
                 readerStream = new Mp3FileReader(fileName);
             }
-            else if (fileName.EndsWith(".aiff"))
+            else if (fileName.EndsWith(".aiff", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".aif", StringComparison.OrdinalIgnoreCase))
             {
                 readerStream = new AiffFileReader(fileName);
             }

--- a/NAudio/Wave/WaveStreams/MediaFoundationReader.cs
+++ b/NAudio/Wave/WaveStreams/MediaFoundationReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -101,6 +101,10 @@ namespace NAudio.Wave
             {
                 pReader = reader;
             }
+            else
+            {
+                Marshal.ReleaseComObject(reader);
+            }
         }
 
         private WaveFormat GetCurrentWaveFormat(IMFSourceReader reader)
@@ -149,13 +153,28 @@ namespace NAudio.Wave
             partialMediaType.SubType = settings.RequestFloatOutput ? AudioSubtypes.MFAudioFormat_Float : AudioSubtypes.MFAudioFormat_PCM;
 
             var currentMediaType = GetCurrentMediaType(reader);
+
             // mono, low sample rate files can go wrong on Windows 10 unless we specify here
             partialMediaType.ChannelCount = currentMediaType.ChannelCount;
             partialMediaType.SampleRate = currentMediaType.SampleRate;
 
-            // set the media type
-            // can return MF_E_INVALIDMEDIATYPE if not supported
-            reader.SetCurrentMediaType(MediaFoundationInterop.MF_SOURCE_READER_FIRST_AUDIO_STREAM, IntPtr.Zero, partialMediaType.MediaFoundationObject);
+            try
+            {
+                // set the media type
+                // can return MF_E_INVALIDMEDIATYPE if not supported
+                reader.SetCurrentMediaType(MediaFoundationInterop.MF_SOURCE_READER_FIRST_AUDIO_STREAM, IntPtr.Zero, partialMediaType.MediaFoundationObject);
+            }
+            catch (COMException ex) when (ex.GetHResult() == MediaFoundationErrors.MF_E_INVALIDMEDIATYPE)
+            {               
+                // HE-AAC (and v2) seems to halve the samplerate
+                if (currentMediaType.SubType == AudioSubtypes.MFAudioFormat_AAC && currentMediaType.ChannelCount == 1)
+                {
+                    partialMediaType.SampleRate = currentMediaType.SampleRate *= 2;
+                    partialMediaType.ChannelCount = currentMediaType.ChannelCount *= 2;
+                    reader.SetCurrentMediaType(MediaFoundationInterop.MF_SOURCE_READER_FIRST_AUDIO_STREAM, IntPtr.Zero, partialMediaType.MediaFoundationObject);
+                }
+                else { throw; }
+            }
 
             Marshal.ReleaseComObject(currentMediaType.MediaFoundationObject);
             return reader;

--- a/NAudioTests/WaveStreams/MultiplexingWaveProviderTests.cs
+++ b/NAudioTests/WaveStreams/MultiplexingWaveProviderTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework;
 using NAudio.Wave;
 using System.Diagnostics;
@@ -27,7 +25,7 @@ namespace NAudioTests.WaveStreams
         public void ZeroOutputsShouldThrowException()
         {
             var input1 = new Mock<IWaveProvider>();
-            Assert.Throws<ArgumentException>(() => new MultiplexingWaveProvider(new IWaveProvider[] { input1.Object }, 0));
+            Assert.Throws<ArgumentException>(() => new MultiplexingWaveProvider(new[] { input1.Object }, 0));
         }
 
         [Test]
@@ -35,7 +33,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new Mock<IWaveProvider>();
             input1.Setup(x => x.WaveFormat).Returns(new Gsm610WaveFormat());
-            Assert.Throws<ArgumentException>(() => new MultiplexingWaveProvider(new IWaveProvider[] { input1.Object }, 1));
+            Assert.Throws<ArgumentException>(() => new MultiplexingWaveProvider(new[] { input1.Object }, 1));
         }
 
         [Test]
@@ -44,7 +42,7 @@ namespace NAudioTests.WaveStreams
             var input1 = new Mock<IWaveProvider>();
             var inputWaveFormat = new WaveFormat(32000, 16, 1);
             input1.Setup(x => x.WaveFormat).Returns(inputWaveFormat);
-            var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1.Object }, 1);
+            var mp = new MultiplexingWaveProvider(new[] { input1.Object }, 1);
             Assert.AreEqual(inputWaveFormat, mp.WaveFormat);
         }
 
@@ -54,7 +52,7 @@ namespace NAudioTests.WaveStreams
             var input1 = new Mock<IWaveProvider>();
             var inputWaveFormat = new WaveFormat(32000, 16, 1);
             input1.Setup(x => x.WaveFormat).Returns(inputWaveFormat);
-            var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1.Object }, 2);
+            var mp = new MultiplexingWaveProvider(new[] { input1.Object }, 2);
             var expectedOutputWaveFormat = new WaveFormat(32000, 16, 2);
             Assert.AreEqual(expectedOutputWaveFormat, mp.WaveFormat);
         }
@@ -63,7 +61,7 @@ namespace NAudioTests.WaveStreams
         public void OneInOneOutShouldCopyInReadMethod()
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 1));
-            byte[] expected = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            byte[] expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 1);
             byte[] buffer = new byte[10];
             var read = mp.Read(buffer, 0, 10);
@@ -77,7 +75,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 1));
             // 16 bit so left right pairs
-            byte[] expected = new byte[] { 0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9, 8, 9 };
+            byte[] expected = { 0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9, 8, 9 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 2);
             byte[] buffer = new byte[20];
             var read = mp.Read(buffer, 0, 20);
@@ -90,7 +88,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 2));
             // 16 bit so left right pairs
-            byte[] expected = new byte[] { 0, 1, 4, 5, 8, 9, 12, 13, 16, 17 };
+            byte[] expected = { 0, 1, 4, 5, 8, 9, 12, 13, 16, 17 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 1);
             byte[] buffer = new byte[10];
             var read = mp.Read(buffer, 0, 10);
@@ -103,7 +101,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 2));
             // 16 bit so left right pairs
-            byte[] expected = new byte[] { 2, 3, 6, 7, 10, 11, 14, 15, 18, 19 };
+            byte[] expected = { 2, 3, 6, 7, 10, 11, 14, 15, 18, 19 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 1);
             mp.ConnectInputToOutput(1, 0);
             byte[] buffer = new byte[10];
@@ -117,7 +115,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 2));
             // 4 bytes per pair of samples
-            byte[] expected = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+            byte[] expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 2);
             byte[] buffer = new byte[12];
             var read = mp.Read(buffer, 0, 12);
@@ -131,7 +129,7 @@ namespace NAudioTests.WaveStreams
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 1));
             var input2 = new TestWaveProvider(new WaveFormat(32000, 16, 1)) { Position = 100 };
             // 4 bytes per pair of samples
-            byte[] expected = new byte[] { 0, 1, 100, 101, 2, 3, 102, 103, 4, 5, 104, 105, };
+            byte[] expected = { 0, 1, 100, 101, 2, 3, 102, 103, 4, 5, 104, 105, };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1, input2 }, 2);
             byte[] buffer = new byte[expected.Length];
             var read = mp.Read(buffer, 0, expected.Length);
@@ -144,7 +142,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 2));
             // 4 bytes per pair of samples
-            byte[] expected = new byte[] { 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, };
+            byte[] expected = { 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 2);
             mp.ConnectInputToOutput(0, 1);
             mp.ConnectInputToOutput(1, 0);
@@ -215,7 +213,7 @@ namespace NAudioTests.WaveStreams
         public void ReadReturnsZeroIfSingleInputHasReachedEnd()
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 1), 0);
-            byte[] expected = new byte[] { };
+            byte[] expected = { };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 1);
             byte[] buffer = new byte[10];
             var read = mp.Read(buffer, 0, 10);
@@ -227,7 +225,7 @@ namespace NAudioTests.WaveStreams
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 1), 0);
             var input2 = new TestWaveProvider(new WaveFormat(32000, 16, 1));
-            byte[] expected = new byte[] { };
+            byte[] expected = { };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1, input2 }, 1);
             byte[] buffer = new byte[10];
             var read = mp.Read(buffer, 0, 10);
@@ -235,10 +233,25 @@ namespace NAudioTests.WaveStreams
         }
 
         [Test]
+        public void SingleInputConstructorUsesTotalOfInputChannels()
+        {
+            var input1 = new TestWaveProvider(new WaveFormat(32000, 8, 2));
+            var input2 = new TestWaveProvider(new WaveFormat(32000, 8, 1));
+            byte[] expected = { 0,1,0,2,3,1,4,5,2};
+            var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1, input2 });
+            Assert.AreEqual(3, mp.WaveFormat.Channels);
+            byte[] buffer = new byte[9];
+            var read = mp.Read(buffer, 0, 9);
+            Assert.AreEqual(9, read);
+            Assert.AreEqual(buffer,expected);
+        }
+
+
+        [Test]
         public void ShouldZeroOutBufferIfInputStopsShort()
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 16, 1), 6);
-            byte[] expected = new byte[] { 0, 1, 2, 3, 4, 5, 0, 0, 0, 0 };
+            byte[] expected = { 0, 1, 2, 3, 4, 5, 0, 0, 0, 0 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 1);
             byte[] buffer = new byte[10];
             for (int n = 0; n < buffer.Length; n++)
@@ -254,7 +267,7 @@ namespace NAudioTests.WaveStreams
         public void CorrectlyHandles24BitAudio()
         {
             var input1 = new TestWaveProvider(new WaveFormat(32000, 24, 1));
-            byte[] expected = new byte[] { 0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5, 6, 7, 8, 6, 7, 8, 9, 10, 11, 9, 10, 11 };
+            byte[] expected = { 0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5, 6, 7, 8, 6, 7, 8, 9, 10, 11, 9, 10, 11 };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 2);
             byte[] buffer = new byte[expected.Length];
             var read = mp.Read(buffer, 0, expected.Length);
@@ -266,7 +279,7 @@ namespace NAudioTests.WaveStreams
         public void CorrectlyHandlesIeeeFloat()
         {
             var input1 = new TestWaveProvider(WaveFormat.CreateIeeeFloatWaveFormat(32000, 1));
-            byte[] expected = new byte[] { 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 9, 10, 11, 8, 9, 10, 11, };
+            byte[] expected = { 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 9, 10, 11, 8, 9, 10, 11, };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 2);
             byte[] buffer = new byte[expected.Length];
             var read = mp.Read(buffer, 0, expected.Length);
@@ -279,7 +292,7 @@ namespace NAudioTests.WaveStreams
         public void CorrectOutputFormatIsSetForIeeeFloat()
         {
             var input1 = new TestWaveProvider(WaveFormat.CreateIeeeFloatWaveFormat(32000, 1));
-            byte[] expected = new byte[] { 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 9, 10, 11, 8, 9, 10, 11, };
+            byte[] expected = { 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 9, 10, 11, 8, 9, 10, 11, };
             var mp = new MultiplexingWaveProvider(new IWaveProvider[] { input1 }, 2);
             Assert.AreEqual(WaveFormatEncoding.IeeeFloat, mp.WaveFormat.Encoding);
         }

--- a/build.fsx
+++ b/build.fsx
@@ -59,7 +59,7 @@ Target "NuGet" (fun _ ->
             Summary = projectSummary
             WorkingDir = packagingDir
             AccessKey = myAccesskey*)
-            Version = "1.8.1" // todo get the version number from elsewhere
+            Version = "1.8.3" // todo get the version number from elsewhere
             WorkingDir = "."
             OutputPath = deployDir
             


### PR DESCRIPTION
… near expected identifier position.

I ran into a problem where a large number of WAV files were created by a professional editor, which appended an "inst" chunk with a length of 7 bytes but the following "data" chunk was 8 bytes away.
WaveFileChunkReader threw a FormatException because it was unable to locate the data chunk.
It seems that this type of thing can happen.
https://sites.google.com/site/musicgapi/technical-documents/wav-file-format#formatvariations

This fix just seeks locally to see if there is a one byte variance in chunk length.

I doubt this problem affects many people otherwise it'd have been handled already.