### PR TITLE
Added EndpointFormFactor enumeration

### DIFF
--- a/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
@@ -252,7 +252,7 @@ namespace NAudio.CoreAudioApi
             {
                 return false;
             }
-            if (hresult == (int)AudioClientErrors.UnsupportedFormat)
+            if (hresult == AudioClientErrorCode.UnsupportedFormat)
             {
                 // documentation is confusing as to what this flag means
                 // https://docs.microsoft.com/en-us/windows/desktop/api/audioclient/nf-audioclient-iaudioclient-isformatsupported

--- a/NAudio.Wasapi/CoreAudioApi/EndpointFormFactor.cs
+++ b/NAudio.Wasapi/CoreAudioApi/EndpointFormFactor.cs
@@ -1,0 +1,58 @@
+﻿namespace NAudio.CoreAudioApi
+{
+    /// <summary>
+    /// The EndpointFormFactor enumeration defines constants that indicate the general physical attributes of an audio endpoint device.
+    /// </summary>
+    public enum EndpointFormFactor : uint
+    {
+        /// <summary>
+        /// An audio endpoint device that the user accesses remotely through a network.
+        /// </summary>
+        RemoteNetworkDevice,
+        /// <summary>
+        /// A set of speakers.
+        /// </summary>
+        Speakers,
+        /// <summary>
+        /// An audio endpoint device that sends a line-level analog signal to a line-input jack on an audio adapter 
+        /// or that receives a line-level analog signal from a line-output jack on the adapter.
+        /// </summary>
+        LineLevel,
+        /// <summary>
+        /// A set of headphones.
+        /// </summary>
+        Headphones,
+        /// <summary>
+        /// A microphone.
+        /// </summary>
+        Microphone,
+        /// <summary>
+        /// An earphone or a pair of earphones with an attached mouthpiece for two-way communication.
+        /// </summary>
+        Headset,
+        /// <summary>
+        /// The part of a telephone that is held in the hand and that contains a speaker and a microphone 
+        /// for two-way communication.
+        /// </summary>
+        Handset,
+        /// <summary>
+        /// An audio endpoint device that connects to an audio adapter through a connector for a digital
+        /// interface of unknown type that transmits non-PCM data in digital pass-through mode.
+        /// </summary>
+        UnknownDigitalPassthrough,
+        /// <summary>
+        /// An audio endpoint device that connects to an audio adapter through a Sony/Philips Digital
+        /// Interface (S/PDIF) connector.
+        /// </summary>
+        SPDIF,
+        /// <summary>
+        /// An audio endpoint device that connects to an audio adapter through a High-Definition Multimedia
+        /// Interface (HDMI) connector or a display port.       
+        /// </summary>
+        DigitalAudioDisplayDevice,
+        /// <summary>
+        /// An audio endpoint device with unknown physical attributes.
+        /// </summary>
+        UnknownFormFactor
+    }
+}

--- a/NAudio.Wasapi/CoreAudioApi/EndpointFormFactor.cs
+++ b/NAudio.Wasapi/CoreAudioApi/EndpointFormFactor.cs
@@ -49,7 +49,7 @@
         /// An audio endpoint device that connects to an audio adapter through a High-Definition Multimedia
         /// Interface (HDMI) connector or a display port.       
         /// </summary>
-        DigitalAudioDisplayDevice,
+        HDMI,
         /// <summary>
         /// An audio endpoint device with unknown physical attributes.
         /// </summary>

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/ErrorCodes.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/ErrorCodes.cs
@@ -6,58 +6,162 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// <summary>
     /// Audio Client WASAPI Error Codes (HResult)
     /// </summary>
-    public enum AudioClientErrors
+    public static class AudioClientErrorCode
     {
+        // All error codes are precalculated.
+        // Calculation:
+        // (winerror.h) 
+        // #define FACILITY_AUDCLNT                 2185 
+        // (audioclient.h)
+        // #define AUDCLNTERR(n) MAKEHRESULT(SEVERITYERROR, FACILITYAUDCLNT, n)
+
         /// <summary>
         /// AUDCLNT_E_NOT_INITIALIZED
         /// </summary>
-        NotInitialized = unchecked((int)0x88890001),
+        public const int NotInitialized = unchecked((int)0x88890001);
+        /// <summary>
+        /// AUDCLNT_E_ALREADY_INITIALIZED
+        /// </summary>
+		public const int AlreadyInitialized = unchecked((int)0x88890002);
+        /// <summary>
+        /// AUDCLNT_E_WRONG_ENDPOINT_TYPE
+        /// </summary>
+		public const int WrongEndpointType = unchecked((int)0x88890003);
+        /// <summary>
+        /// AUDCLNT_E_DEVICE_INVALIDATED
+        /// </summary>
+		public const int DeviceInvalidated = unchecked((int)0x88890004);
+        /// <summary>
+        /// AUDCLNT_E_NOT_STOPPED
+        /// </summary>
+		public const int NotStopped = unchecked((int)0x88890005);
+        /// <summary>
+        /// AUDCLNT_E_BUFFER_TOO_LARGE
+        /// </summary>
+		public const int BufferTooLarge = unchecked((int)0x88890006);
+        /// <summary>
+        /// AUDCLNT_E_OUT_OF_ORDER
+        /// </summary>
+		public const int OutOfOrder = unchecked((int)0x88890007);
         /// <summary>
         /// AUDCLNT_E_UNSUPPORTED_FORMAT
         /// </summary>
-        UnsupportedFormat = unchecked((int)0x88890008),
+		public const int UnsupportedFormat = unchecked((int)0x88890008);
+        /// <summary>
+        /// AUDCLNT_E_INVALID_SIZE
+        /// </summary>
+		public const int InvalidSize = unchecked((int)0x88890009);
         /// <summary>
         /// AUDCLNT_E_DEVICE_IN_USE
         /// </summary>
-        DeviceInUse = unchecked((int)0x8889000A),
+		public const int DeviceInUse = unchecked((int)0x8889000A);
+        /// <summary>
+        /// AUDCLNT_E_BUFFER_OPERATION_PENDING
+        /// </summary>
+		public const int BufferOperationPending = unchecked((int)0x8889000B);
+        /// <summary>
+        /// AUDCLNT_E_THREAD_NOT_REGISTERED
+        /// </summary>
+		public const int ThreadNotRegistered = unchecked((int)0x8889000C);
+        /// <summary>
+        /// AUDCLNT_E_NO_SINGLE_PROCESS
+        /// </summary>
+		public const int NoSingleProcess = unchecked((int)0x8889000D);
+        /// <summary>
+        /// AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED
+        /// </summary>
+		public const int ExclusiveModeNotAllowed = unchecked((int)0x8889000E);
+        /// <summary>
+        /// AUDCLNT_E_ENDPOINT_CREATE_FAILED
+        /// </summary>
+		public const int EndpointCreateFailed = unchecked((int)0x8889000F);
+        /// <summary>
+        /// AUDCLNT_E_SERVICE_NOT_RUNNING
+        /// </summary>
+		public const int ServiceNotRunning = unchecked((int)0x88890010);
+        /// <summary>
+        /// AUDCLNT_E_EVENTHANDLE_NOT_EXPECTED
+        /// </summary>
+		public const int EventHandleNotExpected = unchecked((int)0x88890011);
+        /// <summary>
+        /// AUDCLNT_E_EXCLUSIVE_MODE_ONLY
+        /// </summary>
+		public const int ExclusiveModeOnly = unchecked((int)0x88890012);
+        /// <summary>
+        /// AUDCLNT_E_BUFDURATION_PERIOD_NOT_EQUAL
+        /// </summary>
+		public const int BufferDurationPeriodNotEqual = unchecked((int)0x88890013);
+        /// <summary>
+        /// AUDCLNT_E_EVENTHANDLE_NOT_SET
+        /// </summary>
+		public const int EventHandleNotSet = unchecked((int)0x88890014);
+        /// <summary>
+        /// AUDCLNT_E_INCORRECT_BUFFER_SIZE
+        /// </summary>
+		public const int IncorrectBufferSize = unchecked((int)0x88890015);
+        /// <summary>
+        /// AUDCLNT_E_BUFFER_SIZE_ERROR
+        /// </summary>
+		public const int BufferSizeError = unchecked((int)0x88890016);
+        /// <summary>
+        /// AUDCLNT_E_CPUUSAGE_EXCEEDED
+        /// </summary>
+		public const int CpuUsageExceeded = unchecked((int)0x88890017);
+        /// <summary>
+        /// AUDCLNT_E_BUFFER_ERROR
+        /// </summary>
+		public const int BufferError = unchecked((int)0x88890018);
+        /// <summary>
+        /// AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED
+        /// </summary>
+		public const int BufferSizeNotAligned = unchecked((int)0x88890019);
+        /// <summary>
+        /// AUDCLNT_E_INVALID_DEVICE_PERIOD
+        /// </summary>
+		public const int InvalidDevicePeriod = unchecked((int)0x88890020);
+        /// <summary>
+        /// AUDCLNT_E_INVALID_STREAM_FLAG
+        /// </summary>
+		public const int InvalidStreamFlag = unchecked((int)0x88890021);
+        /// <summary>
+        /// AUDCLNT_E_ENDPOINT_OFFLOAD_NOT_CAPABLE
+        /// </summary>
+		public const int EndpointOffloadNotCapable = unchecked((int)0x88890022);
+        /// <summary>
+        /// AUDCLNT_E_OUT_OF_OFFLOAD_RESOURCES
+        /// </summary>
+		public const int OutOfOffloadResources = unchecked((int)0x88890023);
+        /// <summary>
+        /// AUDCLNT_E_OFFLOAD_MODE_ONLY
+        /// </summary>
+		public const int OffloadModeOnly = unchecked((int)0x88890024);
+        /// <summary>
+        /// AUDCLNT_E_NONOFFLOAD_MODE_ONLY
+        /// </summary>
+		public const int NonOffloadModeOnly = unchecked((int)0x88890025);
         /// <summary>
         /// AUDCLNT_E_RESOURCES_INVALIDATED
         /// </summary>
-        ResourcesInvalidated = unchecked((int)0x88890026),
-    }
-
-    static class ErrorCodes
-    {   // AUDCLNT_ERR(n) MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, n)
-        // AUDCLNT_SUCCESS(n) MAKE_SCODE(SEVERITY_SUCCESS, FACILITY_AUDCLNT, n)
-        // ReSharper disable InconsistentNaming
-        public const int SEVERITY_ERROR = 1;
-        public const int FACILITY_AUDCLNT = 0x889;
-        public static readonly int AUDCLNT_E_NOT_INITIALIZED = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x001);
-        public static readonly int AUDCLNT_E_ALREADY_INITIALIZED = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x002);
-        public static readonly int AUDCLNT_E_WRONG_ENDPOINT_TYPE = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x003);
-        public static readonly int AUDCLNT_E_DEVICE_INVALIDATED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x004);
-        public static readonly int AUDCLNT_E_NOT_STOPPED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x005);
-        public static readonly int AUDCLNT_E_BUFFER_TOO_LARGE  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x006);
-        public static readonly int AUDCLNT_E_OUT_OF_ORDER  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x007);
-        public static readonly int AUDCLNT_E_UNSUPPORTED_FORMAT  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x008);
-        public static readonly int AUDCLNT_E_INVALID_SIZE  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x009);
-        public static readonly int AUDCLNT_E_DEVICE_IN_USE  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x00A);
-        public static readonly int AUDCLNT_E_BUFFER_OPERATION_PENDING  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x00B);
-        public static readonly int AUDCLNT_E_THREAD_NOT_REGISTERED = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x00C);
-        public static readonly int AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x00E);
-        public static readonly int AUDCLNT_E_ENDPOINT_CREATE_FAILED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x00F);
-        public static readonly int AUDCLNT_E_SERVICE_NOT_RUNNING  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x010);
-        public static readonly int AUDCLNT_E_EVENTHANDLE_NOT_EXPECTED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x011);
-        public static readonly int AUDCLNT_E_EXCLUSIVE_MODE_ONLY  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x0012);
-        public static readonly int AUDCLNT_E_BUFDURATION_PERIOD_NOT_EQUAL  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x013);
-        public static readonly int AUDCLNT_E_EVENTHANDLE_NOT_SET  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x014);
-        public static readonly int AUDCLNT_E_INCORRECT_BUFFER_SIZE  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x015);
-        public static readonly int AUDCLNT_E_BUFFER_SIZE_ERROR  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x016);
-        public static readonly int AUDCLNT_E_CPUUSAGE_EXCEEDED  = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x017);
-        public static readonly int AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED = HResult.MAKE_HRESULT(SEVERITY_ERROR, FACILITY_AUDCLNT, 0x019);
-        public static readonly int AUDCLNT_E_RESOURCES_INVALIDATED = unchecked((int) 0x88890026);
-        /*static readonly int AUDCLNT_S_BUFFER_EMPTY              AUDCLNT_SUCCESS(0x001)
-        static readonly int AUDCLNT_S_THREAD_ALREADY_REGISTERED AUDCLNT_SUCCESS(0x002)
-        static readonly int AUDCLNT_S_POSITION_STALLED		   AUDCLNT_SUCCESS(0x003)*/
+		public const int ResourcesInvalidated = unchecked((int)0x88890026);
+        /// <summary>
+        /// AUDCLNT_E_RAW_MODE_UNSUPPORTED
+        /// </summary>
+		public const int RawModeUnsupported = unchecked((int)0x88890027);
+        /// <summary>
+        /// AUDCLNT_E_ENGINE_PERIODICITY_LOCKED
+        /// </summary>
+		public const int EnginePeriodicityLocked = unchecked((int)0x88890028);
+        /// <summary>
+        /// AUDCLNT_E_ENGINE_FORMAT_LOCKED
+        /// </summary>
+		public const int EngineFormatLocked = unchecked((int)0x88890029);
+        /// <summary>
+        /// AUDCLNT_E_HEADTRACKING_ENABLED
+        /// </summary>
+		public const int HeadTrackingEnabled = unchecked((int)0x88890030);
+        /// <summary>
+        /// AUDCLNT_E_HEADTRACKING_UNSUPPORTED
+        /// </summary>
+		public const int HeadTrackingUnsupported = unchecked((int)0x88890040);
     }
 }

--- a/NAudio.Wasapi/WasapiOut.cs
+++ b/NAudio.Wasapi/WasapiOut.cs
@@ -420,7 +420,7 @@ namespace NAudio.Wave
                     {
                         // Starting with Windows 7, Initialize can return AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED for a render device.
                         // We should to initialize again.
-                        if (ex.ErrorCode != ErrorCodes.AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED)
+                        if (ex.ErrorCode != AudioClientErrorCode.BufferSizeNotAligned)
                             throw;
 
                         // Calculate the new latency.


### PR DESCRIPTION
Added the **_EndpointFormFactor_** enumeration. The constants in this enumeration are the values that can be assigned to the _**PKEY_AudioEndpoint_FormFactor**_ property, as described in https://docs.microsoft.com/en-us/windows/win32/api/mmdeviceapi/ne-mmdeviceapi-endpointformfactor

This allows for the ability to determine whether your device is set to one of the following:
- RemoteNetworkDevice
- Speakers
- LineLevel
- Headphones
- Microphone
- Headset
- Handset
- UnknownDigitalPassthrough
- SPDIF
- HDMI
- UnknownFormFactor



```csharp
    // Example use case:
    
    public EndpointFormFactor FormFactor(MMDevice device)
    {
            if (device.Properties.Contains(PropertyKeys.PKEY_AudioEndpoint_FormFactor))
            {
                return (EndpointFormFactor)device.Properties[PropertyKeys.PKEY_AudioEndpoint_FormFactor].Value;
            }
            else
                return EndpointFormFactor.UnknownFormFactor;        
    }
```
