### PR TITLE
Fixed issue reading a MP3 file that does not have a ID3v2 tag.

### DIFF
--- a/NAudio/FileFormats/Mp3/Id3v2Tag.cs
+++ b/NAudio/FileFormats/Mp3/Id3v2Tag.cs
@@ -212,15 +212,16 @@ namespace NAudio.Wave
                     // footer present
                     byte[] footer = reader.ReadBytes(10);
                 }
+
+                tagEndPosition = input.Position;
+                input.Position = tagStartPosition;
+                rawData = reader.ReadBytes((int)(tagEndPosition - tagStartPosition));
             }
             else
             {
                 input.Position = tagStartPosition;
-                throw new FormatException("Not an ID3v2 tag");
+                ////throw new FormatException("Not an ID3v2 tag");
             }
-            tagEndPosition = input.Position;
-            input.Position = tagStartPosition;
-            rawData = reader.ReadBytes((int)(tagEndPosition - tagStartPosition));
 
         }
 


### PR DESCRIPTION
Hello,

I encountered an error when reading a MP3 file. The error was "Not an ID3v2 tag".

The MP3 files did not have a ID3v2 tag, just a ID3v1 tag. I removed the exception. The lib now reads the file without any problem.