### PR TITLE
fix CurrentTime not positioning to a multiple of BlockAlign

### DIFF
--- a/NAudio/Wave/WaveStreams/WaveStream.cs
+++ b/NAudio/Wave/WaveStreams/WaveStream.cs
@@ -105,7 +105,10 @@ namespace NAudio.Wave
             }
             set
             {
-                Position = (long) (value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
+                long bytePosition = (long)(value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
+                long roundedPostion = bytePosition - (bytePosition % BlockAlign);
+
+                Position = roundedPostion;
             }
         }
 


### PR DESCRIPTION
setting CurrentTime of a WaveStream could result in the Position being set to something that is not a multiple of BlockAlign