### PR TITLE
Retrieve error text for MmResult in MmException

### DIFF
--- a/NAudio.Core/MmException.cs
+++ b/NAudio.Core/MmException.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace NAudio
 {
@@ -19,10 +21,34 @@ namespace NAudio
             Function = function;
         }
 
+        private const int ErrorTextMaxLength = 256;
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/mmeapi/nf-mmeapi-waveoutgeterrortext
+        /// <summary>
+        /// The waveOutGetErrorText function retrieves a textual description of the error identified by the given error number.
+        /// </summary>
+        /// <param name="mmrError">Error number.</param>
+        /// <param name="pszText">Pointer to a buffer to be filled with the textual error description.</param>
+        /// <param name="cchText">Size, in characters, of the buffer pointed to by pszText.</param>
+        /// <returns>Returns MMSYSERR_NOERROR if successful or an error otherwise.</returns>
+        [DllImport("winmm.dll", CharSet = CharSet.Auto)]
+        private static extern MmResult waveOutGetErrorText(MmResult mmrError, StringBuilder pszText, uint cchText);
+
+        private static string GetErrorText(MmResult result)
+        {
+            var sb = new StringBuilder(ErrorTextMaxLength);
+            var textResult = waveOutGetErrorText(result, sb, ErrorTextMaxLength);
+            if (textResult == MmResult.NoError)
+            {
+                return sb.ToString();
+            }
+
+            return textResult.ToString();
+        }
 
         private static string ErrorMessage(MmResult result, string function)
         {
-            return $"{result} calling {function}";
+            return $"{result} calling {function}: {GetErrorText(result)}";
         }
 
         /// <summary>


### PR DESCRIPTION
MmException retrieves the error text for the given MmResult and appends it to the exception message.