### PR TITLE
Added WaveInReset (required for MM to trigger callback). Moved callback Reset trigger

### DIFF
--- a/NAudio/Wave/WaveInputs/WaveInEvent.cs
+++ b/NAudio/Wave/WaveInputs/WaveInEvent.cs
@@ -186,8 +186,12 @@ namespace NAudio.Wave
             if (captureState != CaptureState.Stopped)
             {
                 captureState = CaptureState.Stopping;
-                callbackEvent.Set(); // signal the thread to exit
                 MmException.Try(WaveInterop.waveInStop(waveInHandle), "waveInStop");
+
+                //Reset, triggering the buffers to be returned
+                MmException.Try(WaveInterop.waveInReset(waveInHandle), "waveInReset");
+
+                callbackEvent.Set(); // signal the thread to exit
             }
         }
 


### PR DESCRIPTION
Changed WaveInEvent to call WaveInReset after WaveInStop to trigger buffers being returned via the callback as per https://msdn.microsoft.com/en-us/library/windows/desktop/dd743850(v=vs.85).aspx

Also moved callbackEvent.Set to below waveInStop+new waveInReset so those have completed BEFORE the callback look processes those buffers to check for any audio bytes recorded.