### PR TITLE
Fixed WaveOutEvent.Dispose() race condition

### DIFF
--- a/NAudio/Wave/WaveOutputs/WaveOutEvent.cs
+++ b/NAudio/Wave/WaveOutputs/WaveOutEvent.cs
@@ -18,6 +18,7 @@ namespace NAudio.Wave
         private IWaveProvider waveStream;
         private volatile PlaybackState playbackState;
         private AutoResetEvent callbackEvent;
+        private Thread playbackThread;
         private float volume = 1.0f;
 
         /// <summary>
@@ -117,7 +118,8 @@ namespace NAudio.Wave
             {
                 playbackState = PlaybackState.Playing;
                 callbackEvent.Set(); // give the thread a kick
-                ThreadPool.QueueUserWorkItem(state => PlaybackThread(), null);
+                playbackThread = new Thread(PlaybackThread);
+                playbackThread.Start();
             }
             else if (playbackState == PlaybackState.Paused)
             {
@@ -240,6 +242,8 @@ namespace NAudio.Wave
                     throw new MmException(result, "waveOutReset");
                 }
                 callbackEvent.Set(); // give the thread a kick, make sure we exit
+                playbackThread.Join();
+                playbackThread = null;
             }
         }
 


### PR DESCRIPTION
Added code to ensure the playback thread exits before `Stop()` returns to fix a race condition that occurs if `Dispose()` is called on a running player. Fixes issue #339.