### PR TITLE
Need access to writer to override class to add additional chunks

### DIFF
--- a/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -140,6 +140,11 @@ namespace NAudio.Wave
         }
 
         /// <summary>
+        /// The wave writer
+        /// </summary>
+        public BinaryWriter Writer => writer;
+
+        /// <summary>
         /// The wave file name or null if not applicable
         /// </summary>
         public string Filename => filename;
@@ -353,6 +358,7 @@ namespace NAudio.Wave
                 throw new InvalidOperationException("Only 16, 24 or 32 bit PCM or IEEE float audio data supported");
             }
         }
+
 
         /// <summary>
         /// Ensures data is written to disk


### PR DESCRIPTION
I needed to add the smpl chunk to support loops when writing WAV. If anybody see how to extend the WaveFileWriter to support additional chunks without access to the private writer, please let me know!