### PR TITLE
Prevent audio files from staying locked by MediaFoundationReader class

### DIFF
--- a/NAudio/Wave/WaveStreams/MediaFoundationReader.cs
+++ b/NAudio/Wave/WaveStreams/MediaFoundationReader.cs
@@ -101,6 +101,10 @@ namespace NAudio.Wave
             {
                 pReader = reader;
             }
+            else
+            {
+                Marshal.ReleaseComObject(reader);
+            }
         }
 
         private WaveFormat GetCurrentWaveFormat(IMFSourceReader reader)


### PR DESCRIPTION
Fixing an issue that causes audio files used by the MediaFoundationReader class to stay locked after the class instance is disposed, due to unreleased COM object.