### PR TITLE
Release COM objects in DirectSoundOut.cs

### DIFF
--- a/NAudio/Wave/WaveOutputs/DirectSoundOut.cs
+++ b/NAudio/Wave/WaveOutputs/DirectSoundOut.cs
@@ -239,7 +239,7 @@ namespace NAudio.Wave
             // Open DirectSound
             lock (this.m_LockObject)
             {
-                directSound = null;
+                Debug.Assert(directSound == null);
                 DirectSoundCreate(ref device, out directSound, IntPtr.Zero);
 
                 if (directSound != null)
@@ -553,12 +553,19 @@ namespace NAudio.Wave
                     CleanUpSecondaryBuffer();
 
                     secondaryBuffer.Stop();
+                    Marshal.ReleaseComObject(secondaryBuffer);
                     secondaryBuffer = null;
                 }
                 if (primarySoundBuffer != null)
                 {
                     primarySoundBuffer.Stop();
+                    Marshal.ReleaseComObject(primarySoundBuffer);
                     primarySoundBuffer = null;
+                }
+                if (directSound != null)
+                {
+                    Marshal.ReleaseComObject(directSound);
+                    directSound = null;
                 }
             }
         }


### PR DESCRIPTION
The call to `CleanUpSecondaryBuffer` might not be needed after this.

I had a crash the occurred with fast stop/play cycles. Tracked it down to missing release of COM objects.
Before, the objects were being release when the garbage collector freed them.