### PR TITLE
Fix silent failure in WasapiCapture/WasapiOut

### DIFF
--- a/NAudio/Wave/WaveInputs/WasapiCapture.cs
+++ b/NAudio/Wave/WaveInputs/WasapiCapture.cs
@@ -245,10 +245,9 @@ namespace NAudio.CoreAudioApi
             }
             while (captureState == CaptureState.Capturing)
             {
-                bool readBuffer = true;
                 if (isUsingEventSync)
                 {
-                    readBuffer = frameEventWaitHandle.WaitOne(waitMilliseconds, false);
+                    frameEventWaitHandle.WaitOne(waitMilliseconds, false);
                 }
                 else
                 {
@@ -257,11 +256,8 @@ namespace NAudio.CoreAudioApi
                 if (captureState != CaptureState.Capturing)
                     break;
 
-                // If still recording and notification is ok
-                if (readBuffer)
-                {
-                    ReadNextPacket(capture);
-                }
+                // If still recording
+                ReadNextPacket(capture);
             }
         }
 

--- a/NAudio/Wave/WaveOutputs/WasapiOut.cs
+++ b/NAudio/Wave/WaveOutputs/WasapiOut.cs
@@ -121,18 +121,17 @@ namespace NAudio.Wave
                 while (playbackState != PlaybackState.Stopped)
                 {
                     // If using Event Sync, Wait for notification from AudioClient or Sleep half latency
-                    int indexHandle = 0;
                     if (isUsingEventSync)
                     {
-                        indexHandle = WaitHandle.WaitAny(waitHandles, 3 * latencyMilliseconds, false);
+                        WaitHandle.WaitAny(waitHandles, 3 * latencyMilliseconds, false);
                     }
                     else
                     {
                         Thread.Sleep(latencyMilliseconds / 2);
                     }
 
-                    // If still playing and notification is ok
-                    if (playbackState == PlaybackState.Playing && indexHandle != WaitHandle.WaitTimeout)
+                    // If still playing
+                    if (playbackState == PlaybackState.Playing)
                     {
                         // See how much buffer space is available.
                         int numFramesPadding;


### PR DESCRIPTION
When using Wasapi with event sync, if the event was not set then
the audiClient was never queried. If the audioClient has failed for
some reason then the WasapiCapture/WasapiOut will now
notice this and raise PlaybackStopped/RecordingStopped event.