### PR TITLE
Update WasapiCaptureRT.cs

### DIFF
--- a/NAudio/Wave/WaveInputs/WasapiCaptureRT.cs
+++ b/NAudio/Wave/WaveInputs/WasapiCaptureRT.cs
@@ -148,6 +148,14 @@ namespace NAudio.Wave
             if (waveFormat == null)
             {
                 waveFormat = audioClient.MixFormat;
+                if (mix.BitsPerSample == 32)
+                {
+                    waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(mix.SampleRate, mix.Channels);
+                }
+                else
+                {
+                    waveFormat = new WaveFormat(mix.SampleRate, mix.BitsPerSample, mix.Channels);
+                }                
             }
 
             long requestedDuration = REFTIMES_PER_MILLISEC * 100;


### PR DESCRIPTION
.NET native compiled and run UWP app, "System.ArgumentException: 'Unsupported Wave Format'" error occurs.
The cause of this problem is that audioClient.MixFormat is WaveFormatExtensible instead of IeeeFloat, so we modified this class to localize it to UWP.