### PR TITLE
Added a Peek function to Circular Buffer and BufferedWaveProvider

### DIFF
--- a/NAudio.Core/Wave/WaveProviders/BufferedWaveProvider.cs
+++ b/NAudio.Core/Wave/WaveProviders/BufferedWaveProvider.cs
@@ -91,7 +91,7 @@ namespace NAudio.Wave
         {
             // create buffer here to allow user to customise buffer length
             if (circularBuffer == null)
-            { 
+            {
                 circularBuffer = new CircularBuffer(BufferLength);
             }
 
@@ -106,11 +106,11 @@ namespace NAudio.Wave
         /// Reads from this WaveProvider
         /// Will always return count bytes, since we will zero-fill the buffer if not enough available
         /// </summary>
-        public int Read(byte[] buffer, int offset, int count) 
+        public int Read(byte[] buffer, int offset, int count)
         {
             int read = 0;
             if (circularBuffer != null) // not yet created
-            { 
+            {
                 read = circularBuffer.Read(buffer, offset, count);
             }
             if (ReadFully && read < count)
@@ -120,6 +120,21 @@ namespace NAudio.Wave
                 read = count;
             }
             return read;
+        }
+
+        /// <summary>
+        /// Peeks ahead at data in this <see cref="IWaveProvider"/> without affecting the read position.
+        /// </summary>
+        /// <param name="peekOffset">The offset from the current read position where peeking will begin.</param>
+        /// <param name="buffer">The buffer we will read into.</param>
+        /// <param name="offset">The offset into the <paramref name="buffer"/>.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <returns>The number of bytes actually read.</returns>
+        public int Peek(uint peekOffset, byte[] buffer, int offset, int count)
+        {
+            if (circularBuffer == null) { return 0; }
+
+            return circularBuffer.Peek(peekOffset, buffer, offset, count);
         }
 
         /// <summary>

--- a/NAudioTests/WaveStreams/CircularBufferTests.cs
+++ b/NAudioTests/WaveStreams/CircularBufferTests.cs
@@ -10,6 +10,29 @@ namespace NAudioTests.WaveStreams
     [Category("UnitTest")]
     public class CircularBufferTests
     {
+
+        [Test]
+        public void PeekingReadsCorrectlyAndDoesntAffectReadPosition()
+        {
+            CircularBuffer circularBuffer = new CircularBuffer(128);
+            for (int i = 0; i < 128; i++)
+            {
+                circularBuffer.Write(new byte[1] { (byte)i }, 0, 1);
+            }
+
+            byte[] peekData = new byte[1];
+            circularBuffer.Peek(100, peekData, 0, 1);
+
+            byte[] regularRead = new byte[1];
+            circularBuffer.Read(regularRead, 0, 1);
+
+            // Confirm data that was peeked is correct.
+            Assert.AreEqual((byte)100, peekData[0]);
+
+            // Confirm data read is from the start as the read position shouldn't have moved.
+            Assert.AreEqual((byte)0, regularRead[0]);
+        }
+
         [Test]
         public void CircularBufferHasMaxLengthAndCount()
         {


### PR DESCRIPTION
Recently I've required the ability to 'peek ahead' at data in a `BufferedWaveProvider`, i.e read data without advancing the read position. At present there are no functions to do this.

I have implemented the `Peek` function on both the `CircularBuffer` and the `BufferedWaveProvider` and have also created a test to ensure that everything works as it should. I have also added rich documentation to each of the new methods.

This PR does not modify the existing public API methods, it only adds to them, so does not pose any risk when merging.

I look forward to discussing this!