### PR TITLE
Fix ASIO convertor reducing negative values by 1

### DIFF
--- a/NAudio/Wave/Asio/ASIOSampleConvertor.cs
+++ b/NAudio/Wave/Asio/ASIOSampleConvertor.cs
@@ -448,19 +448,19 @@ namespace NAudio.Wave.Asio
         private static int clampTo24Bit(double sampleValue)
         {
             sampleValue = (sampleValue < -1.0) ? -1.0 : (sampleValue > 1.0) ? 1.0 : sampleValue;
-            return (int)(sampleValue * 8388607.0);
+            return (int)(sampleValue * (sampleValue < 0.0 ? 8388608.0 : 8388607.0));
         }
 
         private static int clampToInt(double sampleValue)
         {
             sampleValue = (sampleValue < -1.0) ? -1.0 : (sampleValue > 1.0) ? 1.0 : sampleValue;
-            return (int)(sampleValue * 2147483647.0);
+            return (int)(sampleValue * (sampleValue < 0.0 ? 2147483648.0 : 2147483647.0));
         }
 
         private static short clampToShort(double sampleValue)
         {
             sampleValue = (sampleValue < -1.0) ? -1.0 : (sampleValue > 1.0) ? 1.0 : sampleValue;
-            return (short)(sampleValue * 32767.0);
+            return (short)(sampleValue * (sampleValue < 0.0 ? 32768.0 : 32767.0));
         }
     }
 }


### PR DESCRIPTION
Negative integer limit is greater (in absolute value) then the positive limit by 1 bit. This ended up reducing negative signal values by 1.