### PR TITLE
Fix a bug that WasapiCapture could not use exclusive mode

### DIFF
--- a/NAudio.Wasapi/WasapiCapture.cs
+++ b/NAudio.Wasapi/WasapiCapture.cs
@@ -124,6 +124,11 @@ namespace NAudio.CoreAudioApi
 
             long requestedDuration = ReftimesPerMillisec * audioBufferMillisecondsLength;
 
+            if ((ShareMode == AudioClientShareMode.Exclusive) && !audioClient.IsFormatSupported(ShareMode, waveFormat))
+            {
+                throw new ArgumentException("Unsupported Wave Format");
+            }
+
             var streamFlags = GetAudioClientStreamFlags();
 
             // If using EventSync, setup is specific with shareMode
@@ -172,8 +177,15 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         protected virtual AudioClientStreamFlags GetAudioClientStreamFlags()
         {
-            // enable auto-convert PCM
-            return AudioClientStreamFlags.AutoConvertPcm | AudioClientStreamFlags.SrcDefaultQuality;
+            if (ShareMode == AudioClientShareMode.Shared)
+            {
+                // enable auto-convert PCM
+                return AudioClientStreamFlags.AutoConvertPcm | AudioClientStreamFlags.SrcDefaultQuality;
+            }
+            else
+            {
+                return 0;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When using exclusive mode with WasapiCapture, the InitializeCaptureDevice throws an exception.
In #819 it says "you can't use it with WASAPI exclusive mode playback", but it seems that auto convert cannot be used in exclusive mode for recording as well as playback.

```
System.ArgumentException: Value does not fall within the expected range.
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode)
   at NAudio.CoreAudioApi.AudioClient.Initialize(AudioClientShareMode shareMode, AudioClientStreamFlags streamFlags, Int64 bufferDuration, Int64 periodicity, WaveFormat waveFormat, Guid audioSessionGuid)
   at NAudio.CoreAudioApi.WasapiCapture.InitializeCaptureDevice()
   at NAudio.CoreAudioApi.WasapiCapture.StartRecording()
```