### PR TITLE
Added CachedSound constructor for playing resource wav files

### DIFF
--- a/NAudioWpfDemo/FireAndForgetPlayback/CachedSound.cs
+++ b/NAudioWpfDemo/FireAndForgetPlayback/CachedSound.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NAudio.Wave;
+using System.IO;
 
 namespace NAudioWpfDemo.FireAndForgetPlayback
 {

--- a/NAudioWpfDemo/FireAndForgetPlayback/CachedSound.cs
+++ b/NAudioWpfDemo/FireAndForgetPlayback/CachedSound.cs
@@ -24,5 +24,22 @@ namespace NAudioWpfDemo.FireAndForgetPlayback
                 AudioData = wholeFile.ToArray();
             }
         }
+        public CachedSound(Stream sound) 
+        {
+            using (var audioFileReader = new WaveFileReader(sound))
+            {
+                WaveFormat = audioFileReader.WaveFormat;
+                var sp = audioFileReader.ToSampleProvider();
+                var wholeFile = new List<float>((int)(audioFileReader.Length / 4));
+                var sourceSamples = (int)(audioFileReader.Length / (audioFileReader.WaveFormat.BitsPerSample / 8));
+                var sampleData = new float[sourceSamples];
+                int samplesread;
+                while ((samplesread = sp.Read(sampleData, 0, sourceSamples)) > 0)
+                {
+                    wholeFile.AddRange(sampleData.Take(samplesread));
+                }
+                AudioData = wholeFile.ToArray();                
+            }
+        }
     }
 }


### PR DESCRIPTION
Added CachedSound constructor for playing resource wav files
I played the wav file of Properties.Resource using the following source code:

```csharp
public CachedSound(Stream sound) 
{
        using (var audioFileReader = new WaveFileReader(sound))
        {
            WaveFormat = audioFileReader.WaveFormat;
            var sp = audioFileReader.ToSampleProvider();
            var wholeFile = new List<float>((int)(audioFileReader.Length / 4));
            var sourceSamples = (int)(audioFileReader.Length / (audioFileReader.WaveFormat.BitsPerSample / 8));
            var sampleData = new float[sourceSamples];
            int samplesread;
            while ((samplesread = sp.Read(sampleData, 0, sourceSamples)) > 0)
            {
                wholeFile.AddRange(sampleData.Take(samplesread));
            }
            AudioData = wholeFile.ToArray();                
        }
}
```