### PR TITLE
Add basic Core Audio API DeviceTopology/Connector support

### DIFF
--- a/NAudio/CoreAudioApi/Connector.cs
+++ b/NAudio/CoreAudioApi/Connector.cs
@@ -1,0 +1,105 @@
+﻿using NAudio.CoreAudioApi.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NAudio.CoreAudioApi
+{
+    public class Connector
+    {
+        private readonly IConnector connectorInterface;
+
+        internal Connector(IConnector connector)
+        {
+            connectorInterface = connector;
+        }
+
+        /// <summary>
+        /// Connects this connector to a connector in another device-topology object
+        /// </summary>
+        public void ConnectTo(Connector other)
+        {
+            connectorInterface.ConnectTo(other.connectorInterface);
+        }
+
+        /// <summary>
+        /// Retreives the type of this connector
+        /// </summary>
+        public ConnectorType Type
+        {
+            get
+            {
+                connectorInterface.GetType(out var result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Retreives the data flow of this connector
+        /// </summary>
+        public DataFlow DataFlow
+        {
+            get
+            {
+                connectorInterface.GetDataFlow(out var result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Disconnects this connector from it's connected connector (if connected)
+        /// </summary>
+        public void Disconnect()
+        {
+            connectorInterface.Disconnect();
+        }
+
+        /// <summary>
+        /// Indicates whether this connector is connected to another connector
+        /// </summary>
+        public bool IsConnected
+        {
+            get
+            {
+                connectorInterface.IsConnected(out var result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Retreives the connector this connector is connected to (if connected)
+        /// </summary>
+        public Connector ConnectedTo
+        {
+            get
+            {
+                connectorInterface.GetConnectedTo(out var result);
+                return new Connector(result);
+            }
+        }
+
+        /// <summary>
+        /// Retreives the global ID of the connector this connector is connected to (if connected)
+        /// </summary>
+        public string ConnectedToConnectorId
+        {
+            get
+            {
+                connectorInterface.GetConnectorIdConnectedTo(out var result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Retreives the device ID of the audio device this connector is connected to (if connected)
+        /// </summary>
+        public string ConnectedToDeviceId
+        {
+            get
+            {
+                connectorInterface.GetDeviceIdConnectedTo(out var result);
+                return result;
+            }
+        }
+    }
+}

--- a/NAudio/CoreAudioApi/ConnectorType.cs
+++ b/NAudio/CoreAudioApi/ConnectorType.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NAudio.CoreAudioApi
+{
+    public enum ConnectorType
+    {
+        /// <summary>
+        /// The connector is part of a connection of unknown type.
+        /// </summary>
+        UnknownConnector,
+        /// <summary>
+        /// The connector is part of a physical connection to an auxiliary device that is installed inside the system chassis
+        /// </summary>
+        PhysicalInternal,
+        /// <summary>
+        /// The connector is part of a physical connection to an external device.
+        /// </summary>
+        PhysicalExternal,
+        /// <summary>
+        /// The connector is part of a software-configured I/O connection (typically a DMA channel) between system memory and an audio hardware device on an audio adapter.
+        /// </summary>
+        SoftwareIo,
+        /// <summary>
+        /// The connector is part of a permanent connection that is fixed and cannot be configured under software control.
+        /// </summary>
+        SoftwareFixed,
+        /// <summary>
+        /// The connector is part of a connection to a network.
+        /// </summary>
+        Network,
+    }
+}

--- a/NAudio/CoreAudioApi/DeviceTopology.cs
+++ b/NAudio/CoreAudioApi/DeviceTopology.cs
@@ -1,0 +1,54 @@
+﻿using NAudio.CoreAudioApi.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NAudio.CoreAudioApi
+{
+    /// <summary>
+    /// Windows CoreAudio DeviceTopology
+    /// </summary>
+    public class DeviceTopology
+    {
+        private readonly IDeviceTopology deviceTopologyInterface;
+
+        internal DeviceTopology(IDeviceTopology deviceTopology)
+        {
+            deviceTopologyInterface = deviceTopology;
+        }
+
+        /// <summary>
+        /// Retrieves the number of connections associated with this device-topology object
+        /// </summary>
+        public uint ConnectorCount
+        {
+            get
+            {
+                deviceTopologyInterface.GetConnectorCount(out var count);
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the connector at the supplied index
+        /// </summary>
+        public Connector GetConnector(uint index)
+        {
+            deviceTopologyInterface.GetConnector(index, out var connectorInterface);
+            return new Connector(connectorInterface);
+        }
+
+        /// <summary>
+        /// Retrieves the device id of the device represented by this device-topology object
+        /// </summary>
+        public string DeviceId
+        {
+            get
+            {
+                deviceTopologyInterface.GetDeviceId(out var result);
+                return result;
+            }
+        }
+
+    }
+}

--- a/NAudio/CoreAudioApi/Interfaces/IConnector.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IConnector.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi.Interfaces
+{
+    /// <summary>
+    /// Windows CoreAudio IConnector interface
+    /// Defined in devicetopology.h
+    /// </summary>
+    [Guid("9C2C4058-23F5-41DE-877A-DF3AF236A09E"),
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
+    internal interface IConnector
+    {
+        int GetType(out ConnectorType type);
+        int GetDataFlow(out DataFlow flow);
+        int ConnectTo([In] IConnector connectTo);
+        int Disconnect();
+        int IsConnected(out bool connected);
+        int GetConnectedTo(out IConnector conTo);
+        int GetConnectorIdConnectedTo([MarshalAs(UnmanagedType.LPWStr)] out string id);
+        int GetDeviceIdConnectedTo([MarshalAs(UnmanagedType.LPWStr)] out string id);
+    }
+}

--- a/NAudio/CoreAudioApi/Interfaces/IDeviceTopology.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IDeviceTopology.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi.Interfaces
+{
+    /// <summary>
+    /// Windows CoreAudio IDeviceTopology interface
+    /// Defined in devicetopology.h
+    /// </summary>
+    [Guid("2A07407E-6497-4A18-9787-32F79BD0D98F"),
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
+    internal interface IDeviceTopology
+    {
+        int GetConnectorCount(out uint count);
+        int GetConnector(uint index, out IConnector connector);
+        int GetSubunitCount(out uint count);
+        int GetSubunit(uint index, out ISubunit subunit);
+        int GetPartById(uint id, out IPart part);
+        int GetDeviceId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+        int GetSignalPath(IPart from, IPart to, bool rejectMixedPaths, out IPartsList parts);
+    }
+}

--- a/NAudio/CoreAudioApi/Interfaces/IPart.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IPart.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi.Interfaces
+{
+    /// <summary>
+    /// Windows CoreAudio IPart interface
+    /// Defined in devicetopology.h
+    /// </summary>
+    [Guid("AE2DE0E4-5BCA-4F2D-AA46-5D13F8FDB3A9"),
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
+    internal interface IPart
+    {
+        // Stub, Not implemented
+    }
+}

--- a/NAudio/CoreAudioApi/Interfaces/IPartsList.cs
+++ b/NAudio/CoreAudioApi/Interfaces/IPartsList.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi.Interfaces
+{
+    /// <summary>
+    /// Windows CoreAudio IPartsList interface
+    /// Defined in devicetopology.h
+    /// </summary>
+    [Guid("6DAA848C-5EB0-45CC-AEA5-998A2CDA1FFB"),
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+    ComImport]
+    internal interface IPartsList
+    {
+        int GetCount(out uint count);
+        int GetPart(uint index, out IPart part);
+    }
+}

--- a/NAudio/CoreAudioApi/Interfaces/ISubunit.cs
+++ b/NAudio/CoreAudioApi/Interfaces/ISubunit.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace NAudio.CoreAudioApi.Interfaces
+{
+    [Guid("82149A85-DBA6-4487-86BB-EA8F7FEFCC71"),
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
+    internal interface ISubunit
+    {
+        // Stub, Not Implemented
+    }
+}

--- a/NAudio/CoreAudioApi/MMDevice.cs
+++ b/NAudio/CoreAudioApi/MMDevice.cs
@@ -39,6 +39,7 @@ namespace NAudio.CoreAudioApi
         private AudioMeterInformation audioMeterInformation;
         private AudioEndpointVolume audioEndpointVolume;
         private AudioSessionManager audioSessionManager;
+        private DeviceTopology deviceTopology;
         #endregion
 
         #region Guids
@@ -47,6 +48,7 @@ namespace NAudio.CoreAudioApi
         private static Guid IID_IAudioEndpointVolume = new Guid("5CDF2C82-841E-4546-9722-0CF74078229A");
         private static Guid IID_IAudioClient = new Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2");
         private static Guid IDD_IAudioSessionManager = new Guid("BFA971F1-4D5E-40BB-935E-967039BFBEE4");
+        private static Guid IDD_IDeviceTopology = new Guid("2A07407E-6497-4A18-9787-32F79BD0D98F");
         // ReSharper restore InconsistentNaming
         #endregion
 
@@ -85,6 +87,13 @@ namespace NAudio.CoreAudioApi
             Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IDD_IAudioSessionManager, ClsCtx.ALL, IntPtr.Zero, out var result));
             audioSessionManager = new AudioSessionManager(result as IAudioSessionManager);
         }
+
+        private void GetDeviceTopology()
+        {
+            Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IDD_IDeviceTopology, ClsCtx.ALL, IntPtr.Zero, out var result));
+            deviceTopology = new DeviceTopology(result as IDeviceTopology);
+        }
+
         #endregion
 
         #region Properties
@@ -136,6 +145,21 @@ namespace NAudio.CoreAudioApi
                     GetAudioSessionManager();
                 }
                 return audioSessionManager;
+            }
+        }
+
+        /// <summary>
+        /// DeviceTopology instance
+        /// </summary>
+        public DeviceTopology DeviceTopology
+        {
+            get
+            {
+                if (deviceTopology == null)
+                {
+                    GetDeviceTopology();
+                }
+                return deviceTopology;
             }
         }
 
@@ -208,6 +232,26 @@ namespace NAudio.CoreAudioApi
                 if (propertyStore.Contains(PropertyKeys.PKEY_Device_IconPath))
                 {
                     return (string)propertyStore[PropertyKeys.PKEY_Device_IconPath].Value;
+                }
+
+                return "Unknown";
+            }
+        }
+
+        /// <summary>
+        /// Device Instance Id of Device
+        /// </summary>
+        public string InstanceId
+        {
+            get
+            {
+                if (propertyStore == null)
+                {
+                    GetPropertyInformation();
+                }
+                if (propertyStore.Contains(PropertyKeys.PKEY_Device_InstanceId))
+                {
+                    return (string)propertyStore[PropertyKeys.PKEY_Device_InstanceId].Value;
                 }
 
                 return "Unknown";

--- a/NAudio/CoreAudioApi/PropertyKeys.cs
+++ b/NAudio/CoreAudioApi/PropertyKeys.cs
@@ -97,5 +97,9 @@ namespace NAudio.CoreAudioApi
         /// Device interface key property.
         /// </summary>
         public static readonly PropertyKey PKEY_Device_InterfaceKey = new PropertyKey(new Guid(unchecked((int)0x233164c8), unchecked((short)0x1b2c), 0x4c7d, 0xbc, 0x68, 0xb6, 0x71, 0x68, 0x7a, 0x25, 0x67), 1);
+        /// <summary>
+        /// System-supplied device instance identification string, assigned by PnP manager, persistent across system restarts.
+        /// </summary>
+        public static readonly PropertyKey PKEY_Device_InstanceId = new PropertyKey(new Guid(0x78c34fc8, 0x104a, 0x4aca, 0x9e, 0xa4, 0x52, 0x4d, 0x52, 0x99, 0x6e, 0x57), 256);
     }
 }


### PR DESCRIPTION
With the current capabilities of the Core Audio API, Audio Endpoints cannot be selected based on their device instance id (e.g. USB\VID_0000&PID_0000&MI_00\7&17351104&0&0000 or PCI\VEN_1000&DEV_0001&SUBSYS_00000000&REV_02\1&08). For my needs, I need to select a USB endpoint based on it's Vendor ID & Product Id.

The endpoints which are provided by IMMDeviceEnumerator do have a property (b3f8fa53-0004-438e-9003-51a46e139bfc, 2) which provides the device instance id, but this property is not documented and unsupported.

In order to do it properly, you need to create an IDeviceTopology object from the IMMDevice object, Call IDeviceTopology::GetConnector(n) to get it's associated connector, call IConnector::GetDeviceIdConnectedTo to get the device id of the connector that connector is connected to, use IMMDeviceEnumerator to get the IMMDevice with that device id and then read the "PKEY_Device_InstanceID" property to get the instance ID.

Definitely not the most friendly API.

See: https://matthewvaneerde.wordpress.com/2008/06/13/sample-find-out-if-your-default-audio-playback-and-audio-capture-devices-are-on-the-same-hardware/

Example:

            var deviceEnumerator = new MMDeviceEnumerator();
            var audioEndpoint = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
            var topology = audioEndpoint.DeviceTopology;

            string instanceId = null;
            if (topology.ConnectorCount > 0)
            {
                var topologyConnector = topology.GetConnector(0);
                if (topologyConnector.IsConnected)
                {
                    var devNodeId = topologyConnector.ConnectedToDeviceId;
                    var devNode = deviceEnumerator.GetDevice(devNodeId);
                    instanceId = devNode.InstanceId;
                }
            }

This pull request adds a DeviceTopology class and a partial Connector class.