### PR TITLE
Workaround access violation crash added in .NET 5.0.7 when marshalling non-sealed classes

### DIFF
--- a/NAudio.WinMM/MmeInterop/WaveHeader.cs
+++ b/NAudio.WinMM/MmeInterop/WaveHeader.cs
@@ -8,7 +8,7 @@ namespace NAudio.Wave
     /// http://msdn.microsoft.com/en-us/library/dd743837%28VS.85%29.aspx
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public class WaveHeader
+    public sealed class WaveHeader
     {
         /// <summary>pointer to locked data buffer (lpData)</summary>
         public IntPtr dataBuffer;


### PR DESCRIPTION
Workaround access violation crash added in .NET 5.0.7 when marshalling non-sealed classes.
This is achieved by setting WaveHeader class as sealed.
Close https://github.com/naudio/NAudio/issues/789

# Tests
I setup a small repro project at https://github.com/jackpoz/NetCore507Crash as console application that plays a mp3 file.
- With .NET 5.0.7 and without this PR, an unhandled Access Violation error happens and the application closes
- With .NET 5.0.7 and with this PR, the console application plays the mp3 file correctly and I can hear the music

Please let me know if you need anything further.