### PR TITLE
Fixed wrong duty cycle in generated square wave

### DIFF
--- a/NAudio.Core/Wave/SampleProviders/SignalGenerator.cs
+++ b/NAudio.Core/Wave/SampleProviders/SignalGenerator.cs
@@ -145,7 +145,7 @@ namespace NAudio.Wave.SampleProviders
 
                         multiple = 2*Frequency/waveFormat.SampleRate;
                         sampleSaw = ((nSample*multiple)%2) - 1;
-                        sampleValue = sampleSaw > 0 ? Gain : -Gain;
+                        sampleValue = sampleSaw >= 0 ? Gain : -Gain;
 
                         nSample++;
                         break;


### PR DESCRIPTION
Hello!
I noticed that SignalGenerator generates square waves with wrong duty cycle. It sets the first sample of second half cycle to the minimum value even when sample rate is evenly divisible by wave frequency, e.g. in case of 192000 Hz sample rate and 8000 Hz signal frequency both half cycles should have equal number of samples - 12 and 12, but now it's 13 and 11, see screenshot below

![screenshot](https://user-images.githubusercontent.com/24323496/156929424-d2e00b62-474e-4813-943d-6c7a4546f214.png)
On the screenshot tracks with prefix "naudio" generated by NAudio SignalGenerator, "aud_" are generated by Audacity. 8000, 16000, 24000 are wave frequencies.

Audacity square waves generated via its "Generate" -> "Tone" function.
NAudio square waves generated by this code:
```csharp
using NAudio.Wave;
using NAudio.Wave.SampleProviders;

int sampleRate = 192000;
int channels = 1;

foreach (var freq in new[] { 8000, 16000, 24000 })
{
    var signalGenerator = new SignalGenerator(sampleRate, channels)
    {
        Gain = 0.9,
        Type = SignalGeneratorType.Square,
        Frequency = freq
    };

    var bufferLen = 64;
    var buffer = new float[bufferLen];

    signalGenerator.Read(buffer, 0, bufferLen);

    using (var wav = new WaveFileWriter($"square_{freq}_{sampleRate}_naudio.wav", WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels)))
    {
        wav.WriteSamples(buffer, 0, bufferLen);
        wav.Flush();
    }
}
```

Wav files and test project in the archive
[GeneratorTestProject.zip](https://github.com/naudio/NAudio/files/8192883/GeneratorTestProject.zip)
