### PR TITLE
Fix reading of Wave-Files with odd Chunk-Lengths

### DIFF
--- a/NAudio/FileFormats/Wav/WaveFileChunkReader.cs
+++ b/NAudio/FileFormats/Wav/WaveFileChunkReader.cs
@@ -94,6 +94,16 @@ namespace NAudio.FileFormats.Wav
                     }
                     stream.Position += chunkLength;
                 }
+
+                // All Chunks have to be word aligned.
+                // https://www.tactilemedia.com/info/MCI_Control_Info.html
+                // "If the chunk size is an odd number of bytes, a pad byte with value zero is
+                //  written after ckData. Word aligning improves access speed (for chunks resident in memory)
+                //  and maintains compatibility with EA IFF. The ckSize value does not include the pad byte."
+                if (((chunkLength % 2) != 0) && (br.PeekChar() == 0))
+                {
+                    stream.Position++;
+                }
             }
 
             if (waveFormat == null)


### PR DESCRIPTION
This fixes the problem of reading Wave-Files with odd chunk lengths.
The specification says that odd chunks have to be filled with a padding byte (value zero)
which is not included in the chunk length. So the next chunk is word aligned.
This also fixes the problem in pull request #220 but IMO in a way more aligned
with the wave spec.
To allow for malformed wave-files with no padding byte I check if the byte is zero before skipping it.