### PR TITLE
Added WaveIn.GetPosition and WaveInEvent.GetPosition calling through …

### DIFF
--- a/NAudio/Properties/AssemblyInfo.cs
+++ b/NAudio/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.8.4.0")]
-[assembly: AssemblyFileVersion("1.8.4.0")]
+[assembly: AssemblyVersion("1.8.5.0")]
+[assembly: AssemblyFileVersion("1.8.5.0")]

--- a/NAudio/Wave/MmeInterop/WaveInterop.cs
+++ b/NAudio/Wave/MmeInterop/WaveInterop.cs
@@ -91,13 +91,13 @@ namespace NAudio.Wave
         public static extern MmResult waveOutUnprepareHeader(IntPtr hWaveOut, WaveHeader lpWaveOutHdr, int uSize);
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutWrite(IntPtr hWaveOut, WaveHeader lpWaveOutHdr, int uSize);
-        
+
         // http://msdn.microsoft.com/en-us/library/dd743866%28VS.85%29.aspx
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutOpen(out IntPtr hWaveOut, IntPtr uDeviceID, WaveFormat lpFormat, WaveCallback dwCallback, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
         [DllImport("winmm.dll", EntryPoint = "waveOutOpen")]
         public static extern MmResult waveOutOpenWindow(out IntPtr hWaveOut, IntPtr uDeviceID, WaveFormat lpFormat, IntPtr callbackWindowHandle, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
-        
+
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutReset(IntPtr hWaveOut);
         [DllImport("winmm.dll")]
@@ -114,7 +114,7 @@ namespace NAudio.Wave
         // http://msdn.microsoft.com/en-us/library/dd743874%28VS.85%29.aspx
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutSetVolume(IntPtr hWaveOut, int dwVolume);
-        
+
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutGetVolume(IntPtr hWaveOut, out int dwVolume);
 
@@ -128,13 +128,13 @@ namespace NAudio.Wave
         // http://msdn.microsoft.com/en-us/library/dd743841%28VS.85%29.aspx
         [DllImport("winmm.dll", CharSet = CharSet.Auto)]
         public static extern MmResult waveInGetDevCaps(IntPtr deviceID, out WaveInCapabilities waveInCaps, int waveInCapsSize);
-        
+
         // http://msdn.microsoft.com/en-us/library/dd743838%28VS.85%29.aspx
         [DllImport("winmm.dll")]
         public static extern MmResult waveInAddBuffer(IntPtr hWaveIn, WaveHeader pwh, int cbwh);
         [DllImport("winmm.dll")]
         public static extern MmResult waveInClose(IntPtr hWaveIn);
-        
+
         // http://msdn.microsoft.com/en-us/library/dd743847%28VS.85%29.aspx
         [DllImport("winmm.dll")]
         public static extern MmResult waveInOpen(out IntPtr hWaveIn, IntPtr uDeviceID, WaveFormat lpFormat, WaveCallback dwCallback, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
@@ -144,7 +144,7 @@ namespace NAudio.Wave
         // http://msdn.microsoft.com/en-us/library/dd743848%28VS.85%29.aspx
         [DllImport("winmm.dll")]
         public static extern MmResult waveInPrepareHeader(IntPtr hWaveIn, WaveHeader lpWaveInHdr, int uSize);
-        
+
         [DllImport("winmm.dll")]
         public static extern MmResult waveInUnprepareHeader(IntPtr hWaveIn, WaveHeader lpWaveInHdr, int uSize);
 
@@ -159,6 +159,11 @@ namespace NAudio.Wave
         // http://msdn.microsoft.com/en-us/library/dd743852%28VS.85%29.aspx
         [DllImport("winmm.dll")]
         public static extern MmResult waveInStop(IntPtr hWaveIn);
+
+        // https://msdn.microsoft.com/en-us/library/Dd743845(v=VS.85).aspx
+        [DllImport("winmm.dll")]
+        public static extern MmResult waveInGetPosition(IntPtr hWaveIn, out MmTime mmTime, int uSize);
+
 
     }
 }

--- a/NAudio/Wave/WaveInputs/WaveIn.cs
+++ b/NAudio/Wave/WaveInputs/WaveIn.cs
@@ -135,7 +135,7 @@ namespace NAudio.Wave
                     var hBuffer = (GCHandle)waveHeader.userData;
                     var buffer = (WaveInBuffer)hBuffer.Target;
                     if (buffer == null) return;
-                
+
                     lastReturnedBufferIndex = Array.IndexOf(buffers, buffer);
                     RaiseDataAvailable(buffer);
                     try
@@ -148,7 +148,7 @@ namespace NAudio.Wave
                         RaiseRecordingStopped(e);
                     }
                 }
-                
+
             }
         }
 
@@ -219,7 +219,7 @@ namespace NAudio.Wave
                 // report the last buffers, sometimes more than one, so taking care to report them in the right order
                 for (int n = 0; n < buffers.Length; n++)
                 {
-                    int index = (n + lastReturnedBufferIndex + 1)%buffers.Length;
+                    int index = (n + lastReturnedBufferIndex + 1) % buffers.Length;
                     var buffer = buffers[index];
                     if (buffer.Done)
                     {
@@ -233,10 +233,27 @@ namespace NAudio.Wave
         }
 
         /// <summary>
+        /// Gets the current position in bytes from the wave input device.
+        /// it calls directly into waveInGetPosition)
+        /// </summary>
+        /// <returns>Position in bytes</returns>
+        public long GetPosition()
+        {
+            MmTime mmTime = new MmTime();
+            mmTime.wType = MmTime.TIME_BYTES; // request results in bytes, TODO: perhaps make this a little more flexible and support the other types?
+            MmException.Try(WaveInterop.waveInGetPosition(waveInHandle, out mmTime, Marshal.SizeOf(mmTime)), "waveInGetPosition");
+
+            if (mmTime.wType != MmTime.TIME_BYTES)
+                throw new Exception(string.Format("waveInGetPosition: wType -> Expected {0}, Received {1}", MmTime.TIME_BYTES, mmTime.wType));
+
+            return mmTime.cb;
+        }
+
+        /// <summary>
         /// WaveFormat we are recording in
         /// </summary>
         public WaveFormat WaveFormat { get; set; }
-        
+
         /// <summary>
         /// Dispose pattern
         /// </summary>

--- a/NAudio/Wave/WaveInputs/WaveInEvent.cs
+++ b/NAudio/Wave/WaveInputs/WaveInEvent.cs
@@ -96,7 +96,7 @@ namespace NAudio.Wave
         private void OpenWaveInDevice()
         {
             CloseWaveInDevice();
-            MmResult result = WaveInterop.waveInOpenWindow(out waveInHandle, (IntPtr)DeviceNumber, WaveFormat, 
+            MmResult result = WaveInterop.waveInOpenWindow(out waveInHandle, (IntPtr)DeviceNumber, WaveFormat,
                 callbackEvent.SafeWaitHandle.DangerousGetHandle(), IntPtr.Zero, WaveInterop.WaveInOutOpenFlags.CallbackEvent);
             MmException.Try(result, "waveInOpen");
             CreateBuffers();
@@ -108,7 +108,7 @@ namespace NAudio.Wave
         public void StartRecording()
         {
             if (captureState != CaptureState.Stopped)
-                throw new InvalidOperationException("Already recording"); 
+                throw new InvalidOperationException("Already recording");
             OpenWaveInDevice();
             MmException.Try(WaveInterop.waveInStart(waveInHandle), "waveInStart");
             captureState = CaptureState.Starting;
@@ -192,10 +192,27 @@ namespace NAudio.Wave
         }
 
         /// <summary>
+        /// Gets the current position in bytes from the wave input device.
+        /// it calls directly into waveInGetPosition)
+        /// </summary>
+        /// <returns>Position in bytes</returns>
+        public long GetPosition()
+        {
+            MmTime mmTime = new MmTime();
+            mmTime.wType = MmTime.TIME_BYTES; // request results in bytes, TODO: perhaps make this a little more flexible and support the other types?
+            MmException.Try(WaveInterop.waveInGetPosition(waveInHandle, out mmTime, Marshal.SizeOf(mmTime)), "waveInGetPosition");
+
+            if (mmTime.wType != MmTime.TIME_BYTES)
+                throw new Exception(string.Format("waveInGetPosition: wType -> Expected {0}, Received {1}", MmTime.TIME_BYTES, mmTime.wType));
+
+            return mmTime.cb;
+        }
+
+        /// <summary>
         /// WaveFormat we are recording in
         /// </summary>
         public WaveFormat WaveFormat { get; set; }
-        
+
         /// <summary>
         /// Dispose pattern
         /// </summary>
@@ -205,7 +222,7 @@ namespace NAudio.Wave
             {
                 if (captureState != CaptureState.Stopped)
                     StopRecording();
-                
+
                 CloseWaveInDevice();
             }
         }


### PR DESCRIPTION
This adds in a new GetPosition method to WaveIn and WaveInEvent that calls through to waveInGetPosition, as previously there was no way to retrieve the current number of bytes that have been recorded.

This uses the same pattern as the WaveOut.GetPosition method.