### PR TITLE
Fixed issue where BinaryReader.PeekChar would fail

### DIFF
--- a/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
+++ b/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
@@ -88,9 +88,9 @@ namespace NAudio.FileFormats.Wav
                     }
                     if (storeAllChunks)
                     {
-                        if (chunkLength > Int32.MaxValue)
-                            throw new InvalidDataException(string.Format("RiffChunk chunk length must be between 0 and {0}.", Int32.MaxValue));
-                        riffChunks.Add(GetRiffChunk(stream, chunkIdentifier, (int)chunkLength));
+                        if (chunkLength > UInt32.MaxValue)
+                            throw new InvalidDataException(string.Format("RiffChunk chunk length must be between 0 and {0}.", UInt32.MaxValue));
+                        riffChunks.Add(GetRiffChunk(stream, chunkIdentifier, chunkLength));
                     }
                     stream.Position += chunkLength;
                 }
@@ -134,7 +134,7 @@ namespace NAudio.FileFormats.Wav
             reader.ReadBytes(chunkSize - 24); // get to the end of this chunk (should parse extra stuff later)
         }
 
-        private static RiffChunk GetRiffChunk(Stream stream, Int32 chunkIdentifier, Int32 chunkLength)
+        private static RiffChunk GetRiffChunk(Stream stream, Int32 chunkIdentifier, UInt32 chunkLength)
         {
             return new RiffChunk(chunkIdentifier, chunkLength, stream.Position);
         }

--- a/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
+++ b/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
@@ -100,9 +100,9 @@ namespace NAudio.FileFormats.Wav
                 // "If the chunk size is an odd number of bytes, a pad byte with value zero is
                 //  written after ckData. Word aligning improves access speed (for chunks resident in memory)
                 //  and maintains compatibility with EA IFF. The ckSize value does not include the pad byte."
-                if (((chunkLength % 2) != 0) && (br.PeekChar() == 0))
+                if (((chunkLength % 2) != 0) && (br.ReadByte() != 0))
                 {
-                    stream.Position++;
+                    stream.Position--;
                 }
             }
 

--- a/NAudio.Core/Wave/WaveStreams/RiffChunk.cs
+++ b/NAudio.Core/Wave/WaveStreams/RiffChunk.cs
@@ -12,7 +12,7 @@ namespace NAudio.Wave
         /// <summary>
         /// Creates a RiffChunk object
         /// </summary>
-        public RiffChunk(int identifier, int length, long streamPosition)
+        public RiffChunk(int identifier, UInt32 length, long streamPosition)
         {
             Identifier = identifier;
             Length = length;
@@ -32,7 +32,7 @@ namespace NAudio.Wave
         /// <summary>
         /// The chunk length
         /// </summary>
-        public int Length { get; private set; }
+        public UInt32 Length { get; private set; }
 
         /// <summary>
         /// The stream position this chunk is located at


### PR DESCRIPTION
Fixed issue where BinaryReader.PeekChar would fail, since bytedata is not UTF8 content