### PR TITLE
Bugfix ~AcmStreamHeader finalizer exception

### DIFF
--- a/NAudio.WinMM/Compression/AcmStreamHeader.cs
+++ b/NAudio.WinMM/Compression/AcmStreamHeader.cs
@@ -97,8 +97,14 @@ namespace NAudio.Wave.Compression
                 //Unprepare();
                 SourceBuffer = null;
                 DestBuffer = null;
-                hSourceBuffer.Free();
-                hDestBuffer.Free();
+                if (hSourceBuffer.IsAllocated)
+                {
+                    hSourceBuffer.Free();
+                }
+                if (hDestBuffer.IsAllocated)
+                {
+                    hDestBuffer.Free();
+                }
             }
             disposed = true;
         }


### PR DESCRIPTION
Fix application crash caused by unallocated GCHandle..Free in ~AcmStreamHeader finalizer. Occurs if corrupted data bytes cause exception during constructor.