### PR TITLE
Update SilenceWaveProvider.cs

### DIFF
--- a/NAudio/Wave/WaveProviders/SilenceWaveProvider.cs
+++ b/NAudio/Wave/WaveProviders/SilenceWaveProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 // ReSharper disable once CheckNamespace
@@ -21,11 +21,7 @@ namespace NAudio.Wave
         /// </summary>
         public int Read(byte[] buffer, int offset, int count)
         {
-            var end = offset + count;
-            for (var pos = offset; pos < end; pos++)
-            {
-                buffer[pos] = 0;
-            }
+            Array.Clear(buffer, offset, count);
             return count;
         }
 


### PR DESCRIPTION
Hi,

I am using the SilenceProvider to keep my mixer running and noticed it's using a for-loop to zero out the buffer. I replaced it with Array.Clear() as it is much faster (https://msdn.microsoft.com/en-us/library/system.array.clear%28v=vs.110%29.aspx). 
Might be of use to others as well?
