### PR TITLE
Prevent deadlock in WasapiCapture

### DIFF
--- a/NAudioTests/Wasapi/AudioClientTests.cs
+++ b/NAudioTests/Wasapi/AudioClientTests.cs
@@ -187,7 +187,7 @@ namespace NAudioTests.Wasapi
             }
         }
  
-        [Test, MaxTime(3000)]
+        [Test]
         public void CanReuseWasapiCapture()
         {
             using (var wasapiClient = new WasapiCapture())


### PR DESCRIPTION
Used locking to make the WasapiCapture class prevent deadlock when it gets a call to stop recording before it has had a chance to start capturing.