### PR TITLE
Update AiffFileWriter.cs

### DIFF
--- a/NAudio.Core/Wave/WaveOutputs/AiffFileWriter.cs
+++ b/NAudio.Core/Wave/WaveOutputs/AiffFileWriter.cs
@@ -13,7 +13,7 @@ namespace NAudio.Wave
         private BinaryWriter writer;
         private long dataSizePos;
         private long commSampleCountPos;
-        private int dataChunkSize = 8;
+        private long dataChunkSize = 8;
         private WaveFormat format;
         private string filename;
 


### PR DESCRIPTION
dataChunkSize needs to be defined bigger than int, else the multiplication in function UpdateCommChunk will return negative value if the product of the multiplication exceeds Int.MaxValue