### PR TITLE
Mark DirectSoundOut as Windows only

### DIFF
--- a/NAudio.Core/NAudio.Core.csproj
+++ b/NAudio.Core/NAudio.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>Latest</LangVersion>
     <Authors>Mark Heath</Authors>
     <Version>2.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -15,6 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>naudio-icon.png</PackageIcon>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +24,13 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 

--- a/NAudio.Core/Wave/WaveOutputs/DirectSoundOut.cs
+++ b/NAudio.Core/Wave/WaveOutputs/DirectSoundOut.cs
@@ -12,6 +12,7 @@ namespace NAudio.Wave
     /// Contact author: Alexandre Mutel - alexandre_mutel at yahoo.fr
     /// Modified by: Graham "Gee" Plumb
     /// </summary>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     public class DirectSoundOut : IWavePlayer
     {
         /// <summary>


### PR DESCRIPTION
`DirectSoundOut` uses COM Interop and native method calls to `dsound.dll` and `user32.dll`. This pull request marks the class as Windows-only to make it more clear to users that this will not function on other platforms.

This pull request also adds a nontransitive reference to [PolySharp](https://github.com/Sergio0694/PolySharp), which is required to use the `SupportedOSPlatform` attribute on .NET Standard.