### PR TITLE
recognise MP3 Xing headers with 'Info' magic

### DIFF
--- a/NAudio/FileFormats/Mp3/XingHeader.cs
+++ b/NAudio/FileFormats/Mp3/XingHeader.cs
@@ -91,6 +91,14 @@ namespace NAudio.Wave
                 xingHeader.startOffset = offset;
                 offset += 4;
             }
+            else if ((frame.RawData[offset + 0] == 'I') &&
+                     (frame.RawData[offset + 1] == 'n') &&
+                     (frame.RawData[offset + 2] == 'f') &&
+                     (frame.RawData[offset + 3] == 'o'))
+            {
+                xingHeader.startOffset = offset;
+                offset += 4;
+            }
             else
             {
                 return null;


### PR DESCRIPTION
The header is the same, but used for CBR files by some encoders. (ref: http://gabriel.mp3-tech.org/mp3infotag.html)

Even though it's not necessary for the library to function, having easy access to this frame is useful for getting things like LAME encode settings.