### PR TITLE
It's a really very bad practice, that a Property Collection returns an exception if the value of a key is accessed…

### DIFF
--- a/NAudio/CoreAudioApi/PropVariant.cs
+++ b/NAudio/CoreAudioApi/PropVariant.cs
@@ -263,6 +263,8 @@ namespace NAudio.CoreAudioApi.Interfaces
                             default:
                                 throw new NotSupportedException("PropVariant VT_BOOL must be either -1 or 0");
                         }
+                    case VarEnum.VT_FILETIME:
+                        return DateTime.FromFileTime((((long)filetime.dwHighDateTime) << 32) + filetime.dwLowDateTime);
                 }
                 throw new NotImplementedException("PropVariant " + ve);
             }


### PR DESCRIPTION
So I fixed the issue, that accessing a VarEnum.VT_FILETIME Value in PropertyStoreProperty raises a NotImplementedException.

I have no Unit test, but it works perfectly.
