### PR TITLE
fixed WASAPI helper threads not being background

### DIFF
--- a/NAudio.Wasapi/WasapiCapture.cs
+++ b/NAudio.Wasapi/WasapiCapture.cs
@@ -187,7 +187,10 @@ namespace NAudio.CoreAudioApi
             }
             captureState = CaptureState.Starting;
             InitializeCaptureDevice();
-            captureThread = new Thread(() => CaptureThread(audioClient));
+            captureThread = new Thread(() => CaptureThread(audioClient))
+            {
+                IsBackground = true,
+            };
             captureThread.Start();
         }
 

--- a/NAudio.Wasapi/WasapiOut.cs
+++ b/NAudio.Wasapi/WasapiOut.cs
@@ -323,7 +323,10 @@ namespace NAudio.Wave
             {
                 if (playbackState == PlaybackState.Stopped)
                 {
-                    playThread = new Thread(PlayThread);
+                    playThread = new Thread(PlayThread)
+                    {
+                        IsBackground = true,
+                    };
                     playbackState = PlaybackState.Playing;
                     playThread.Start();                    
                 }


### PR DESCRIPTION
This caused the app that uses WasapiCapture and/or WasapiOut to not exit unless all instances are disposed.