### PR TITLE
fix time conversion

### DIFF
--- a/NAudio.Core/Wave/WaveStreams/WaveStream.cs
+++ b/NAudio.Core/Wave/WaveStreams/WaveStream.cs
@@ -101,7 +101,7 @@ namespace NAudio.Wave
         {
             get
             {
-                return TimeSpan.FromSeconds((double)Position / WaveFormat.AverageBytesPerSecond);                
+                return TimeSpan.FromSeconds((double)(Position / WaveFormat.AverageBytesPerSecond));
             }
             set
             {
@@ -116,7 +116,7 @@ namespace NAudio.Wave
         {
             get
             {
-                return TimeSpan.FromSeconds((double) Length / WaveFormat.AverageBytesPerSecond);
+                return TimeSpan.FromSeconds((double)(Length / WaveFormat.AverageBytesPerSecond));
             }
         }
 


### PR DESCRIPTION
Fixed a double rounding error. First integer arithmetic, then getting the time through a double value.