### PR TITLE
Add MP3 frame duration property

### DIFF
--- a/NAudio/FileFormats/Mp3/Mp3Frame.cs
+++ b/NAudio/FileFormats/Mp3/Mp3Frame.cs
@@ -274,5 +274,22 @@ namespace NAudio.Wave
         /// Not part of the MP3 frame itself - indicates where in the stream we found this header
         /// </summary>
         public long FileOffset { get; private set; }
+
+
+        /// <summary>
+        /// Gets the duration of the frame in seconds
+        /// </summary>
+        public double FrameDuration
+        {
+            get
+            {
+                double duration = SampleCount * 2.0 / SampleRate;
+
+                if (ChannelMode != ChannelMode.Mono)
+                    duration *= 2;
+
+                return duration;
+            }
+        }
     }
 }


### PR DESCRIPTION
https://stackoverflow.com/questions/383164/how-to-retrieve-duration-of-mp3-in-net/13269914#13269914

This very helpful answer has been up since '12, however such a workaround should be handled by the library. So I simply modified the code a little bit and put it in a property in MP3 frame. No idea if this is applicable in any other frame types, since I'm not too familiar with audio processing, however it should do the thing for the MP3 use case.