### PR TITLE
CPU intrinsics

### DIFF
--- a/NAudio.sln
+++ b/NAudio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29424.173
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NAudio", "NAudio\NAudio.csproj", "{DA4F02E3-0B5E-42CD-B8D9-5583FA51D66E}"
 EndProject
@@ -63,6 +63,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{BA7F6DBB-9
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NAudioUniversalDemo", "NAudioUniversalDemo\NAudioUniversalDemo.csproj", "{0BE833CC-8127-4079-BEEC-27397EDA3EDB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NAudioBenchmark", "NAudioBenchmark\NAudioBenchmark.csproj", "{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -180,6 +182,22 @@ Global
 		{0BE833CC-8127-4079-BEEC-27397EDA3EDB}.Release|x86.ActiveCfg = Release|x86
 		{0BE833CC-8127-4079-BEEC-27397EDA3EDB}.Release|x86.Build.0 = Release|x86
 		{0BE833CC-8127-4079-BEEC-27397EDA3EDB}.Release|x86.Deploy.0 = Release|x86
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|ARM.Build.0 = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|x64.Build.0 = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Debug|x86.Build.0 = Debug|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|ARM.ActiveCfg = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|ARM.Build.0 = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|x64.ActiveCfg = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|x64.Build.0 = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|x86.ActiveCfg = Release|Any CPU
+		{9F94E661-E0A8-4FCB-8FBD-2AA9568CAA57}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard2.0;uap10.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net35;netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <Version>1.9.0</Version>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard2.0;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net35;netstandard2.0;uap10.0;netcoreapp3.0</TargetFrameworks>
     <Version>1.9.0</Version>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -72,5 +72,23 @@
     <Compile Remove="Dmo\DmoDistortion.cs" />
     <Compile Remove="Dmo\Effect\*.cs" />
     <Compile Remove="Wave\WaveProviders\DmoEffectWaveProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <Compile Remove="Utils\ProgressLog*.*" />
+    <Compile Remove="Gui\*.*" />
+    <Compile Remove="Wave\MmeInterop\WaveWindow.cs" />
+    <Compile Remove="Wave\MmeInterop\WaveCallbackInfo.cs" />
+    <Compile Remove="Wave\WaveInputs\WaveIn.cs" />
+    <Compile Remove="Wave\WaveOutputs\WaveOut.cs" />
+    <Compile Remove="Wave\WaveOutputs\AsioOut.cs" />
+    <Compile Remove="Wave\WaveOutputs\AsioAudioAvailableEventArgs.cs" />
+    <Compile Remove="Wave\WaveFormats\WaveFormatCustomMarshaler.cs" />
+    <Compile Remove="Wave\WaveOutputs\WasapiOutRT.cs" />
+    <Compile Remove="Wave\WaveInputs\WasapiCaptureRT.cs" />
+    <Compile Remove="Wave\WaveOutputs\WaveFileWriterRT.cs" />
+    <PackageReference Include="System.Resources.Extensions">
+      <Version>4.6.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/NAudio/Wave/SampleProviders/VolumeSampleProvider.cs
+++ b/NAudio/Wave/SampleProviders/VolumeSampleProvider.cs
@@ -1,4 +1,9 @@
-﻿namespace NAudio.Wave.SampleProviders
+﻿#if NETCOREAPP3_0
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace NAudio.Wave.SampleProviders
 {
     /// <summary>
     /// Very simple sample provider supporting adjustable gain
@@ -34,10 +39,14 @@
             int samplesRead = source.Read(buffer, offset, sampleCount);
             if (Volume != 1f)
             {
+#if NETCOREAPP3_0
+                FastPath(buffer, offset, sampleCount);
+#else
                 for (int n = 0; n < sampleCount; n++)
                 {
                     buffer[offset + n] *= Volume;
                 }
+#endif
             }
             return samplesRead;
         }
@@ -46,5 +55,53 @@
         /// Allows adjusting the volume, 1.0f = full volume
         /// </summary>
         public float Volume { get; set; }
+
+#if NETCOREAPP3_0
+        private unsafe void FastPath(float[] buffer, int offset, int sampleCount)
+        {
+            fixed (float* b = buffer)
+            {
+                var pStart = b + offset;
+                var pCurrent = pStart;
+                var pEnd = pStart;
+
+                if (Avx.IsSupported)
+                {
+                    var volume = Vector256.Create(Volume);
+                    var vector256SampleCount = sampleCount & ~7;
+                    pEnd = pStart + vector256SampleCount;
+                    while (pCurrent < pEnd)
+                    {
+                        var input = Avx.LoadVector256(pCurrent);
+                        var output = Avx.Multiply(input, volume);
+                        Avx.Store(pCurrent, output);
+                        pCurrent += 8;
+                    }
+                }
+
+                if (Sse.IsSupported)
+                {
+                    var volume = Vector128.Create(Volume);
+                    var vector128SampleCount = sampleCount & ~3;
+                    pEnd = pStart + vector128SampleCount;
+                    while (pCurrent < pEnd)
+                    {
+                        var input = Sse.LoadVector128(pCurrent);
+                        var output = Sse.Multiply(input, volume);
+                        Sse.Store(pCurrent, output);
+                        pCurrent += 4;
+                    }
+                }
+
+                pEnd = pStart + sampleCount;
+                while (pCurrent < pEnd)
+                {
+                    *pCurrent *= Volume;
+                    pCurrent++;
+                }
+            }
+        }
+#endif
     }
 }
+

--- a/NAudioBenchmark/BenchmarkSampleProvider.cs
+++ b/NAudioBenchmark/BenchmarkSampleProvider.cs
@@ -1,0 +1,22 @@
+﻿using NAudio.Wave;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NAudioBenchmark
+{
+    public class BenchmarkSampleProvider : ISampleProvider
+    {
+        public WaveFormat WaveFormat { get; private set; }
+
+        public BenchmarkSampleProvider(WaveFormat waveFormat)
+        {
+            WaveFormat = waveFormat;
+        }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            return count;
+        }
+    }
+}

--- a/NAudioBenchmark/MultipleRuntimes.cs
+++ b/NAudioBenchmark/MultipleRuntimes.cs
@@ -1,0 +1,20 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NAudioBenchmark
+{
+    public class MultipleRuntimes : ManualConfig
+    {
+        public MultipleRuntimes()
+        {
+            Add(Job.Default.With(CsProjClassicNetToolchain.Net472));
+            Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp21));
+            Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp22));
+            Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp30));
+        }
+    }
+}

--- a/NAudioBenchmark/NAudioBenchmark.csproj
+++ b/NAudioBenchmark/NAudioBenchmark.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.0;net47;netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NAudio\NAudio.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NAudioBenchmark/Program.cs
+++ b/NAudioBenchmark/Program.cs
@@ -1,0 +1,17 @@
+﻿using BenchmarkDotNet.Running;
+using System;
+
+namespace NAudioBenchmark
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<VolumeSampleProviderBenchmark>();
+            //var benchmark = new VolumeSampleProviderBenchmark();
+            //benchmark.Setup();
+            //benchmark.Benchmark();
+            Console.ReadLine();
+        }
+    }
+}

--- a/NAudioBenchmark/VolumeSampleProviderBenchmark.cs
+++ b/NAudioBenchmark/VolumeSampleProviderBenchmark.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Attributes;
+using NAudio.Wave.SampleProviders;
+using System;
+
+#if NETCOREAPP3_0
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace NAudioBenchmark
+{
+    [Config(typeof(MultipleRuntimes))]
+    public class VolumeSampleProviderBenchmark
+    {
+        BenchmarkSampleProvider benchmarkSampleProvider;
+        VolumeSampleProvider volumeSampleProvider;
+
+        const int sampleCount = 1005;
+        float[] buffer;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            benchmarkSampleProvider = new BenchmarkSampleProvider(new NAudio.Wave.WaveFormat(48000, 1));
+            volumeSampleProvider = new VolumeSampleProvider(benchmarkSampleProvider)
+            {
+                Volume = 0.5f
+            };
+            buffer = new float[1005];
+        }
+
+        [Benchmark]
+        public void Benchmark()
+        {
+            volumeSampleProvider.Read(buffer, 0, sampleCount);
+        }
+    }
+}


### PR DESCRIPTION
This pull request is here to generate some discussion about integrating the CPU intrinsics available in .NET Core 3.0 into NAudio by providing a code example of how it might be integrated into a class.

I benchmarked this pull request, and as expected, VolumeSampleProvider runs significantly faster:

![image](https://user-images.githubusercontent.com/1031306/67795440-2841da00-fa76-11e9-857e-06effee5d5af.png)

Is this compatible with your vision for NAudio? 

Would you be interested in a larger pull request that uses intrinsics in a wide variety of places?
