### PR TITLE
Minor fixes:

### DIFF
--- a/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -384,8 +384,8 @@ namespace NAudio.Wave
                     finally
                     {
                         Type Mem = typeof(MemoryStream); 
-                        if (outStream.GetType().Equals(Mem) == false) //   Do not close MemoryStreams. This makes them unavailable to the caller.
-                        {                                                                                       
+                        if (outStream.GetType().Equals(Mem) == false) //   Do not close MemoryStreams. This makes them unavailable to the caller
+                        {                                             //   which defeats the purpose as to why WaveFileWriter was called in the first place.                                           
                           // in a finally block as we don't want the FileStream to run its disposer in
                           // the GC thread if the code above caused an IOException (e.g. due to disk full)
                             outStream.Dispose(); // will close the underlying base stream

--- a/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -383,10 +383,14 @@ namespace NAudio.Wave
                     }
                     finally
                     {
-                        // in a finally block as we don't want the FileStream to run its disposer in
-                        // the GC thread if the code above caused an IOException (e.g. due to disk full)
-                        outStream.Dispose(); // will close the underlying base stream
-                        outStream = null;
+                        Type Mem = typeof(MemoryStream); 
+                        if (outStream.GetType().Equals(Mem) == false) //   Do not close MemoryStreams. This makes them unavailable to the caller.
+                        {                                                                                       
+                          // in a finally block as we don't want the FileStream to run its disposer in
+                          // the GC thread if the code above caused an IOException (e.g. due to disk full)
+                            outStream.Dispose(); // will close the underlying base stream
+                            outStream = null;
+                        }
                     }
                 }
             }

--- a/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
+++ b/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
@@ -252,11 +252,15 @@ namespace NAudio.Wave
             Mp3Frame frame = null;
             try
             {
-                frame = Mp3Frame.LoadFromStream(mp3Stream, readData);
-                if (frame != null)
+                if (mp3Stream != null) //  in case we're called after the stream is closed 
                 {
-                    tocIndex++;
+                    frame = Mp3Frame.LoadFromStream(mp3Stream, readData);
+                    if (frame != null)
+                    {
+                        tocIndex++;
+                    }
                 }
+                
             }
             catch (EndOfStreamException)
             {

--- a/NAudio.Wasapi/WasapiOut.cs
+++ b/NAudio.Wasapi/WasapiOut.cs
@@ -152,11 +152,14 @@ namespace NAudio.Wave
                     }
                 }
                 Thread.Sleep(latencyMilliseconds / 2);
-                audioClient.Stop();
-                if (playbackState == PlaybackState.Stopped)
+                if (audioClient != null)  //        avoid null reference (probably due to timing issues)
                 {
-                    audioClient.Reset();
-                }
+                    audioClient.Stop();
+                    if (playbackState == PlaybackState.Stopped)
+                    {
+                        audioClient.Reset();
+                    }
+                } 
             }
             catch (Exception e)
             {


### PR DESCRIPTION
I've been using these 2 fixes since release 1.8. Thought they might be of use.

Fix 1) WaveFileWriter: 
- Don't dispose of memory streams in the Finalizer. It deletes them (which defeats WaveFileWriter's purpose)

Fix 2) Mp3FileReader.ReadNextFrame: 
- Don't try to read from a closed stream.
- Was happening intermittently in the past (probably due to some sort of timing + multi tasking issue)

Many thanks for this wonderful library. 