### PR TITLE
WaveOutEvent device capabilities

### DIFF
--- a/NAudio.WinMM/WaveOutEvent.cs
+++ b/NAudio.WinMM/WaveOutEvent.cs
@@ -65,6 +65,24 @@ namespace NAudio.Wave
         }
 
         /// <summary>
+        /// Returns the number of Wave Out devices available in the system
+        /// </summary>
+        public static int DeviceCount => WaveInterop.waveOutGetNumDevs();
+
+        /// <summary>
+        /// Retrieves the capabilities of a waveOut device
+        /// </summary>
+        /// <param name="devNumber">Device to test</param>
+        /// <returns>The WaveOut device capabilities</returns>
+        public static WaveOutCapabilities GetCapabilities(int devNumber)
+        {
+            var caps = new WaveOutCapabilities();
+            var structSize = Marshal.SizeOf(caps);
+            MmException.Try(WaveInterop.waveOutGetDevCaps((IntPtr)devNumber, out caps, structSize), "waveOutGetDevCaps");
+            return caps;
+        }
+
+        /// <summary>
         /// Initialises the WaveOut device
         /// </summary>
         /// <param name="waveProvider">WaveProvider to play</param>


### PR DESCRIPTION
Adding `DeviceCount` and `GetCapabilities` to `WaveOutEvent`, unifying it with `WaveInEvent`.