### PR TITLE
StereoToMonoSampleProvider.Read fills incorrect range

### DIFF
--- a/NAudio/Wave/SampleProviders/StereoToMonoSampleProvider.cs
+++ b/NAudio/Wave/SampleProviders/StereoToMonoSampleProvider.cs
@@ -50,7 +50,7 @@ namespace NAudio.Wave.SampleProviders
             if (sourceBuffer == null || sourceBuffer.Length < sourceSamplesRequired) sourceBuffer = new float[sourceSamplesRequired];
 
             var sourceSamplesRead = sourceProvider.Read(sourceBuffer, 0, sourceSamplesRequired);
-            var destOffset = offset / 2;
+            var destOffset = offset;
             for (var sourceSample = 0; sourceSample < sourceSamplesRead; sourceSample += 2)
             {
                 var left = sourceBuffer[sourceSample];

--- a/NAudioTests/WaveStreams/StereoToMonoSampleProviderTests.cs
+++ b/NAudioTests/WaveStreams/StereoToMonoSampleProviderTests.cs
@@ -31,5 +31,39 @@ namespace NAudioTests.WaveStreams
             Assert.AreEqual(1, mono.WaveFormat.Channels);
             Assert.AreEqual(44100, mono.WaveFormat.SampleRate);
         }
+
+        [Test]
+        public void CorrectOffset()
+        {
+            var stereoSampleProvider = new TestSampleProvider(44100, 2)
+            {
+                UseConstValue = true,
+                ConstValue = 1
+            };
+            var mono = stereoSampleProvider.ToMono();
+
+            var bufferLength = 30;
+            var offset = 10;
+            var samples = 10;
+
+            // [10,20) in buffer will be filled with 1
+            var buffer = new float[bufferLength];
+            var read = mono.Read(buffer, offset, samples);
+            Assert.AreEqual(samples, read, "samples read");
+
+            for (int i = 0; i < bufferLength; i++)
+            {
+                var sample = buffer[i];
+
+                if (i < offset || i >= offset + samples)
+                {
+                    Assert.AreEqual(0, sample, "not in Read range");
+                }
+                else
+                {
+                    Assert.AreNotEqual(0, sample, "in Read range");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
I found that `StereoToMonoSampleProvider.Read` would not work when I specify non-zero value to `offset` parameter. The method fills the range which starts from half of the `offset` I specified with samples.

I fixed it and wrote a test which tests whether the method fills the specified range and not fills the rest.