### PR TITLE
CueWaveFileReader constructor should call base(inputStream)

### DIFF
--- a/NAudio/Wave/WaveStreams/CueWaveFileReader.cs
+++ b/NAudio/Wave/WaveStreams/CueWaveFileReader.cs
@@ -25,7 +25,7 @@ namespace NAudio.Wave
         /// </summary>
         /// <param name="inputStream"></param>
         public CueWaveFileReader(Stream inputStream)
-            : this(inputStream)
+            : base(inputStream)
         {
         }
 


### PR DESCRIPTION
This is a fix for https://github.com/naudio/NAudio/pull/376