### PR TITLE
Fix WaveStream.CurrentTime

### DIFF
--- a/NAudio.Core/Wave/WaveStreams/WaveStream.cs
+++ b/NAudio.Core/Wave/WaveStreams/WaveStream.cs
@@ -105,7 +105,7 @@ namespace NAudio.Wave
             }
             set
             {
-                Position = (long) (value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
+                Position = (long) (value.TotalSeconds * WaveFormat.SampleRate) * BlockAlign;
             }
         }
 


### PR DESCRIPTION
`WaveStream.CurrentTime` can set `WaveStream.Position` to a fraction of `WaveStream.BlockAlign`.
This fix makes the setter use `SampleRate` and `BlockAlign` to make sure Position is set to a value that corresponds to a Sample boundary.

This should not be a breaking change, as the current behavior is clearly buggy.