### PR TITLE
WaveIn object no longer stops recording

### DIFF
--- a/NAudio/Wave/WaveInputs/WaveIn.cs
+++ b/NAudio/Wave/WaveInputs/WaveIn.cs
@@ -142,10 +142,9 @@ namespace NAudio.Wave
                     {
                         buffer.Reuse();
                     }
-                    catch (Exception e)
+                    catch (MmException)
                     {
-                        recording = false;
-                        RaiseRecordingStopped(e);
+                        // skip Resuse() if MmException
                     }
                 }
                 

--- a/NAudio/Wave/WaveOutputs/WaveOut.cs
+++ b/NAudio/Wave/WaveOutputs/WaveOut.cs
@@ -276,7 +276,10 @@ namespace NAudio.Wave
         /// </summary>
         public float Volume
         {
-            get => volume;
+            get
+            {
+                return volume;
+            }
             set 
             {
                 SetWaveOutVolume(value, hWaveOut, waveOutLock);


### PR DESCRIPTION
Fixed issue with WaveIn object setting recording to false on its own
when mutiple WaveIn objects are used, and after recording has been
stopped and then started again.

I don't know if this is the best way to do it, but it fixed the bug for my program, which uses multiple WaveIn objects for multiple streams. If I recreated the WaveIn objects (to allow for a clean change of input device for that object), and tried to restart recording, exactly every other time, the 'recording' property would be set to false, due to an MmException.