### PR TITLE
[ASIO] Added DriverResetRequest event 

### DIFF
--- a/NAudio/Wave/Asio/ASIODriverExt.cs
+++ b/NAudio/Wave/Asio/ASIODriverExt.cs
@@ -31,6 +31,7 @@ namespace NAudio.Wave.Asio
         private int bufferSize;
         private int outputChannelOffset;
         private int inputChannelOffset;
+        public Action ResetRequestCallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsioDriverExt"/> class based on an already
@@ -338,6 +339,7 @@ namespace NAudio.Wave.Asio
                         case AsioMessageSelector.kAsioEngineVersion:
                             return 1;
                         case AsioMessageSelector.kAsioResetRequest:
+                            ResetRequestCallback?.Invoke();
                             return 0;
                         case AsioMessageSelector.kAsioBufferSizeChange:
                             return 0;
@@ -356,6 +358,7 @@ namespace NAudio.Wave.Asio
                 case AsioMessageSelector.kAsioEngineVersion:
                     return 2;
                 case AsioMessageSelector.kAsioResetRequest:
+                    ResetRequestCallback?.Invoke();
                     return 1;
                 case AsioMessageSelector.kAsioBufferSizeChange:
                     return 0;

--- a/NAudio/Wave/WaveOutputs/AsioOut.cs
+++ b/NAudio/Wave/WaveOutputs/AsioOut.cs
@@ -40,6 +40,11 @@ namespace NAudio.Wave
         public event EventHandler<AsioAudioAvailableEventArgs> AudioAvailable;
 
         /// <summary>
+        /// Occurs when the driver settings are changed by the user, e.g. in the control panel.
+        /// </summary>
+        public event EventHandler DriverResetRequest;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AsioOut"/> class with the first 
         /// available ASIO Driver.
         /// </summary>
@@ -97,6 +102,7 @@ namespace NAudio.Wave
                 {
                     driver.Stop();
                 }
+                driver.ResetRequestCallback = null;
                 driver.ReleaseDriver();
                 driver = null;
             }
@@ -135,7 +141,15 @@ namespace NAudio.Wave
 
             // Instantiate the extended driver
             driver = new AsioDriverExt(basicDriver);
+            driver.ResetRequestCallback = OnDriverResetRequest;
             this.ChannelOffset = 0;
+        }
+
+
+
+        private void OnDriverResetRequest()
+        {
+            DriverResetRequest?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
This occurs when settings are changed by the user, e.g. in the ASIO control panel.
Many professional soundcards have a dedicated control panel, with this event it is possible to react to user changes.