### PR TITLE
Docs: Fix example code in AsioPlayback.md

### DIFF
--- a/Docs/AsioPlayback.md
+++ b/Docs/AsioPlayback.md
@@ -31,7 +31,7 @@ Next, I call `Init`. This lets us pass the `IWaveProvider` or `ISampleProvider` 
 
 ```c#
 // optionally, change the starting channel for outputting audio:
-asioOut.OutputChannelOffset = 2;  
+asioOut.ChannelOffset = 2;  
 asioOut.Init(mySampleProvider);
 ```
 


### PR DESCRIPTION
I noticed that in the example code the name of the property `ChannelOffset` in `AsioOut` was wrong and fixed it.