### PR TITLE
Don't discard last data before stream end from MFTransform buffer

### DIFF
--- a/NAudio/MediaFoundation/MediaFoundationTransform.cs
+++ b/NAudio/MediaFoundation/MediaFoundationTransform.cs
@@ -130,6 +130,7 @@ namespace NAudio.MediaFoundation
                     EndStreamAndDrain();
                     // resampler might have given us a little bit more to return
                     bytesWritten += ReadFromOutputBuffer(buffer, offset + bytesWritten, count - bytesWritten);
+                    ClearOutputBuffer();
                     break;
                 }
 
@@ -170,12 +171,16 @@ namespace NAudio.MediaFoundation
             {
                 read = ReadFromTransform();
             } while (read > 0);
-            outputBufferCount = 0;
-            outputBufferOffset = 0;
             inputPosition = 0;
             outputPosition = 0;
             transform.ProcessMessage(MFT_MESSAGE_TYPE.MFT_MESSAGE_NOTIFY_END_STREAMING, IntPtr.Zero);
             initializedForStreaming = false;
+        }
+
+        private void ClearOutputBuffer()
+        {
+            outputBufferCount = 0;
+            outputBufferOffset = 0;
         }
 
         /// <summary>
@@ -280,6 +285,7 @@ namespace NAudio.MediaFoundation
             if (initializedForStreaming)
             {
                 EndStreamAndDrain();
+                ClearOutputBuffer();
                 InitializeTransformForStreaming();
             }
         }


### PR DESCRIPTION
Some MFTs, DMOs etc., e.g. resamplers, will read ahead more input data than requested, because future data is needed to determine the requested output, and store it in an internal buffer.

Issue: When the input stream has just ended, MediaFoundationTransform correctly ends the stream and drains the buffer, but then discards its data before trying to pass it on.

Solution: After draining the Transform's buffer into the OutputBuffer, don't immediatly clear the OutputBuffer, but call ReadFromOutputBuffer before that.

Detailed explanation of the issue: When upsampling from 11 to 44 kHz, I counted the number of bytes consumed and produced by the resampler (for position-tracking purposes) and found that, at the end of the input file, all input samples had been read but output had not been produced for the last 62 input samples (at the default ResamplerQuality of 60 — with quality 30, output for 32 input samples was missing). It turns out that code to handle the end of the input already exists in MediaFoundationTransform.Read but had a bug that cleared the data read from the Transform before passing it on to the caller's buffer.

Caveat to this simple fix: Since EndStreamAndDrain calls ReadFromTransform in a loop, a block of output obtained from the Transform will be overwritten by the next block if more than one call to IMFTransform.ProcessOutput (returning data without needing more input) is needed to drain the buffer. ReadFromOutputBuffer is called after the loop has ended and can therefore only process the last block of output. To my understanding, this problem should only occur if the Transform has buffered more data internally than fits into the OutputBuffer which is allocated for at least one second's worth of audio data.

I decline to create a unit test for this simple fix as I don't have any experience with NUnit. However, I can provide my byte-counting WaveProvider, if requested.
When testing the fix by upsampling something from 11 to 44 kHz, I observed that, given a stream of n input samples, MediaFoundationResampler will now produce (n – 1) * 4 + 1 output samples. That looks like, when the output sample rate is a whole multiple of the input sample rate, the resampler will space the input samples evenly and then fill in the resulting gaps between them with new, interpolated samples. (In contrast, WdlResamplingSampleProvider will produce n * 4 samples, effectively stretching each sample in terms of duration somehow.)