### PR TITLE
MMDevice property manipulation functionality for NAudio

### DIFF
--- a/NAudio/CoreAudioApi/Interfaces/Blob.cs
+++ b/NAudio/CoreAudioApi/Interfaces/Blob.cs
@@ -27,9 +27,18 @@ using System.Runtime.InteropServices;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {
+    /// <summary>
+    /// Representation of binary large object container.
+    /// </summary>
     public struct Blob
     {
+        /// <summary>
+        /// Length of binary object.
+        /// </summary>
         public int Length;
+        /// <summary>
+        /// Pointer to buffer storing data.
+        /// </summary>
         public IntPtr Data;
 
         //Code Should Compile at warning level4 without any warnings, 

--- a/NAudio/CoreAudioApi/Interfaces/Blob.cs
+++ b/NAudio/CoreAudioApi/Interfaces/Blob.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {
-    internal struct Blob
+    public struct Blob
     {
         public int Length;
         public IntPtr Data;

--- a/NAudio/CoreAudioApi/Interfaces/StorageAccessMode.cs
+++ b/NAudio/CoreAudioApi/Interfaces/StorageAccessMode.cs
@@ -7,7 +7,7 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// <summary>
     /// MMDevice STGM enumeration
     /// </summary>
-    enum StorageAccessMode
+    public enum StorageAccessMode
     {
         Read,
         Write,

--- a/NAudio/CoreAudioApi/Interfaces/StorageAccessMode.cs
+++ b/NAudio/CoreAudioApi/Interfaces/StorageAccessMode.cs
@@ -9,8 +9,17 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// </summary>
     public enum StorageAccessMode
     {
+        /// <summary>
+        /// Read-only access mode.
+        /// </summary>
         Read,
+        /// <summary>
+        /// Write-only access mode.
+        /// </summary>
         Write,
+        /// <summary>
+        /// Read-write access mode.
+        /// </summary>
         ReadWrite
     }
 }

--- a/NAudio/CoreAudioApi/MMDevice.cs
+++ b/NAudio/CoreAudioApi/MMDevice.cs
@@ -49,6 +49,11 @@ namespace NAudio.CoreAudioApi
         #endregion
 
         #region Init
+        /// <summary>
+        /// Initializes the device's property store.
+        /// </summary>
+        /// <param name="stgmAccess">The storage-access mode to open store for.</param>
+        /// <remarks>Administrative client is required for Write and ReadWrite modes.</remarks>
         public void GetPropertyInformation(StorageAccessMode stgmAccess = StorageAccessMode.Read)
         {
             IPropertyStore propstore;

--- a/NAudio/CoreAudioApi/MMDevice.cs
+++ b/NAudio/CoreAudioApi/MMDevice.cs
@@ -49,10 +49,10 @@ namespace NAudio.CoreAudioApi
         #endregion
 
         #region Init
-        private void GetPropertyInformation()
+        public void GetPropertyInformation(StorageAccessMode stgmAccess = StorageAccessMode.Read)
         {
             IPropertyStore propstore;
-            Marshal.ThrowExceptionForHR(deviceInterface.OpenPropertyStore(StorageAccessMode.Read, out propstore));
+            Marshal.ThrowExceptionForHR(deviceInterface.OpenPropertyStore(stgmAccess, out propstore));
             propertyStore = new PropertyStore(propstore);
         }
 

--- a/NAudio/CoreAudioApi/PropVariant.cs
+++ b/NAudio/CoreAudioApi/PropVariant.cs
@@ -35,35 +35,35 @@ namespace NAudio.CoreAudioApi.Interfaces
     [StructLayout(LayoutKind.Explicit)]
     public struct PropVariant
     {
-        [FieldOffset(0)] private short vt;
-        [FieldOffset(2)] private short wReserved1;
-        [FieldOffset(4)] private short wReserved2;
-        [FieldOffset(6)] private short wReserved3;
-        [FieldOffset(8)] private sbyte cVal;
-        [FieldOffset(8)] private byte bVal;
-        [FieldOffset(8)] private short iVal;
-        [FieldOffset(8)] private ushort uiVal;
-        [FieldOffset(8)] private int lVal;
-        [FieldOffset(8)] private uint ulVal;
-        [FieldOffset(8)] private int intVal;
-        [FieldOffset(8)] private uint uintVal;
-        [FieldOffset(8)] private long hVal;
-        [FieldOffset(8)] private long uhVal;
-        [FieldOffset(8)] private float fltVal;
-        [FieldOffset(8)] private double dblVal;
+        [FieldOffset(0)] public short vt;
+        [FieldOffset(2)] public short wReserved1;
+        [FieldOffset(4)] public short wReserved2;
+        [FieldOffset(6)] public short wReserved3;
+        [FieldOffset(8)] public sbyte cVal;
+        [FieldOffset(8)] public byte bVal;
+        [FieldOffset(8)] public short iVal;
+        [FieldOffset(8)] public ushort uiVal;
+        [FieldOffset(8)] public int lVal;
+        [FieldOffset(8)] public uint ulVal;
+        [FieldOffset(8)] public int intVal;
+        [FieldOffset(8)] public uint uintVal;
+        [FieldOffset(8)] public long hVal;
+        [FieldOffset(8)] public long uhVal;
+        [FieldOffset(8)] public float fltVal;
+        [FieldOffset(8)] public double dblVal;
         //VARIANT_BOOL boolVal;
-        [FieldOffset(8)] private short boolVal;
-        [FieldOffset(8)] private int scode;
+        [FieldOffset(8)] public short boolVal;
+        [FieldOffset(8)] public int scode;
         //CY cyVal;
         //[FieldOffset(8)] private DateTime date; - can cause issues with invalid value
-        [FieldOffset(8)] private System.Runtime.InteropServices.ComTypes.FILETIME filetime;
+        [FieldOffset(8)] public System.Runtime.InteropServices.ComTypes.FILETIME filetime;
         //CLSID* puuid;
         //CLIPDATA* pclipdata;
         //BSTR bstrVal;
         //BSTRBLOB bstrblobVal;
-        [FieldOffset(8)] private Blob blobVal;
+        [FieldOffset(8)] public Blob blobVal;
         //LPSTR pszVal;
-        [FieldOffset(8)] private IntPtr pointerValue; //LPWSTR 
+        [FieldOffset(8)] public IntPtr pointerValue; //LPWSTR 
         //IUnknown* punkVal;
         /*IDispatch* pdispVal;
         IStream* pStream;

--- a/NAudio/CoreAudioApi/PropVariant.cs
+++ b/NAudio/CoreAudioApi/PropVariant.cs
@@ -35,34 +35,97 @@ namespace NAudio.CoreAudioApi.Interfaces
     [StructLayout(LayoutKind.Explicit)]
     public struct PropVariant
     {
+        /// <summary>
+        /// Value type tag.
+        /// </summary>
         [FieldOffset(0)] public short vt;
+        /// <summary>
+        /// Reserved1.
+        /// </summary>
         [FieldOffset(2)] public short wReserved1;
+        /// <summary>
+        /// Reserved2.
+        /// </summary>
         [FieldOffset(4)] public short wReserved2;
+        /// <summary>
+        /// Reserved3.
+        /// </summary>
         [FieldOffset(6)] public short wReserved3;
+        /// <summary>
+        /// cVal.
+        /// </summary>
         [FieldOffset(8)] public sbyte cVal;
+        /// <summary>
+        /// bVal.
+        /// </summary>
         [FieldOffset(8)] public byte bVal;
+        /// <summary>
+        /// iVal.
+        /// </summary>
         [FieldOffset(8)] public short iVal;
+        /// <summary>
+        /// uiVal.
+        /// </summary>
         [FieldOffset(8)] public ushort uiVal;
+        /// <summary>
+        /// lVal.
+        /// </summary>
         [FieldOffset(8)] public int lVal;
+        /// <summary>
+        /// ulVal.
+        /// </summary>
         [FieldOffset(8)] public uint ulVal;
+        /// <summary>
+        /// intVal.
+        /// </summary>
         [FieldOffset(8)] public int intVal;
+        /// <summary>
+        /// uintVal.
+        /// </summary>
         [FieldOffset(8)] public uint uintVal;
+        /// <summary>
+        /// hVal.
+        /// </summary>
         [FieldOffset(8)] public long hVal;
+        /// <summary>
+        /// uhVal.
+        /// </summary>
         [FieldOffset(8)] public long uhVal;
+        /// <summary>
+        /// fltVal.
+        /// </summary>
         [FieldOffset(8)] public float fltVal;
+        /// <summary>
+        /// dblVal.
+        /// </summary>
         [FieldOffset(8)] public double dblVal;
         //VARIANT_BOOL boolVal;
+        /// <summary>
+        /// boolVal.
+        /// </summary>
         [FieldOffset(8)] public short boolVal;
+        /// <summary>
+        /// scode.
+        /// </summary>
         [FieldOffset(8)] public int scode;
         //CY cyVal;
         //[FieldOffset(8)] private DateTime date; - can cause issues with invalid value
+        /// <summary>
+        /// Date time.
+        /// </summary>
         [FieldOffset(8)] public System.Runtime.InteropServices.ComTypes.FILETIME filetime;
         //CLSID* puuid;
         //CLIPDATA* pclipdata;
         //BSTR bstrVal;
         //BSTRBLOB bstrblobVal;
+        /// <summary>
+        /// Binary large object.
+        /// </summary>
         [FieldOffset(8)] public Blob blobVal;
         //LPSTR pszVal;
+        /// <summary>
+        /// Pointer value.
+        /// </summary>
         [FieldOffset(8)] public IntPtr pointerValue; //LPWSTR 
         //IUnknown* punkVal;
         /*IDispatch* pdispVal;

--- a/NAudio/CoreAudioApi/PropertyKeys.cs
+++ b/NAudio/CoreAudioApi/PropertyKeys.cs
@@ -84,5 +84,17 @@ namespace NAudio.CoreAudioApi
         /// PKEY _Device_IconPath
         /// </summary>
         public static readonly PropertyKey PKEY_Device_IconPath = new PropertyKey(new Guid(unchecked((int)0x259abffc), unchecked((short)0x50a7), 0x47ce, 0xaf, 0x8, 0x68, 0xc9, 0xa7, 0xd7, 0x33, 0x66), 12);
+        /// <summary>
+        /// Device description property.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_DeviceDesc = new PropertyKey(new Guid(unchecked((int)0xa45c254e), unchecked((short)0xdf1c), 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0), 2);
+        /// <summary>
+        /// Id of controller device for endpoint device property.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_ControllerDeviceId = new PropertyKey(new Guid(unchecked((int)0xb3f8fa53), unchecked((short)0x0004), 0x438e, 0x90, 0x03, 0x51, 0xa4, 0x6e, 0x13, 0x9b, 0xfc), 2);
+        /// <summary>
+        /// Device interface key property.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_InterfaceKey = new PropertyKey(new Guid(unchecked((int)0x233164c8), unchecked((short)0x1b2c), 0x4c7d, 0xbc, 0x68, 0xb6, 0x71, 0x68, 0x7a, 0x25, 0x67), 1);
     }
 }

--- a/NAudio/CoreAudioApi/PropertyStore.cs
+++ b/NAudio/CoreAudioApi/PropertyStore.cs
@@ -132,7 +132,7 @@ namespace NAudio.CoreAudioApi
         /// Sets property value at specified key.
         /// </summary>
         /// <param name="key">Key of property to set.</param>
-        /// <param name="key">Value to write.</param>
+        /// <param name="value">Value to write.</param>
         public void SetValue(PropertyKey key, PropVariant value)
         {
             Marshal.ThrowExceptionForHR(storeInterface.SetValue(ref key, ref value));

--- a/NAudio/CoreAudioApi/PropertyStore.cs
+++ b/NAudio/CoreAudioApi/PropertyStore.cs
@@ -129,6 +129,24 @@ namespace NAudio.CoreAudioApi
         }
 
         /// <summary>
+        /// Sets property value at specified key.
+        /// </summary>
+        /// <param name="key">Key of property to set.</param>
+        /// <param name="key">Value to write.</param>
+        public void SetValue(PropertyKey key, PropVariant value)
+        {
+            Marshal.ThrowExceptionForHR(storeInterface.SetValue(ref key, ref value));
+        }
+
+        /// <summary>
+        /// Saves a property change.
+        /// </summary>
+        public void Commit()
+        {
+            Marshal.ThrowExceptionForHR(storeInterface.Commit());
+        }
+
+        /// <summary>
         /// Creates a new property store
         /// </summary>
         /// <param name="store">IPropertyStore COM interface</param>


### PR DESCRIPTION
Key changes:
- PropVariant fields now publicly alterable
- Updates PropertyKeys dictionary with new PropertyKey static fields
- MMDevice::GetPropertyInformation method now public and allows for access mode change
- Implemented SetValue and Commit methods for PropertyStore class.

Changes listed above are targeted to allow user to modify MMDevice properties dynamically e.g: endpoint's displayed name.

Example code:
```
PropertyKey propKey = PropertyKeys.PKEY_Device_DeviceDesc;
IntPtr pointer = Marshal.StringToHGlobalAuto("hello world");
PropVariant value = new PropVariant()
{
    vt = (short)VarEnum.VT_LPWSTR,
    pointerValue = pointer
};

// deviceId string, enumerator MMDeviceEnumerator
MMDevice device = enumerator.GetDevice(deviceId);

// by default, read-only flag is used which causes Access Denied exception to occur
device.GetPropertyInformation(StorageAccessMode.ReadWrite);

PropertyStore store = device.Properties;
store.SetValue(propKey, value);
store.Commit();
// free memory
Marshal.FreeHGlobal(pointer);
```