### PR TITLE
Fix two wasapi exclusive | event mode issue: IAudioClient Initialize …

### DIFF
--- a/NAudio/CoreAudioApi/Interfaces/ErrorCodes.cs
+++ b/NAudio/CoreAudioApi/Interfaces/ErrorCodes.cs
@@ -54,6 +54,7 @@ namespace NAudio.CoreAudioApi.Interfaces
         public static readonly int AUDCLNT_E_INCORRECT_BUFFER_SIZE  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x015);
         public static readonly int AUDCLNT_E_BUFFER_SIZE_ERROR  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x016);
         public static readonly int AUDCLNT_E_CPUUSAGE_EXCEEDED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x017);
+        public static readonly int AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x019);
         public static readonly int AUDCLNT_E_RESOURCES_INVALIDATED = unchecked((int) 0x88890026);
         /*static readonly int AUDCLNT_S_BUFFER_EMPTY              AUDCLNT_SUCCESS(0x001)
         static readonly int AUDCLNT_S_THREAD_ALREADY_REGISTERED AUDCLNT_SUCCESS(0x002)

--- a/NAudio/Wave/WaveOutputs/WasapiOut.cs
+++ b/NAudio/Wave/WaveOutputs/WasapiOut.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 using System.Threading;
 using System.Runtime.InteropServices;
 
@@ -197,13 +198,20 @@ namespace NAudio.Wave
             {
                 playbackState = PlaybackState.Stopped;
             }
-            Marshal.Copy(readBuffer,0,buffer,read);
-            int actualFrameCount = read / bytesPerFrame;
-            /*if (actualFrameCount != frameCount)
+            Marshal.Copy(readBuffer, 0, buffer, read);
+            if (this.isUsingEventSync && this.shareMode == AudioClientShareMode.Exclusive)
             {
-                Debug.WriteLine(String.Format("WASAPI wanted {0} frames, supplied {1}", frameCount, actualFrameCount ));
-            }*/
-            renderClient.ReleaseBuffer(actualFrameCount, AudioClientBufferFlags.None);
+                renderClient.ReleaseBuffer(frameCount, AudioClientBufferFlags.None);
+            }
+            else
+            {
+                int actualFrameCount = read / bytesPerFrame;
+                /*if (actualFrameCount != frameCount)
+                {
+                    Debug.WriteLine(String.Format("WASAPI wanted {0} frames, supplied {1}", frameCount, actualFrameCount ));
+                }*/
+                renderClient.ReleaseBuffer(actualFrameCount, AudioClientBufferFlags.None);
+            }
         }
 
         /// <summary>
@@ -376,9 +384,29 @@ namespace NAudio.Wave
                 }
                 else
                 {
-                    // With EventCallBack and Exclusive, both latencies must equals
-                    audioClient.Initialize(shareMode, AudioClientStreamFlags.EventCallback, latencyRefTimes, latencyRefTimes,
-                                        outputFormat, Guid.Empty);
+                    try
+                    {
+                        // With EventCallBack and Exclusive, both latencies must equals
+                        audioClient.Initialize(shareMode, AudioClientStreamFlags.EventCallback, latencyRefTimes, latencyRefTimes,
+                                            outputFormat, Guid.Empty);
+                    }
+                    catch (COMException ex)
+                    {
+                        // Starting with Windows 7, Initialize can return AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED for a render device.
+                        // We should to initialize again.
+                        if (ex.ErrorCode != ErrorCodes.AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED)
+                            throw ex;
+
+                        // Calculate the new latency.
+                        long newLatencyRefTimes = (long)(10000000.0 /
+                            (double)this.outputFormat.SampleRate *
+                            (double)this.audioClient.BufferSize + 0.5);
+
+                        this.audioClient.Dispose();
+                        this.audioClient = this.mmDevice.AudioClient;
+                        this.audioClient.Initialize(this.shareMode, AudioClientStreamFlags.EventCallback,
+                                            newLatencyRefTimes, newLatencyRefTimes, this.outputFormat, Guid.Empty);
+                    }
                 }
 
                 // Create the Wait Event Handle


### PR DESCRIPTION
Fix two wasapi exclusive | event mode issue:
1. IAudioClient Initialize returns AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED.
2. IAudioRenderClient ReleaseBuffer returns AUDCLNT_E_BUFFER_SIZE_ERROR.