### PR TITLE
Don't write extraSize WAV-header field for PCM data

### DIFF
--- a/NAudio.Core/Wave/WaveFormats/WaveFormat.cs
+++ b/NAudio.Core/Wave/WaveFormats/WaveFormat.cs
@@ -302,14 +302,24 @@ namespace NAudio.Wave
         /// <param name="writer">the output stream</param>
         public virtual void Serialize(BinaryWriter writer)
         {
-            writer.Write((int)(18 + extraSize)); // wave format length
+            if(Encoding == WaveFormatEncoding.Pcm)
+            {
+                writer.Write((int)(16)); // wave format length
+            }
+            else
+            {
+                writer.Write((int)(18 + extraSize)); // wave format length
+            }
             writer.Write((short)Encoding);
             writer.Write((short)Channels);
             writer.Write((int)SampleRate);
             writer.Write((int)AverageBytesPerSecond);
             writer.Write((short)BlockAlign);
             writer.Write((short)BitsPerSample);
-            writer.Write((short)extraSize);
+            if(Encoding != WaveFormatEncoding.Pcm)
+            {
+                writer.Write((short)extraSize);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #934