### PR TITLE
Changed error details for MmException

### DIFF
--- a/Docs/FadeInOutSampleProvider.md
+++ b/Docs/FadeInOutSampleProvider.md
@@ -14,6 +14,14 @@ var fade = new FadeInOutSampleProvider(audio, true);
 fade.BeginFadeIn(2000);
 ```
 
+After fade in is complete, `FadeInComplete` event is triggered:
+```c#
+fade.FadeInComplete += (sender, e) => {
+    Console.WriteLine("Fade in was done!");
+};
+fade.BeginFadeIn(2000);
+```
+
 Now we can pass our `FadeInOutSampleProvider` to an output device and start playing. We'll hear the audio fading in over the first two seconds.
 
 ```c#
@@ -25,6 +33,15 @@ waveOutDevice.Play();
 At some point in the future, we might want to fade out, and we can trigger that with `BeginFadeOut`, again specifying a 2 second fadeout. 
 
 ```c#
+fade.BeginFadeOut(2000);
+```
+
+It also triggers `FadeOutComplete` event, when fade out is complete
+
+```c#
+fade.FadeOutComplete += (sender, e) => {
+    Console.WriteLine("Fade out was done!");
+};
 fade.BeginFadeOut(2000);
 ```
 

--- a/NAudio.Asio/ASIODriverExt.cs
+++ b/NAudio.Asio/ASIODriverExt.cs
@@ -31,6 +31,9 @@ namespace NAudio.Wave.Asio
         private int bufferSize;
         private int outputChannelOffset;
         private int inputChannelOffset;
+        /// <summary>
+        /// Reset Request Callback
+        /// </summary>
         public Action ResetRequestCallback;
 
         /// <summary>

--- a/NAudio.Asio/NAudio.Asio.csproj
+++ b/NAudio.Asio/NAudio.Asio.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
+++ b/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using System.IO;
 using NAudio.Utils;
 using NAudio.Wave;
-using System.Diagnostics;
 
 namespace NAudio.FileFormats.Wav
 {
+    /// <summary>
+    /// Reader of RIFF chunks from a WAV file
+    /// </summary>
     public class WaveFileChunkReader
     {
         private WaveFormat waveFormat;
@@ -19,12 +21,18 @@ namespace NAudio.FileFormats.Wav
         private readonly bool storeAllChunks;
         private long riffSize;
 
+        /// <summary>
+        /// Creates a new WaveFileChunkReader
+        /// </summary>
         public WaveFileChunkReader()
         {
             storeAllChunks = true;
             strictMode = false;
         }
 
+        /// <summary>
+        /// Read the WAV header
+        /// </summary>
         public void ReadWaveHeader(Stream stream)
         {
             this.dataChunkPosition = -1;

--- a/NAudio.Core/MmException.cs
+++ b/NAudio.Core/MmException.cs
@@ -22,7 +22,7 @@ namespace NAudio
 
         private static string ErrorMessage(MmResult result, string function)
         {
-            return $"{result} calling {function}";
+            return $"Windows MMAPI returned \"{result}\" after call to \"{function}\"";
         }
 
         /// <summary>

--- a/NAudio.Core/NAudio.Core.csproj
+++ b/NAudio.Core/NAudio.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Mark Heath</Authors>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/NAudio.Core/Wave/SampleProviders/FadeInOutSampleProvider.cs
+++ b/NAudio.Core/Wave/SampleProviders/FadeInOutSampleProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace NAudio.Wave.SampleProviders
+﻿using System;
+
+namespace NAudio.Wave.SampleProviders
 {
     /// <summary>
     /// Sample Provider to allow fading in and out
@@ -12,6 +14,16 @@
             FullVolume,
             FadingOut,
         }
+
+        /// <summary>
+        /// Raised when scheduled fade-in is done
+        /// </summary>
+        public event EventHandler FadeInComplete;
+
+        /// <summary>
+        /// Raised when scheduled fade-out is done
+        /// </summary>
+        public event EventHandler FadeOutComplete;
 
         private readonly object lockObject = new object();
         private readonly ISampleProvider source;
@@ -108,6 +120,8 @@
                 if (fadeSamplePosition > fadeSampleCount)
                 {
                     fadeState = FadeState.Silence;
+                    FadeOutComplete?.Invoke(this, EventArgs.Empty);
+
                     // clear out the end
                     ClearBuffer(buffer, sample + offset, sourceSamplesRead - sample);
                     break;
@@ -129,6 +143,8 @@
                 if (fadeSamplePosition > fadeSampleCount)
                 {
                     fadeState = FadeState.FullVolume;
+                    FadeInComplete?.Invoke(this, EventArgs.Empty);
+
                     // no need to multiply any more
                     break;
                 }

--- a/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
+++ b/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
@@ -73,6 +73,13 @@ namespace NAudio.Wave
             
         }
 
+        /// <summary>
+        /// Constructor that takes an input stream and a frame decompressor builder
+        /// </summary>
+        /// <param name="inputStream">Input stream</param>
+        /// <param name="frameDecompressorBuilder">Factory method to build a frame decompressor</param>
+        /// <param name="ownInputStream">Whether we own the stream and should dispose it</param>
+        /// <exception cref="ArgumentNullException"></exception>
         protected Mp3FileReaderBase(Stream inputStream, FrameDecompressorBuilder frameDecompressorBuilder, bool ownInputStream)
         {
             if (inputStream == null) throw new ArgumentNullException(nameof(inputStream));

--- a/NAudio.Extras/AudioPlaybackEngine.cs
+++ b/NAudio.Extras/AudioPlaybackEngine.cs
@@ -12,6 +12,9 @@ namespace NAudio.Extras
         private readonly IWavePlayer outputDevice;
         private readonly MixingSampleProvider mixer;
 
+        /// <summary>
+        /// Audio Playback Engine
+        /// </summary>
         public AudioPlaybackEngine(int sampleRate = 44100, int channelCount = 2)
         {
             outputDevice = new WaveOutEvent();
@@ -21,6 +24,9 @@ namespace NAudio.Extras
             outputDevice.Play();
         }
 
+        /// <summary>
+        /// Fire and forget playback of sound
+        /// </summary>
         public void PlaySound(string fileName)
         {
             var input = new AudioFileReader(fileName);
@@ -40,6 +46,9 @@ namespace NAudio.Extras
             throw new NotImplementedException("Not yet implemented this channel count conversion");
         }
 
+        /// <summary>
+        /// Fire and forget playback of a cached sound
+        /// </summary>
         public void PlaySound(CachedSound sound)
         {
             AddMixerInput(new CachedSoundSampleProvider(sound));
@@ -50,6 +59,9 @@ namespace NAudio.Extras
             mixer.AddMixerInput(ConvertToRightChannelCount(input));
         }
 
+        /// <summary>
+        /// Disposes this instance
+        /// </summary>
         public void Dispose()
         {
             outputDevice.Dispose();

--- a/NAudio.Extras/AutoDisposeFileReader.cs
+++ b/NAudio.Extras/AutoDisposeFileReader.cs
@@ -11,12 +11,19 @@ namespace NAudio.Extras
     {
         private readonly ISampleProvider reader;
         private bool isDisposed;
+
+        /// <summary>
+        /// Creates a new file reader that disposes the source reader when it finishes
+        /// </summary>
         public AutoDisposeFileReader(ISampleProvider reader)
         {
             this.reader = reader;
             WaveFormat = reader.WaveFormat;
         }
 
+        /// <summary>
+        /// Reads samples from this file reader
+        /// </summary>
         public int Read(float[] buffer, int offset, int count)
         {
             if (isDisposed)
@@ -33,6 +40,9 @@ namespace NAudio.Extras
             return read;
         }
 
+        /// <summary>
+        /// The WaveFormat of this file reader
+        /// </summary>
         public WaveFormat WaveFormat { get; }
     }
 }

--- a/NAudio.Extras/CachedSound.cs
+++ b/NAudio.Extras/CachedSound.cs
@@ -9,8 +9,19 @@ namespace NAudio.Extras
     /// </summary>
     public class CachedSound
     {
+        /// <summary>
+        /// Audio data
+        /// </summary>
         public float[] AudioData { get; }
+
+        /// <summary>
+        /// Format of the audio
+        /// </summary>
         public WaveFormat WaveFormat { get; }
+
+        /// <summary>
+        /// Creates a new CachedSound from a file
+        /// </summary>
         public CachedSound(string audioFileName)
         {
             using (var audioFileReader = new AudioFileReader(audioFileName))

--- a/NAudio.Extras/Equalizer.cs
+++ b/NAudio.Extras/Equalizer.cs
@@ -18,6 +18,9 @@ namespace NAudio.Extras
         private readonly int bandCount;
         private bool updated;
 
+        /// <summary>
+        /// Creates a new Equalizer
+        /// </summary>
         public Equalizer(ISampleProvider sourceProvider, EqualizerBand[] bands)
         {
             this.sourceProvider = sourceProvider;
@@ -43,14 +46,23 @@ namespace NAudio.Extras
             }
         }
 
+        /// <summary>
+        /// Update the equalizer settings
+        /// </summary>
         public void Update()
         {
             updated = true;
             CreateFilters();
         }
 
+        /// <summary>
+        /// Gets the WaveFormat of this Sample Provider
+        /// </summary>
         public WaveFormat WaveFormat => sourceProvider.WaveFormat;
 
+        /// <summary>
+        /// Reads samples from this Sample Provider
+        /// </summary>
         public int Read(float[] buffer, int offset, int count)
         {
             int samplesRead = sourceProvider.Read(buffer, offset, count);

--- a/NAudio.Extras/EqualizerBand.cs
+++ b/NAudio.Extras/EqualizerBand.cs
@@ -1,9 +1,21 @@
 namespace NAudio.Extras
 {
+    /// <summary>
+    /// Equalizer Band
+    /// </summary>
     public class EqualizerBand
     {
+        /// <summary>
+        /// Frequency
+        /// </summary>
         public float Frequency { get; set; }
+        /// <summary>
+        /// Gain
+        /// </summary>
         public float Gain { get; set; }
+        /// <summary>
+        /// Bandwidth
+        /// </summary>
         public float Bandwidth { get; set; }
     }
 }

--- a/NAudio.Extras/NAudio.Extras.csproj
+++ b/NAudio.Extras/NAudio.Extras.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/naudio/NAudio</RepositoryUrl>
     <Copyright>© Mark Heath 2023</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <PackageIcon>naudio-icon.png</PackageIcon>
   </PropertyGroup>
 

--- a/NAudio.Extras/SampleAggregator.cs
+++ b/NAudio.Extras/SampleAggregator.cs
@@ -10,16 +10,28 @@ namespace NAudio.Extras
     /// </summary>
     public class SampleAggregator : ISampleProvider
     {
-        // volume
+        /// <summary>
+        /// Raised to indicate the maximum volume level in this period
+        /// </summary>
         public event EventHandler<MaxSampleEventArgs> MaximumCalculated;
         private float maxValue;
         private float minValue;
+        /// <summary>
+        /// Notification count, number of samples between MaximumCalculated events
+        /// </summary>
         public int NotificationCount { get; set; }
         int count;
 
-        // FFT
+        /// <summary>
+        /// Raised to indicate that a block of samples has had an FFT performed on it
+        /// </summary>
         public event EventHandler<FftEventArgs> FftCalculated;
+
+        /// <summary>
+        /// If true, performs an FFT on each block of samples
+        /// </summary>
         public bool PerformFFT { get; set; }
+
         private readonly Complex[] fftBuffer;
         private readonly FftEventArgs fftArgs;
         private int fftPos;
@@ -29,6 +41,11 @@ namespace NAudio.Extras
 
         private readonly int channels;
 
+        /// <summary>
+        /// Creates a new SampleAggregator
+        /// </summary>
+        /// <param name="source">source sample provider</param>
+        /// <param name="fftLength">FFT length, must be a power of 2</param>
         public SampleAggregator(ISampleProvider source, int fftLength = 1024)
         {
             channels = source.WaveFormat.Channels;
@@ -48,7 +65,9 @@ namespace NAudio.Extras
             return (x & (x - 1)) == 0;
         }
 
-
+        /// <summary>
+        /// Reset the volume calculation
+        /// </summary>
         public void Reset()
         {
             count = 0;
@@ -81,8 +100,14 @@ namespace NAudio.Extras
             }
         }
 
+        /// <summary>
+        /// Gets the WaveFormat of this Sample Provider
+        /// </summary>
         public WaveFormat WaveFormat => source.WaveFormat;
 
+        /// <summary>
+        /// Reads samples from this sample provider
+        /// </summary>
         public int Read(float[] buffer, int offset, int count)
         {
             var samplesRead = source.Read(buffer, offset, count);
@@ -95,25 +120,46 @@ namespace NAudio.Extras
         }
     }
 
+    /// <summary>
+    /// Max sample event args
+    /// </summary>
     public class MaxSampleEventArgs : EventArgs
     {
+        /// <summary>
+        /// Creates a new MaxSampleEventArgs
+        /// </summary>
         [DebuggerStepThrough]
         public MaxSampleEventArgs(float minValue, float maxValue)
         {
             MaxSample = maxValue;
             MinSample = minValue;
         }
+        /// <summary>
+        /// Maximum sample value in this period
+        /// </summary>
         public float MaxSample { get; private set; }
+        /// <summary>
+        /// Minimum sample value in this period
+        /// </summary>
         public float MinSample { get; private set; }
     }
 
+    /// <summary>
+    /// FFT Event Args
+    /// </summary>
     public class FftEventArgs : EventArgs
     {
+        /// <summary>
+        /// Creates a new FFTEventArgs
+        /// </summary>
         [DebuggerStepThrough]
         public FftEventArgs(Complex[] result)
         {
             Result = result;
         }
+        /// <summary>
+        /// Result of FFT
+        /// </summary>
         public Complex[] Result { get; private set; }
     }
 }

--- a/NAudio.Midi/NAudio.Midi.csproj
+++ b/NAudio.Midi/NAudio.Midi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Uap/NAudio.Uap.csproj
+++ b/NAudio.Uap/NAudio.Uap.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- https://docs.microsoft.com/en-us/windows/uwp/updates-and-versions/choose-a-uwp-version -->
     <TargetFramework>uap10.0.18362</TargetFramework>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
@@ -56,6 +56,10 @@ namespace NAudio.CoreAudioApi
             return new AudioClient((IAudioClient)audioClient2);
         }
 
+        /// <summary>
+        /// Creates a new AudioClient
+        /// </summary>
+        /// <param name="audioClientInterface"></param>
         public AudioClient(IAudioClient audioClientInterface)
         {
             this.audioClientInterface = audioClientInterface;

--- a/NAudio.Wasapi/CoreAudioApi/AudioClientStreamFlags.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClientStreamFlags.cs
@@ -54,6 +54,8 @@ namespace NAudio.CoreAudioApi
            
     }
 
+    /* not currently used
+
     /// <summary>
     /// AUDIOCLIENT_ACTIVATION_PARAMS
     /// https://docs.microsoft.com/en-us/windows/win32/api/audioclientactivationparams/ns-audioclientactivationparams-audioclient_activation_params
@@ -78,6 +80,8 @@ namespace NAudio.CoreAudioApi
         public uint TargetProcessId;
         public ProcessLoopbackMode ProcessLoopbackMode;
     }
+
+    */
 
     /// <summary>
     /// PROCESS_LOOPBACK_MODE

--- a/NAudio.Wasapi/CoreAudioApi/AudioMute.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioMute.cs
@@ -1,11 +1,11 @@
-﻿using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using NAudio.CoreAudioApi.Interfaces;
 
 namespace NAudio.CoreAudioApi
 {
+    /// <summary>
+    /// Audio Mute
+    /// </summary>
     public class AudioMute
     {
         private IAudioMute audioMuteInterface;
@@ -14,6 +14,9 @@ namespace NAudio.CoreAudioApi
             audioMuteInterface = audioMute;
         }
 
+        /// <summary>
+        /// Is Muted
+        /// </summary>
         public bool IsMuted
         {
             get

--- a/NAudio.Wasapi/CoreAudioApi/AudioVolumeLevel.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioVolumeLevel.cs
@@ -15,6 +15,9 @@ namespace NAudio.Wasapi.CoreAudioApi
             audioVolumeLevelInterface = audioVolumeLevel;
         }
 
+        /// <summary>
+        /// Channel Count
+        /// </summary>
         public uint ChannelCount
         {
             get
@@ -24,29 +27,55 @@ namespace NAudio.Wasapi.CoreAudioApi
             }
         }
 
+        /// <summary>
+        /// Get Level Range
+        /// </summary>
+        /// <param name="channel">Channel</param>
+        /// <param name="minLevelDb">Minimum Level dB</param>
+        /// <param name="maxLevelDb">Maximum Level dB</param>
+        /// <param name="stepping">Stepping</param>
         public void GetLevelRange(uint channel, out float minLevelDb, out float maxLevelDb, out float stepping)
         {
             audioVolumeLevelInterface.GetLevelRange(channel, out minLevelDb, out maxLevelDb, out stepping);
         }
 
+        /// <summary>
+        /// Get Channel Volume Level
+        /// </summary>
+        /// <param name="channel">Channel</param>
+        /// <returns>Volume Level</returns>
         public float GetLevel(uint channel)
         {
             audioVolumeLevelInterface.GetLevel(channel, out float result);
             return result;
         }
 
+        /// <summary>
+        /// Set Channel Volume Level
+        /// </summary>
+        /// <param name="channel">Channel</param>
+        /// <param name="value">Volume</param>
         public void SetLevel(uint channel, float value)
         {
             var guid = Guid.Empty;
             audioVolumeLevelInterface.SetLevel(channel, value, ref guid);
         }
 
+        /// <summary>
+        /// Sets all channels in the audio stream to the same uniform volume level, in decibels.
+        /// </summary>
+        /// <param name="value">Volume in decibels</param>
         public void SetLevelUniform(float value)
         {
             var guid = Guid.Empty;
             audioVolumeLevelInterface.SetLevelUniform(value, ref guid);
         }
 
+        /// <summary>
+        /// sets the volume levels, in decibels, of all the channels in the audio stream
+        /// </summary>
+        /// <param name="values">Volume levels in decibels</param>
+        /// <param name="channels">Channels</param>
         public void SetLevelAllChannel(float[] values, uint channels)
         {
             var guid = Guid.Empty;

--- a/NAudio.Wasapi/CoreAudioApi/Connector.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Connector.cs
@@ -102,6 +102,9 @@ namespace NAudio.CoreAudioApi
             }
         }
 
+        /// <summary>
+        /// Part
+        /// </summary>
         public Part Part
         {
             get

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceAsyncOperation.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceAsyncOperation.cs
@@ -3,11 +3,17 @@ using System.Runtime.InteropServices;
 
 namespace NAudio.Wasapi.CoreAudioApi.Interfaces
 {
+    /// <summary>
+    /// Represents an asynchronous operation activating a WASAPI interface and provides a method to retrieve the results of the activation.
+    /// </summary>
     [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("72A22D78-CDE4-431D-B8CC-843A71199B6D")]
     public interface IActivateAudioInterfaceAsyncOperation
     {
         //virtual HRESULT STDMETHODCALLTYPE GetActivateResult(/*[out]*/ _Out_  
         //  HRESULT *activateResult, /*[out]*/ _Outptr_result_maybenull_  IUnknown **activatedInterface) = 0;
+        /// <summary>
+        /// Gets the results of an asynchronous activation of a WASAPI interface initiated by an application calling the ActivateAudioInterfaceAsync function
+        /// </summary>
         void GetActivateResult([Out] out int activateResult,
                                [Out, MarshalAs(UnmanagedType.IUnknown)] out object activateInterface);
     }

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceCompletionHandler.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceCompletionHandler.cs
@@ -3,11 +3,17 @@ using System.Runtime.InteropServices;
 
 namespace NAudio.Wasapi.CoreAudioApi.Interfaces
 {
+    /// <summary>
+    /// Provides a callback to indicate that activation of a WASAPI interface is complete.
+    /// </summary>
     [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("41D949AB-9862-444A-80F6-C261334DA5EB")]
     public interface IActivateAudioInterfaceCompletionHandler
     {
         //virtual HRESULT STDMETHODCALLTYPE ActivateCompleted(/*[in]*/ _In_  
         //   IActivateAudioInterfaceAsyncOperation *activateOperation) = 0;
+        /// <summary>
+        /// Indicates that activation of a WASAPI interface is complete and results are available.
+        /// </summary>
         void ActivateCompleted(IActivateAudioInterfaceAsyncOperation activateOperation);
     }
 }

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioClient.cs
@@ -13,6 +13,16 @@ namespace NAudio.CoreAudioApi.Interfaces
         ComImport]
     public interface IAudioClient
     {
+        /// <summary>
+        /// initializes the audio stream.
+        /// </summary>
+        /// <param name="shareMode">The sharing mode for the connection. Through this parameter, the client tells the audio engine whether it wants to share the audio endpoint device with other clients.</param>
+        /// <param name="streamFlags">Flags to control creation of the stream. The client should set this parameter to 0 or to the bitwise OR of one or more of the AUDCLNT_STREAMFLAGS_XXX Constants or the AUDCLNT_SESSIONFLAGS_XXX Constants.</param>
+        /// <param name="hnsBufferDuration">The buffer capacity as a time value. This parameter is of type REFERENCE_TIME and is expressed in 100-nanosecond units. This parameter contains the buffer size that the caller requests for the buffer that the audio application will share with the audio engine (in shared mode) or with the endpoint device (in exclusive mode). If the call succeeds, the method allocates a buffer that is a least this large.</param>
+        /// <param name="hnsPeriodicity">The device period. This parameter can be nonzero only in exclusive mode. In shared mode, always set this parameter to 0. In exclusive mode, this parameter specifies the requested scheduling period for successive buffer accesses by the audio endpoint device. If the requested device period lies outside the range that is set by the device's minimum period and the system's maximum period, then the method clamps the period to that range. If this parameter is 0, the method sets the device period to its default value. To obtain the default device period, call the IAudioClient::GetDevicePeriod method. If the AUDCLNT_STREAMFLAGS_EVENTCALLBACK stream flag is set and AUDCLNT_SHAREMODE_EXCLUSIVE is set as the ShareMode, then hnsPeriodicity must be nonzero and equal to hnsBufferDuration.</param>
+        /// <param name="pFormat">Pointer to a format descriptor. This parameter must point to a valid format descriptor of type WAVEFORMATEX (or WAVEFORMATEXTENSIBLE).</param>
+        /// <param name="audioSessionGuid">Pointer to a session GUID. This parameter points to a GUID value that identifies the audio session that the stream belongs to. If the GUID identifies a session that has been previously opened, the method adds the stream to that session. If the GUID does not identify an existing session, the method opens a new session and adds the stream to that session. The stream remains a member of the same session for its lifetime. Setting this parameter to NULL is equivalent to passing a pointer to a GUID_NULL value.</param>
+        /// <returns></returns>
         [PreserveSig]
         int Initialize(AudioClientShareMode shareMode,
             AudioClientStreamFlags streamFlags,
@@ -26,28 +36,55 @@ namespace NAudio.CoreAudioApi.Interfaces
         /// </summary>
         int GetBufferSize(out uint bufferSize);
 
+        /// <summary>
+        /// retrieves the maximum latency for the current stream and can be called any time after the stream has been initialized.
+        /// </summary>
         [return: MarshalAs(UnmanagedType.I8)]
         long GetStreamLatency();
 
+        /// <summary>
+        /// retrieves the number of frames of padding in the endpoint buffer.
+        /// </summary>
         int GetCurrentPadding(out int currentPadding);
 
+        /// <summary>
+        /// Indicates whether the audio endpoint device supports a particular stream format.
+        /// </summary>
         [PreserveSig]
         int IsFormatSupported(
             AudioClientShareMode shareMode,
             [In] WaveFormat pFormat,
             IntPtr closestMatchFormat); // or outIntPtr??
 
+        /// <summary>
+        /// retrieves the stream format that the audio engine uses for its internal processing of shared-mode streams.
+        /// </summary>
         int GetMixFormat(out IntPtr deviceFormatPointer);
 
-        // REFERENCE_TIME is 64 bit int        
+        // REFERENCE_TIME is 64 bit int
+        /// <summary>
+        /// retrieves the length of the periodic interval separating successive processing passes by the audio engine on the data in the endpoint buffer.
+        /// </summary>
         int GetDevicePeriod(out long defaultDevicePeriod, out long minimumDevicePeriod);
 
+        /// <summary>
+        /// starts the audio stream.
+        /// </summary>
         int Start();
 
+        /// <summary>
+        /// stops the audio stream.
+        /// </summary>
         int Stop();
 
+        /// <summary>
+        /// resets the audio stream.
+        /// </summary>
         int Reset();
-        
+
+        /// <summary>
+        /// sets the event handle that the system signals when an audio buffer is ready to be processed by the client.
+        /// </summary>
         int SetEventHandle(IntPtr eventHandle);
 
         /// <summary>

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioVolumeLevel.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioVolumeLevel.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IControlInterface.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IControlInterface.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {
+    /// <summary>
+    /// The IControlInterface interface represents a control interface on a part (connector or subunit) in a device topology. The client obtains a reference to a part's IControlInterface interface by calling the IPart::GetControlInterface method.
+    /// </summary>
     [Guid("45d37c3f-5140-444a-ae24-400789f3cbf3"),
         InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
         ComImport]

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IPerChannelDbLevel.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IPerChannelDbLevel.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/PartType.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/PartType.cs
@@ -1,13 +1,37 @@
 ﻿namespace NAudio.CoreAudioApi.Interfaces
 {
+    /// <summary>
+    /// The PartType enumeration defines constants that indicate whether a part in a device topology is a connector or subunit.
+    /// </summary>
     public enum PartTypeEnum
     {
+        /// <summary>
+        /// Connector
+        /// </summary>
         Connector = 0,
+        /// <summary>
+        /// Subunit
+        /// </summary>
         Subunit = 1,
+        /// <summary>
+        /// Hardware Periphery
+        /// </summary>
         HardwarePeriphery = 2,
+        /// <summary>
+        /// Software Driver
+        /// </summary>
         SoftwareDriver = 3,
+        /// <summary>
+        /// Splitter
+        /// </summary>
         Splitter = 4,
+        /// <summary>
+        /// Category
+        /// </summary>
         Category = 5,
+        /// <summary>
+        /// Other
+        /// </summary>
         Other = 6
     }
 }

--- a/NAudio.Wasapi/CoreAudioApi/KsJackDescription.cs
+++ b/NAudio.Wasapi/CoreAudioApi/KsJackDescription.cs
@@ -2,6 +2,9 @@
 
 namespace NAudio.CoreAudioApi
 {
+    /// <summary>
+    /// KS Jack Description
+    /// </summary>
     public class KsJackDescription
     {
         private readonly IKsJackDescription ksJackDescriptionInterface;
@@ -11,6 +14,9 @@ namespace NAudio.CoreAudioApi
             ksJackDescriptionInterface = ksJackDescription;
         }
 
+        /// <summary>
+        /// Jack count
+        /// </summary>
         public uint Count
         {
             get
@@ -20,6 +26,9 @@ namespace NAudio.CoreAudioApi
             }
         }
 
+        /// <summary>
+        /// Get Jack Description by index
+        /// </summary>
         public string this[uint index]
         {
             get

--- a/NAudio.Wasapi/CoreAudioApi/PartsList.cs
+++ b/NAudio.Wasapi/CoreAudioApi/PartsList.cs
@@ -1,10 +1,11 @@
-﻿using NAudio.CoreAudioApi.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using NAudio.CoreAudioApi.Interfaces;
 
 namespace NAudio.CoreAudioApi
 {
+    /// <summary>
+    /// Parts List
+    /// </summary>
     public class PartsList
     {
         private IPartsList partsListInterface;
@@ -14,6 +15,9 @@ namespace NAudio.CoreAudioApi
             partsListInterface = partsList;
         }
 
+        /// <summary>
+        /// Part count
+        /// </summary>
         public uint Count
         {
             get
@@ -28,6 +32,9 @@ namespace NAudio.CoreAudioApi
             }
         }
 
+        /// <summary>
+        /// Get part by index
+        /// </summary>
         public Part this[uint index]
         {
             get

--- a/NAudio.Wasapi/MediaFoundationEncoder.cs
+++ b/NAudio.Wasapi/MediaFoundationEncoder.cs
@@ -193,6 +193,9 @@ namespace NAudio.Wave
                 .FirstOrDefault();
         }
 
+        /// <summary>
+        /// Default read buffer size
+        /// </summary>
         public int DefaultReadBufferSize { get; set; }
         private readonly MediaType outputMediaType;
         private bool disposed;

--- a/NAudio.Wasapi/NAudio.Wasapi.csproj
+++ b/NAudio.Wasapi/NAudio.Wasapi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;uap10.0.18362</TargetFrameworks>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.WinForms/NAudio.WinForms.csproj
+++ b/NAudio.WinForms/NAudio.WinForms.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.WinMM/Compression/AcmStream.cs
+++ b/NAudio.WinMM/Compression/AcmStream.cs
@@ -175,6 +175,11 @@ namespace NAudio.Wave.Compression
                 bytesToConvert -= (bytesToConvert % sourceFormat.BlockAlign);
             }
 
+            if (streamHeader == null)
+            {
+                throw new ObjectDisposedException("AcmStream has already been disposed");
+            }
+
             return streamHeader.Convert(bytesToConvert, out sourceBytesConverted);
         }
 

--- a/NAudio.WinMM/MmeInterop/MmTime.cs
+++ b/NAudio.WinMM/MmeInterop/MmTime.cs
@@ -10,36 +10,87 @@ namespace NAudio.Wave
     [StructLayout(LayoutKind.Explicit)]
     public struct MmTime
     {
+        /// <summary>
+        /// Time in milliseconds.
+        /// </summary>
         public const int TIME_MS = 0x0001;
+        /// <summary>
+        /// Number of waveform-audio samples.
+        /// </summary>
         public const int TIME_SAMPLES = 0x0002;
+        /// <summary>
+        /// Current byte offset from beginning of the file.
+        /// </summary>
         public const int TIME_BYTES = 0x0004;
 
+        /// <summary>
+        /// Time format.
+        /// </summary>
         [FieldOffset(0)]
         public UInt32 wType;
+        /// <summary>
+        /// Number of milliseconds. Used when wType is TIME_MS.
+        /// </summary>
         [FieldOffset(4)]
         public UInt32 ms;
+        /// <summary>
+        /// Number of samples. Used when wType is TIME_SAMPLES.
+        /// </summary>
         [FieldOffset(4)]
         public UInt32 sample;
+        /// <summary>
+        /// Byte count. Used when wType is TIME_BYTES.
+        /// </summary>
         [FieldOffset(4)]
         public UInt32 cb;
+        /// <summary>
+        /// Ticks in MIDI stream. Used when wType is TIME_TICKS.
+        /// </summary>
         [FieldOffset(4)]
         public UInt32 ticks;
+        /// <summary>
+        /// SMPTE time structure - hours. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(4)]
         public Byte smpteHour;
+        /// <summary>
+        /// SMPTE time structure - minutes. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(5)]
         public Byte smpteMin;
+        /// <summary>
+        /// SMPTE time structure - seconds. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(6)]
         public Byte smpteSec;
+        /// <summary>
+        /// SMPTE time structure - frames. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(7)]
         public Byte smpteFrame;
+        /// <summary>
+        /// SMPTE time structure - frames per second. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(8)]
         public Byte smpteFps;
+        /// <summary>
+        /// SMPTE time structure - dummy byte for alignment. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(9)]
         public Byte smpteDummy;
+        /// <summary>
+        /// SMPTE time structure - padding. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(10)]
         public Byte smptePad0;
+        /// <summary>
+        /// SMPTE time structure - padding. Used when wType is TIME_SMPTE.
+        /// </summary>
         [FieldOffset(11)]
         public Byte smptePad1;
+        /// <summary>
+        /// MIDI time structure. Used when wType is TIME_MIDI.
+        /// </summary>
         [FieldOffset(4)]
         public UInt32 midiSongPtrPos;
     }

--- a/NAudio.WinMM/MmeInterop/WaveInCapabilities.cs
+++ b/NAudio.WinMM/MmeInterop/WaveInCapabilities.cs
@@ -96,10 +96,22 @@ namespace NAudio.Wave
 
     }
 
+    /// <summary>
+    /// Wave Capabilities Helpers
+    /// </summary>
     public static class WaveCapabilitiesHelpers
     {
+        /// <summary>
+        /// Microsoft default manufacturer id
+        /// </summary>
         public static readonly Guid MicrosoftDefaultManufacturerId = new Guid("d5a47fa8-6d98-11d1-a21a-00a0c9223196");
+        /// <summary>
+        /// Default wave out guid
+        /// </summary>
         public static readonly Guid DefaultWaveOutGuid = new Guid("E36DC310-6D9A-11D1-A21A-00A0C9223196");
+        /// <summary>
+        /// Default wave in guid
+        /// </summary>
         public static readonly Guid DefaultWaveInGuid = new Guid("E36DC311-6D9A-11D1-A21A-00A0C9223196");
 
         /// <summary>

--- a/NAudio.WinMM/MmeInterop/WaveInterop.cs
+++ b/NAudio.WinMM/MmeInterop/WaveInterop.cs
@@ -8,6 +8,9 @@ namespace NAudio.Wave
     /// </summary>
     public class WaveInterop
     {
+        /// <summary>
+        /// WaveInOut Open Flags
+        /// </summary>
         [Flags]
         public enum WaveInOutOpenFlags
         {
@@ -46,6 +49,9 @@ namespace NAudio.Wave
         //public const int TIME_SAMPLES = 0x0002;  // number of wave samples 
         //public const int TIME_BYTES = 0x0004;  // current byte offset 
 
+        /// <summary>
+        /// Wave Message
+        /// </summary>
         public enum WaveMessage
         {
             /// <summary>
@@ -78,89 +84,179 @@ namespace NAudio.Wave
         // use the userdata as a reference
         // WaveOutProc http://msdn.microsoft.com/en-us/library/dd743869%28VS.85%29.aspx
         // WaveInProc http://msdn.microsoft.com/en-us/library/dd743849%28VS.85%29.aspx
+        /// <summary>
+        /// Wave Callback
+        /// </summary>
         public delegate void WaveCallback(IntPtr hWaveOut, WaveMessage message, IntPtr dwInstance, WaveHeader wavhdr, IntPtr dwReserved);
 
+        /// <summary>
+        /// Convert a mmio string to FOURCC
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern Int32 mmioStringToFOURCC([MarshalAs(UnmanagedType.LPStr)] String s, int flags);
 
+        /// <summary>
+        /// Get number of WaveOut devices
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern Int32 waveOutGetNumDevs();
+        /// <summary>
+        /// Prepare wave out header
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutPrepareHeader(IntPtr hWaveOut, WaveHeader lpWaveOutHdr, int uSize);
+        /// <summary>
+        /// Unprepare WaveOut header
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutUnprepareHeader(IntPtr hWaveOut, WaveHeader lpWaveOutHdr, int uSize);
+        /// <summary>
+        /// Write to WaveOut device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutWrite(IntPtr hWaveOut, WaveHeader lpWaveOutHdr, int uSize);
 
         // http://msdn.microsoft.com/en-us/library/dd743866%28VS.85%29.aspx
+        /// <summary>
+        /// Open WaveOut Device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutOpen(out IntPtr hWaveOut, IntPtr uDeviceID, WaveFormat lpFormat, WaveCallback dwCallback, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
+
+        /// <summary>
+        /// Open WaveOut Device with window callback
+        /// </summary>
         [DllImport("winmm.dll", EntryPoint = "waveOutOpen")]
         public static extern MmResult waveOutOpenWindow(out IntPtr hWaveOut, IntPtr uDeviceID, WaveFormat lpFormat, IntPtr callbackWindowHandle, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
 
+
+        /// <summary>
+        /// Reset WaveOut device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutReset(IntPtr hWaveOut);
+
+        /// <summary>
+        /// Close WaveOut device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutClose(IntPtr hWaveOut);
+
+        /// <summary>
+        /// Pause WaveOut device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutPause(IntPtr hWaveOut);
+
+        /// <summary>
+        /// Restart WaveOut device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutRestart(IntPtr hWaveOut);
 
         // http://msdn.microsoft.com/en-us/library/dd743863%28VS.85%29.aspx
+        /// <summary>
+        /// Get WaveOut device position
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutGetPosition(IntPtr hWaveOut, ref MmTime mmTime, int uSize);
 
         // http://msdn.microsoft.com/en-us/library/dd743874%28VS.85%29.aspx
+        /// <summary>
+        /// Set WaveOut device volume
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutSetVolume(IntPtr hWaveOut, int dwVolume);
 
+        /// <summary>
+        /// Get WaveOut device volume
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveOutGetVolume(IntPtr hWaveOut, out int dwVolume);
 
         // http://msdn.microsoft.com/en-us/library/dd743857%28VS.85%29.aspx
+        /// <summary>
+        /// Get WaveOut device capabilities
+        /// </summary>
         [DllImport("winmm.dll", CharSet = CharSet.Auto)]
         public static extern MmResult waveOutGetDevCaps(IntPtr deviceID, out WaveOutCapabilities waveOutCaps, int waveOutCapsSize);
 
+        /// <summary>
+        /// Get number of WaveIn devices
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern Int32 waveInGetNumDevs();
 
         // http://msdn.microsoft.com/en-us/library/dd743841%28VS.85%29.aspx
+        /// <summary>
+        /// Get WaveIn Device capabilities
+        /// </summary>
         [DllImport("winmm.dll", CharSet = CharSet.Auto)]
         public static extern MmResult waveInGetDevCaps(IntPtr deviceID, out WaveInCapabilities waveInCaps, int waveInCapsSize);
 
         // http://msdn.microsoft.com/en-us/library/dd743838%28VS.85%29.aspx
+        /// <summary>
+        /// Add WaveIn Buffer
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInAddBuffer(IntPtr hWaveIn, WaveHeader pwh, int cbwh);
+        /// <summary>
+        /// Close WaveIn device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInClose(IntPtr hWaveIn);
 
         // http://msdn.microsoft.com/en-us/library/dd743847%28VS.85%29.aspx
+        /// <summary>
+        /// Open WaveIn Device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInOpen(out IntPtr hWaveIn, IntPtr uDeviceID, WaveFormat lpFormat, WaveCallback dwCallback, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
+
+        /// <summary>
+        /// Open WaveIn Device with Window callbacks
+        /// </summary>
         [DllImport("winmm.dll", EntryPoint = "waveInOpen")]
         public static extern MmResult waveInOpenWindow(out IntPtr hWaveIn, IntPtr uDeviceID, WaveFormat lpFormat, IntPtr callbackWindowHandle, IntPtr dwInstance, WaveInOutOpenFlags dwFlags);
 
         // http://msdn.microsoft.com/en-us/library/dd743848%28VS.85%29.aspx
+        /// <summary>
+        /// Prepare WaveIn Header
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInPrepareHeader(IntPtr hWaveIn, WaveHeader lpWaveInHdr, int uSize);
 
+        /// <summary>
+        /// Unprepare WaveIn Header
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInUnprepareHeader(IntPtr hWaveIn, WaveHeader lpWaveInHdr, int uSize);
 
         // http://msdn.microsoft.com/en-us/library/dd743850%28VS.85%29.aspx
+        /// <summary>
+        /// Reset WaveIn Device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInReset(IntPtr hWaveIn);
 
         // http://msdn.microsoft.com/en-us/library/dd743851%28VS.85%29.aspx
+        /// <summary>
+        /// Start WaveIn device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInStart(IntPtr hWaveIn);
 
         // http://msdn.microsoft.com/en-us/library/dd743852%28VS.85%29.aspx
+        /// <summary>
+        /// Stop WaveIn Device
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInStop(IntPtr hWaveIn);
 
         // https://msdn.microsoft.com/en-us/library/Dd743845(v=VS.85).aspx
+        /// <summary>
+        /// Get WaveIn Device Position
+        /// </summary>
         [DllImport("winmm.dll")]
         public static extern MmResult waveInGetPosition(IntPtr hWaveIn, out MmTime mmTime, int uSize);
 

--- a/NAudio.WinMM/NAudio.WinMM.csproj
+++ b/NAudio.WinMM/NAudio.WinMM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/NAudio.WinMM/WaveOutUtils.cs
+++ b/NAudio.WinMM/WaveOutUtils.cs
@@ -4,8 +4,14 @@ using System.Runtime.InteropServices;
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave
 {
+    /// <summary>
+    /// WaveOutUtils
+    /// </summary>
     public static class WaveOutUtils
     {
+        /// <summary>
+        /// Get WaveOut Volume
+        /// </summary>
         public static float GetWaveOutVolume(IntPtr hWaveOut, object lockObject)
         {
             int stereoVolume;
@@ -18,6 +24,9 @@ namespace NAudio.Wave
             return (stereoVolume & 0xFFFF) / (float)0xFFFF;
         }
 
+        /// <summary>
+        /// Set WaveOut Volume
+        /// </summary>
         public static void SetWaveOutVolume(float value, IntPtr hWaveOut, object lockObject)
         {
             if (value < 0) throw new ArgumentOutOfRangeException(nameof(value), "Volume must be between 0.0 and 1.0");
@@ -34,6 +43,9 @@ namespace NAudio.Wave
             MmException.Try(result, "waveOutSetVolume");
         }
 
+        /// <summary>
+        /// Get position in bytes
+        /// </summary>
         public static long GetPositionBytes(IntPtr hWaveOut, object lockObject)
         {
             lock (lockObject)

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net6.0</TargetFrameworks>
-    <Version>2.2.1</Version>
+    <Version>2.2.1-SA</Version>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>NAudio, an audio library for .NET</Description>

--- a/NAudioTests/WaveStreams/FadeInOutSampleProviderTests.cs
+++ b/NAudioTests/WaveStreams/FadeInOutSampleProviderTests.cs
@@ -120,5 +120,61 @@ namespace NAudioTests.WaveStreams
             Assert.AreEqual(20, read);
             Assert.AreEqual(0, buffer[0]);
         }
+
+        [Test]
+        public void FadeInCompleteInvoked()
+        {
+            // given
+            var source = new TestSampleProvider(10, 1); // 10 samples per second
+            source.UseConstValue = true;
+            source.ConstValue = 100;
+            var fade = new FadeInOutSampleProvider(source);
+            var fadeInsCount = 0;
+            fade.FadeInComplete += (sender, e) =>
+            {
+                fadeInsCount++;
+            };
+
+            // when
+            fade.BeginFadeIn(1000);
+            
+            // then
+            float[] buffer = new float[20];
+            int read = fade.Read(buffer, 0, 20);
+            Assert.AreEqual(20, read);
+            Assert.AreEqual(0, buffer[0]); // start of fade-in
+            Assert.AreEqual(50, buffer[5]); // half-way
+            Assert.AreEqual(100, buffer[10]); // fully fade in
+            Assert.AreEqual(100, buffer[15]); // fully fade in
+            Assert.AreEqual(1, fadeInsCount); // we want one-shot event (when fade in was completed once)
+        }
+
+        [Test]
+        public void FadeOutCompleteInvoked()
+        {
+            // given
+            var source = new TestSampleProvider(10, 1); // 10 samples per second
+            source.UseConstValue = true;
+            source.ConstValue = 100;
+            var fade = new FadeInOutSampleProvider(source);
+            var fadeOutsCount = 0;
+            fade.FadeOutComplete += (sender, e) =>
+            {
+                fadeOutsCount++;
+            };
+
+            // when
+            fade.BeginFadeOut(1000);
+
+            // then
+            float[] buffer = new float[20];
+            int read = fade.Read(buffer, 0, 20);
+            Assert.AreEqual(20, read);
+            Assert.AreEqual(100, buffer[0]); // start of fade-out
+            Assert.AreEqual(50, buffer[5]); // half-way
+            Assert.AreEqual(0, buffer[10]); // fully fade out
+            Assert.AreEqual(0, buffer[15]); // fully fade out
+            Assert.AreEqual(1, fadeOutsCount); // we want one-shot event (when fade out was completed once)
+        }
     }
 }

--- a/SA_version.sh
+++ b/SA_version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+FILELIST=$(grep -rn '<Version>2.2.1</Version>' | cut -f 1 -d ':')
+for FILE in $FILELIST; do
+	echo ">>> $FILE"
+	sed 's/<Version>2.2.1<\/Version>/<Version>2.2.1-SA<\/Version>/g' -i $FILE
+done


### PR DESCRIPTION
I think current error description is vague, as all it tells is i.e. `NoDriver calling waveOutSetVolume`. The point of this pull request is to make debugging and troubleshooting easier. (especially for non-experienced library users)