### PR TITLE
Add `ComImport` attribute to CoreAudioApi interfaces

### DIFF
--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioClock2.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioClock2.cs
@@ -7,7 +7,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioClient.h
     /// </summary>
     [Guid("CD63314F-3FBA-4a1b-812C-EF96358728E7"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     internal interface IAudioClock
     {
         [PreserveSig]
@@ -24,7 +25,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioClient.h
     /// </summary>
     [Guid("6f49ff73-6727-49AC-A008-D98CF5E70048"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     internal interface IAudioClock2 : IAudioClock
     {
         [PreserveSig]

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioEndpointVolume.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioEndpointVolume.cs
@@ -25,7 +25,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("5CDF2C82-841E-4546-9722-0CF74078229A"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     internal interface IAudioEndpointVolume
     {
         int RegisterControlChangeNotify(IAudioEndpointVolumeCallback pNotify);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioEndpointVolumeCallback.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioEndpointVolumeCallback.cs
@@ -28,7 +28,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("657804FA-D6AD-4496-8A60-352752AF4F89"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     internal interface IAudioEndpointVolumeCallback
     {
         void OnNotify(IntPtr notifyData);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioMeterInformation.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioMeterInformation.cs
@@ -25,7 +25,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("C02216F6-8C67-4B5B-9D00-D008E73E0064"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     internal interface IAudioMeterInformation
     {
         int GetPeakValue(out float pfPeak);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionControl.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionControl.cs
@@ -29,7 +29,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioPolicy.h
     /// </summary>
     [Guid("F4B1A599-7266-4319-A8CA-E70ACB11E8CD"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     public interface IAudioSessionControl
     {
         /// <summary>
@@ -126,7 +127,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioPolicy.h
     /// </summary>
     [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     public interface IAudioSessionControl2 : IAudioSessionControl
     {
         /// <summary>

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionEnumerator.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionEnumerator.cs
@@ -5,7 +5,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("E2F5BB11-0570-40CA-ACDD-3AA01277DEE8"),
-    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+    ComImport]
     internal interface IAudioSessionEnumerator
     {
         int GetCount(out int sessionCount);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionEvents.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionEvents.cs
@@ -92,7 +92,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioPolicy.h
     /// </summary>
     [Guid("24918ACC-64B3-37C1-8CA9-74A66E9957A8"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     public interface IAudioSessionEvents
     {
         /// <summary>

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionManager.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionManager.cs
@@ -29,7 +29,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioPolicy.h
     /// </summary>
     [Guid("BFA971F1-4D5E-40BB-935E-967039BFBEE4"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     internal interface IAudioSessionManager
     {
         /// <summary>
@@ -61,7 +62,8 @@ namespace NAudio.CoreAudioApi.Interfaces
 
 
     [Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     internal interface IAudioSessionManager2 : IAudioSessionManager
     {
         /// <summary>

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionNotification.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioSessionNotification.cs
@@ -9,7 +9,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioPolicy.h
     /// </summary>
     [Guid("641DD20B-4D41-49CC-ABA3-174B9477BB08"),
-    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+    ComImport]
     public interface IAudioSessionNotification
     {
 

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioStreamVolume.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioStreamVolume.cs
@@ -5,7 +5,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("93014887-242D-4068-8A15-CF5E93B90FE3"),
-     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+     ComImport]
     interface IAudioStreamVolume
     {
         [PreserveSig]

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDevice.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDevice.cs
@@ -4,7 +4,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("D666063F-1587-4E43-81F1-B948E807363F"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     interface IMMDevice
     {
         // activationParams is a propvariant

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDeviceCollection.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDeviceCollection.cs
@@ -4,7 +4,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     interface IMMDeviceCollection
     {
         int GetCount(out int numDevices);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDeviceEnumerator.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDeviceEnumerator.cs
@@ -4,7 +4,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.CoreAudioApi.Interfaces
 {
     [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     interface IMMDeviceEnumerator
     {
         int EnumAudioEndpoints(DataFlow dataFlow, DeviceState stateMask,

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMEndpoint.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMEndpoint.cs
@@ -7,7 +7,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// defined in MMDeviceAPI.h
     /// </summary>
     [Guid("1BE09788-6894-4089-8586-9A2A6C265AC5"),
-    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+    ComImport]
     interface IMMEndpoint
     {
         int GetDataFlow(out DataFlow dataFlow);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMNotificationClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMNotificationClient.cs
@@ -7,7 +7,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// IMMNotificationClient
     /// </summary>
     [Guid("7991EEC9-7E89-4D85-8390-6C703CEC60C0"), 
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     public interface IMMNotificationClient
     {
         /// <summary>

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IPropertyStore.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IPropertyStore.cs
@@ -7,7 +7,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// is defined in propsys.h
     /// </summary>
     [Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     interface IPropertyStore
     {
         int GetCount(out int propCount);

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/ISimpleAudioVolume.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/ISimpleAudioVolume.cs
@@ -29,7 +29,8 @@ namespace NAudio.CoreAudioApi.Interfaces
     /// Defined in AudioClient.h
     /// </summary>
     [Guid("87CE5498-68D6-44E5-9215-6DA47EF883D8"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     internal interface ISimpleAudioVolume
     {
         /// <summary>

--- a/NAudio.Wasapi/Dmo/IEnumDmo.cs
+++ b/NAudio.Wasapi/Dmo/IEnumDmo.cs
@@ -4,7 +4,8 @@ using System.Runtime.InteropServices;
 namespace NAudio.Dmo
 {
     [Guid("2c3cd98a-2bfa-4a53-9c27-5249ba64ba0f"), 
-    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+    ComImport]
     interface IEnumDmo
     {
         // int Next(int itemsToFetch, CLSID[] clsids, string[] names, out int itemsFetched);

--- a/NAudio.Wasapi/Dmo/IWMResamplerProps.cs
+++ b/NAudio.Wasapi/Dmo/IWMResamplerProps.cs
@@ -8,7 +8,8 @@ namespace NAudio.Dmo
     /// wmcodecdsp.h
     /// </summary>
     [Guid("E7E9984F-F09F-4da4-903F-6E2E0EFE56B5"),
-        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComImport]
     interface IWMResamplerProps
     {
         /// <summary>


### PR DESCRIPTION
Hello, Thank you for maintaining this great software!
I've fixed an error when using MMDeviceEnumerator on Unity by adding `ComImport` attribute to CoreAudioApi interfaces.
I know some files are already added like that: https://github.com/naudio/NAudio/issues/350, but some interfaces are not added it.

## Issue
* Error message
```
NullReferenceException: Object reference not set to an instance of an object
NAudio.CoreAudioApi.MMDeviceEnumerator.EnumerateAudioEndPoints (NAudio.CoreAudioApi.DataFlow dataFlow, NAudio.CoreAudioApi.DeviceState dwStateMask) (at <c5f0d1c4fdd64335af6a4a446d436693>:0)
WasapiTest.Start () (at Assets/WasapiTest.cs:9)
```

* Code (Assets/WasapiTest .cs)
```csharp
01: using UnityEngine;
02: using NAudio.CoreAudioApi;
03: 
04: public class WasapiTest : MonoBehaviour
05: {
06:     void Start()
07:     {
08:         var enumerator = new MMDeviceEnumerator();
09:         var collection = enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.Active);
10:     }
11: }
```

## Test
- I checked `NAudioTests.Wasapi` tests are passed on Visual Studio 2020.
- I checked `new MMDeviceEnumerator().EnumerateAudioEndPoints()` can enumerate devices with fixed new dll on WinForms application and Unity.
