### PR TITLE
Release asio driver if init was with error

### DIFF
--- a/NAudio.Asio/AsioOut.cs
+++ b/NAudio.Asio/AsioOut.cs
@@ -151,8 +151,16 @@ namespace NAudio.Wave
             // Get the basic driver
             AsioDriver basicDriver = AsioDriver.GetAsioDriverByName(driverName);
 
-            // Instantiate the extended driver
-            driver = new AsioDriverExt(basicDriver);
+            try
+            {
+                // Instantiate the extended driver
+                driver = new AsioDriverExt(basicDriver);
+            }
+            catch
+            {
+                ReleaseDriver(basicDriver);
+                throw;
+            }
             driver.ResetRequestCallback = OnDriverResetRequest;
             this.ChannelOffset = 0;
         }
@@ -162,6 +170,15 @@ namespace NAudio.Wave
         private void OnDriverResetRequest()
         {
             DriverResetRequest?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Release driver
+        /// </summary>
+        private void ReleaseDriver(AsioDriver driver)
+        {
+            driver.DisposeBuffers();
+            driver.ReleaseComAsioDriver();
         }
 
         /// <summary>


### PR DESCRIPTION
I use NAudio to get sound from Dante devices via AsioDriver. 
I found a problem with the driver: If i init AsioDriverExt when device unavailable, then future connect attempts return exception code like Dante Visual Soundcard is already in use. My code resolve problem.