### PR TITLE
Performance & General Housekeeping

### DIFF
--- a/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
@@ -12,6 +12,11 @@ namespace NAudio.CoreAudioApi
     /// </summary>
     public class AudioClient : IDisposable
     {
+        private static readonly Guid ID_AudioStreamVolume = new Guid("93014887-242D-4068-8A15-CF5E93B90FE3");
+        private static readonly Guid ID_AudioClockClient = new Guid("CD63314F-3FBA-4a1b-812C-EF96358728E7");
+        private static readonly Guid ID_AudioRenderClient = new Guid("F294ACFC-3146-4483-A7BF-ADDCA7C260E2");
+        private static readonly Guid ID_AudioCaptureClient = new Guid("c8adbd64-e71e-48a0-a4de-185c395cd317");
+        private static readonly Guid IID_IAudioClient2 = new Guid("726778CD-F60A-4eda-82DE-E47610CD78AA");
         private IAudioClient audioClientInterface;
         private WaveFormat mixFormat;
         private AudioRenderClient audioRenderClient;
@@ -50,8 +55,7 @@ namespace NAudio.CoreAudioApi
                                AudioClientStreamFlags.EventCallback | AudioClientStreamFlags.NoPersist,
                                10000000, 0, wfx, IntPtr.Zero);*/
                 });
-            var IID_IAudioClient2 = new Guid("726778CD-F60A-4eda-82DE-E47610CD78AA");
-            NativeMethods.ActivateAudioInterfaceAsync(deviceInterfacePath, IID_IAudioClient2, IntPtr.Zero, icbh, out var activationOperation);
+            NativeMethods.ActivateAudioInterfaceAsync(deviceInterfacePath, IID_IAudioClient2, IntPtr.Zero, icbh, out _);
             var audioClient2 = await icbh;
             return new AudioClient((IAudioClient)audioClient2);
         }
@@ -186,8 +190,7 @@ namespace NAudio.CoreAudioApi
                 }
                 if (audioStreamVolume == null)
                 {
-                    var audioStreamVolumeGuid = new Guid("93014887-242D-4068-8A15-CF5E93B90FE3");
-                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(audioStreamVolumeGuid, out var audioStreamVolumeInterface));
+                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(ID_AudioStreamVolume, out var audioStreamVolumeInterface));
                     audioStreamVolume = new AudioStreamVolume((IAudioStreamVolume)audioStreamVolumeInterface);
                 }
                 return audioStreamVolume;
@@ -203,8 +206,7 @@ namespace NAudio.CoreAudioApi
             {
                 if (audioClockClient == null)
                 {
-                    var audioClockClientGuid = new Guid("CD63314F-3FBA-4a1b-812C-EF96358728E7");
-                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(audioClockClientGuid, out var audioClockClientInterface));
+                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(ID_AudioClockClient, out var audioClockClientInterface));
                     audioClockClient = new AudioClockClient((IAudioClock)audioClockClientInterface);
                 }
                 return audioClockClient;
@@ -220,8 +222,7 @@ namespace NAudio.CoreAudioApi
             {
                 if (audioRenderClient == null)
                 {
-                    var audioRenderClientGuid = new Guid("F294ACFC-3146-4483-A7BF-ADDCA7C260E2");
-                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(audioRenderClientGuid, out var audioRenderClientInterface));
+                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(ID_AudioRenderClient, out var audioRenderClientInterface));
                     audioRenderClient = new AudioRenderClient((IAudioRenderClient)audioRenderClientInterface);
                 }
                 return audioRenderClient;
@@ -237,8 +238,7 @@ namespace NAudio.CoreAudioApi
             {
                 if (audioCaptureClient == null)
                 {
-                    var audioCaptureClientGuid = new Guid("c8adbd64-e71e-48a0-a4de-185c395cd317");
-                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(audioCaptureClientGuid, out var audioCaptureClientInterface));
+                    Marshal.ThrowExceptionForHR(audioClientInterface.GetService(ID_AudioCaptureClient, out var audioCaptureClientInterface));
                     audioCaptureClient = new AudioCaptureClient((IAudioCaptureClient)audioCaptureClientInterface);
                 }
                 return audioCaptureClient;

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDevice.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMDevice.cs
@@ -9,7 +9,7 @@ namespace NAudio.CoreAudioApi.Interfaces
     interface IMMDevice
     {
         // activationParams is a propvariant
-        int Activate(ref Guid id, ClsCtx clsCtx, IntPtr activationParams,
+        int Activate(in Guid id, ClsCtx clsCtx, IntPtr activationParams,
             [MarshalAs(UnmanagedType.IUnknown)] out object interfacePointer);
         
         int OpenPropertyStore(StorageAccessMode stgmAccess, out IPropertyStore properties);

--- a/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
@@ -44,11 +44,11 @@ namespace NAudio.CoreAudioApi
 
         #region Guids
         // ReSharper disable InconsistentNaming
-        private static Guid IID_IAudioMeterInformation = new Guid("C02216F6-8C67-4B5B-9D00-D008E73E0064");
-        private static Guid IID_IAudioEndpointVolume = new Guid("5CDF2C82-841E-4546-9722-0CF74078229A");
-        private static Guid IID_IAudioClient = new Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2");
-        private static Guid IDD_IAudioSessionManager = new Guid("BFA971F1-4D5E-40BB-935E-967039BFBEE4");
-        private static Guid IDD_IDeviceTopology = new Guid("2A07407E-6497-4A18-9787-32F79BD0D98F");
+        private static readonly Guid IID_IAudioMeterInformation = new Guid("C02216F6-8C67-4B5B-9D00-D008E73E0064");
+        private static readonly Guid IID_IAudioEndpointVolume = new Guid("5CDF2C82-841E-4546-9722-0CF74078229A");
+        private static readonly Guid IID_IAudioClient = new Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2");
+        private static readonly Guid IDD_IAudioSessionManager = new Guid("BFA971F1-4D5E-40BB-935E-967039BFBEE4");
+        private static readonly Guid IDD_IDeviceTopology = new Guid("2A07407E-6497-4A18-9787-32F79BD0D98F");
         // ReSharper restore InconsistentNaming
         #endregion
 
@@ -66,31 +66,31 @@ namespace NAudio.CoreAudioApi
 
         private AudioClient GetAudioClient()
         {
-            Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IID_IAudioClient, ClsCtx.ALL, IntPtr.Zero, out var result));
+            Marshal.ThrowExceptionForHR(deviceInterface.Activate(IID_IAudioClient, ClsCtx.ALL, IntPtr.Zero, out var result));
             return new AudioClient(result as IAudioClient);
         }
 
         private void GetAudioMeterInformation()
         {
-            Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IID_IAudioMeterInformation, ClsCtx.ALL, IntPtr.Zero, out var result));
+            Marshal.ThrowExceptionForHR(deviceInterface.Activate(IID_IAudioMeterInformation, ClsCtx.ALL, IntPtr.Zero, out var result));
             audioMeterInformation = new AudioMeterInformation(result as IAudioMeterInformation);
         }
 
         private void GetAudioEndpointVolume()
         {
-            Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IID_IAudioEndpointVolume, ClsCtx.ALL, IntPtr.Zero, out var result));
+            Marshal.ThrowExceptionForHR(deviceInterface.Activate(IID_IAudioEndpointVolume, ClsCtx.ALL, IntPtr.Zero, out var result));
             audioEndpointVolume = new AudioEndpointVolume(result as IAudioEndpointVolume);
         }
 
         private void GetAudioSessionManager()
         {
-            Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IDD_IAudioSessionManager, ClsCtx.ALL, IntPtr.Zero, out var result));
+            Marshal.ThrowExceptionForHR(deviceInterface.Activate(IDD_IAudioSessionManager, ClsCtx.ALL, IntPtr.Zero, out var result));
             audioSessionManager = new AudioSessionManager(result as IAudioSessionManager);
         }
 
         private void GetDeviceTopology()
         {
-            Marshal.ThrowExceptionForHR(deviceInterface.Activate(ref IDD_IDeviceTopology, ClsCtx.ALL, IntPtr.Zero, out var result));
+            Marshal.ThrowExceptionForHR(deviceInterface.Activate(IDD_IDeviceTopology, ClsCtx.ALL, IntPtr.Zero, out var result));
             deviceTopology = new DeviceTopology(result as IDeviceTopology);
         }
 

--- a/NAudio.Wasapi/CoreAudioApi/MMDeviceEnumerator.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDeviceEnumerator.cs
@@ -39,7 +39,7 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public MMDeviceEnumerator()
         {
-            if (System.Environment.OSVersion.Version.Major < 6)
+            if (Environment.OSVersion.Version.Major < 6)
             {
                 throw new NotSupportedException("This functionality is only supported on Windows Vista or newer.");
             }
@@ -66,7 +66,7 @@ namespace NAudio.CoreAudioApi
         /// <returns>Device</returns>
         public MMDevice GetDefaultAudioEndpoint(DataFlow dataFlow, Role role)
         {
-            Marshal.ThrowExceptionForHR(((IMMDeviceEnumerator)realEnumerator).GetDefaultAudioEndpoint(dataFlow, role, out var device));
+            Marshal.ThrowExceptionForHR(realEnumerator.GetDefaultAudioEndpoint(dataFlow, role, out var device));
             return new MMDevice(device);
         }
 
@@ -79,7 +79,7 @@ namespace NAudio.CoreAudioApi
         public bool HasDefaultAudioEndpoint(DataFlow dataFlow, Role role)
         {
             const int E_NOTFOUND = unchecked((int)0x80070490);
-            int hresult = ((IMMDeviceEnumerator)realEnumerator).GetDefaultAudioEndpoint(dataFlow, role, out var device);
+            int hresult = realEnumerator.GetDefaultAudioEndpoint(dataFlow, role, out var device);
             if (hresult == 0x0)
             {
                 Marshal.ReleaseComObject(device);
@@ -100,7 +100,7 @@ namespace NAudio.CoreAudioApi
         /// <returns>Device</returns>
         public MMDevice GetDevice(string id)
         {
-            Marshal.ThrowExceptionForHR(((IMMDeviceEnumerator)realEnumerator).GetDevice(id, out var device));
+            Marshal.ThrowExceptionForHR(realEnumerator.GetDevice(id, out var device));
             return new MMDevice(device);
         }
 

--- a/NAudio.Wasapi/CoreAudioApi/PropertyKeys.cs
+++ b/NAudio.Wasapi/CoreAudioApi/PropertyKeys.cs
@@ -84,7 +84,7 @@ namespace NAudio.CoreAudioApi
         /// <summary>
         /// PKEY _Device_IconPath
         /// </summary>
-        public static readonly PropertyKey PKEY_Device_IconPath = new PropertyKey(new Guid(unchecked((int)0x259abffc), unchecked((short)0x50a7), 0x47ce, 0xaf, 0x8, 0x68, 0xc9, 0xa7, 0xd7, 0x33, 0x66), 12);
+        public static readonly PropertyKey PKEY_Device_IconPath = new PropertyKey(new Guid(unchecked(0x259abffc), unchecked(0x50a7), 0x47ce, 0xaf, 0x8, 0x68, 0xc9, 0xa7, 0xd7, 0x33, 0x66), 12);
         /// <summary>
         /// Device description property.
         /// </summary>
@@ -92,11 +92,11 @@ namespace NAudio.CoreAudioApi
         /// <summary>
         /// Id of controller device for endpoint device property.
         /// </summary>
-        public static readonly PropertyKey PKEY_Device_ControllerDeviceId = new PropertyKey(new Guid(unchecked((int)0xb3f8fa53), unchecked((short)0x0004), 0x438e, 0x90, 0x03, 0x51, 0xa4, 0x6e, 0x13, 0x9b, 0xfc), 2);
+        public static readonly PropertyKey PKEY_Device_ControllerDeviceId = new PropertyKey(new Guid(unchecked((int)0xb3f8fa53), unchecked(0x0004), 0x438e, 0x90, 0x03, 0x51, 0xa4, 0x6e, 0x13, 0x9b, 0xfc), 2);
         /// <summary>
         /// Device interface key property.
         /// </summary>
-        public static readonly PropertyKey PKEY_Device_InterfaceKey = new PropertyKey(new Guid(unchecked((int)0x233164c8), unchecked((short)0x1b2c), 0x4c7d, 0xbc, 0x68, 0xb6, 0x71, 0x68, 0x7a, 0x25, 0x67), 1);
+        public static readonly PropertyKey PKEY_Device_InterfaceKey = new PropertyKey(new Guid(unchecked(0x233164c8), unchecked(0x1b2c), 0x4c7d, 0xbc, 0x68, 0xb6, 0x71, 0x68, 0x7a, 0x25, 0x67), 1);
         /// <summary>
         /// System-supplied device instance identification string, assigned by PnP manager, persistent across system restarts.
         /// </summary>

--- a/NAudio.Wasapi/Dmo/Effect/DmoChorus.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoChorus.cs
@@ -33,6 +33,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoChorus : IDmoEffector<DmoChorus.Params>
     {
+        private static readonly Guid ID_Chorus = new Guid("EFE6629C-81F7-4281-BD91-C9D604A95AF6");
+
         /// <summary>
         /// DMO Chorus Params
         /// </summary>
@@ -265,42 +267,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO Chorus
         /// </summary>
         public DmoChorus()
         {
-            var guidChorus = new Guid("EFE6629C-81F7-4281-BD91-C9D604A95AF6");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidChorus));
+                Equals(descriptor.Clsid, ID_Chorus));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject) mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
-                effectParams = new Params((IDirectSoundFXChorus) mediaComObject);
+                MediaObject = new MediaObject((IMediaObject) mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
+                EffectParams = new Params((IDirectSoundFXChorus) mediaComObject);
             }
         }
 
@@ -309,8 +305,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoCompressor.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoCompressor.cs
@@ -32,6 +32,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoCompressor : IDmoEffector<DmoCompressor.Params>
     {
+        private static readonly Guid Id_Compressor = new Guid("EF011F79-4000-406D-87AF-BFFB3FC39D57");
+
         /// <summary>
         /// DMO Compressor Params
         /// </summary>
@@ -242,42 +244,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO Compressor
         /// </summary>
         public DmoCompressor()
         {
-            var guidChorus = new Guid("EF011F79-4000-406D-87AF-BFFB3FC39D57");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidChorus));
+                Equals(descriptor.Clsid, Id_Compressor));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject)mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
-                effectParams = new Params((IDirectSoundFXCompressor)mediaComObject);
+                MediaObject = new MediaObject((IMediaObject)mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
+                EffectParams = new Params((IDirectSoundFXCompressor)mediaComObject);
             }
         }
 
@@ -286,8 +282,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoDistortion.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoDistortion.cs
@@ -31,6 +31,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoDistortion : IDmoEffector<DmoDistortion.Params>
     {
+        private static readonly Guid Id_Distortion = new Guid("EF114C90-CD1D-484E-96E5-09CFAF912A21");
+
         /// <summary>
         /// DMO Distortion Params
         /// </summary>
@@ -210,42 +212,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO Distortion
         /// </summary>
         public DmoDistortion()
         {
-            var guidDistortion = new Guid("EF114C90-CD1D-484E-96E5-09CFAF912A21");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidDistortion));
+                Equals(descriptor.Clsid, Id_Distortion));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject)mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
-                effectParams = new Params((IDirectSoundFXDistortion)mediaComObject);
+                MediaObject = new MediaObject((IMediaObject)mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
+                EffectParams = new Params((IDirectSoundFXDistortion)mediaComObject);
             }
         }
 
@@ -254,8 +250,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoEcho.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoEcho.cs
@@ -31,6 +31,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoEcho : IDmoEffector<DmoEcho.Params>
     {
+        private static readonly Guid Id_Echo = new Guid("EF3E932C-D40B-4F51-8CCF-3F98F1B29D5D");
+
         /// <summary>
         /// DMO Echo Params
         /// </summary>
@@ -205,42 +207,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO Echo
         /// </summary>
         public DmoEcho()
         {
-            var guidEcho = new Guid("EF3E932C-D40B-4F51-8CCF-3F98F1B29D5D");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidEcho));
+                Equals(descriptor.Clsid, Id_Echo));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject) mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
-                effectParams = new Params((IDirectSoundFXEcho) mediaComObject);
+                MediaObject = new MediaObject((IMediaObject) mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
+                EffectParams = new Params((IDirectSoundFXEcho) mediaComObject);
             }
         }
 
@@ -249,8 +245,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoFlanger.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoFlanger.cs
@@ -33,6 +33,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoFlanger : IDmoEffector<DmoFlanger.Params>
     {
+        private static readonly Guid Id_Flanger = new Guid("EFCA3D92-DFD8-4672-A603-7420894BAD98");
+
         /// <summary>
         /// DMO Flanger Params
         /// </summary>
@@ -265,42 +267,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO Flanger
         /// </summary>
         public DmoFlanger()
         {
-            var guidFlanger = new Guid("EFCA3D92-DFD8-4672-A603-7420894BAD98");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidFlanger));
+                Equals(descriptor.Clsid, Id_Flanger));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject)mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
-                effectParams = new Params((IDirectSoundFXFlanger)mediaComObject);
+                MediaObject = new MediaObject((IMediaObject)mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
+                EffectParams = new Params((IDirectSoundFXFlanger)mediaComObject);
             }
         }
 
@@ -309,8 +305,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoGargle.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoGargle.cs
@@ -28,6 +28,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoGargle : IDmoEffector<DmoGargle.Params>
     {
+        private static readonly Guid Id_Gargle = new Guid("DAFD8210-5711-4B91-9FE3-F75B7AE279BF");
+
         /// <summary>
         /// DMO Gargle Params
         /// </summary>
@@ -109,42 +111,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO Gargle
         /// </summary>
         public DmoGargle()
         {
-            var guidGargle = new Guid("DAFD8210-5711-4B91-9FE3-F75B7AE279BF");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidGargle));
+                Equals(descriptor.Clsid, Id_Gargle));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject) mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
-                effectParams = new Params((IDirectSoundFXGargle) mediaComObject);
+                MediaObject = new MediaObject((IMediaObject) mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
+                EffectParams = new Params((IDirectSoundFXGargle) mediaComObject);
             }
         }
 
@@ -153,8 +149,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoI3DL2Reverb.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoI3DL2Reverb.cs
@@ -50,6 +50,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoI3DL2Reverb : IDmoEffector<DmoI3DL2Reverb.Params>
     {
+        private static readonly Guid Id_I3DL2Reverb = new Guid("EF985E71-D5C7-42D4-BA4D-2D073E2E96F4");
+
         /// <summary>
         /// DMO I3DL2Reverb Params
         /// </summary>
@@ -492,42 +494,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO I3DL2Reverb
         /// </summary>
         public DmoI3DL2Reverb()
         {
-            var guidi3Dl2Reverb = new Guid("EF985E71-D5C7-42D4-BA4D-2D073E2E96F4");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidi3Dl2Reverb));
+                Equals(descriptor.Clsid, Id_I3DL2Reverb));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject)mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
-                effectParams = new Params((IDirectSoundFXI3DL2Reverb)mediaComObject);
+                MediaObject = new MediaObject((IMediaObject)mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace)mediaComObject);
+                EffectParams = new Params((IDirectSoundFXI3DL2Reverb)mediaComObject);
             }
         }
 
@@ -536,8 +532,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoParamEq.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoParamEq.cs
@@ -29,6 +29,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoParamEq : IDmoEffector<DmoParamEq.Params>
     {
+        private static readonly Guid Id_ParamEq = new Guid("120CED89-3BF4-4173-A132-3CB406CF3231");
+
         /// <summary>
         /// DMO ParamEq Params
         /// </summary>
@@ -146,42 +148,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO ParamEq
         /// </summary>
         public DmoParamEq()
         {
-            var guidParamEq = new Guid("120CED89-3BF4-4173-A132-3CB406CF3231");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidParamEq));
+                Equals(descriptor.Clsid, Id_ParamEq));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject) mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
-                effectParams = new Params((IDirectSoundFxParamEq) mediaComObject);
+                MediaObject = new MediaObject((IMediaObject) mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
+                EffectParams = new Params((IDirectSoundFxParamEq) mediaComObject);
             }
         }
 
@@ -190,8 +186,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/Dmo/Effect/DmoWavesReverb.cs
+++ b/NAudio.Wasapi/Dmo/Effect/DmoWavesReverb.cs
@@ -30,6 +30,8 @@ namespace NAudio.Dmo.Effect
     /// </summary>
     public class DmoWavesReverb : IDmoEffector<DmoWavesReverb.Params>
     {
+        private static readonly Guid Id_WavesReverb = new Guid("87FC0268-9A55-4360-95AA-004A1D9DE26C");
+
         /// <summary>
         /// DMO Reverb Params
         /// </summary>
@@ -178,42 +180,36 @@ namespace NAudio.Dmo.Effect
             }
         }
 
-        private readonly MediaObject mediaObject;
-        private readonly MediaObjectInPlace mediaObjectInPlace;
-        private readonly Params effectParams;
-
         /// <summary>
         /// Media Object
         /// </summary>
-        public MediaObject MediaObject => mediaObject;
+        public MediaObject MediaObject { get; }
 
         /// <summary>
         /// Media Object InPlace
         /// </summary>
-        public MediaObjectInPlace MediaObjectInPlace => mediaObjectInPlace;
+        public MediaObjectInPlace MediaObjectInPlace { get; }
 
         /// <summary>
         /// Effect Parameter
         /// </summary>
-        public Params EffectParams => effectParams;
+        public Params EffectParams { get; }
 
         /// <summary>
         /// Create new DMO WavesReverb
         /// </summary>
         public DmoWavesReverb()
         {
-            var guidWavesReverb = new Guid("87FC0268-9A55-4360-95AA-004A1D9DE26C");
-
             var targetDescriptor = DmoEnumerator.GetAudioEffectNames().First(descriptor =>
-                Equals(descriptor.Clsid, guidWavesReverb));
+                Equals(descriptor.Clsid, Id_WavesReverb));
 
             if (targetDescriptor != null)
             {
                 var mediaComObject = Activator.CreateInstance(Type.GetTypeFromCLSID(targetDescriptor.Clsid));
 
-                mediaObject = new MediaObject((IMediaObject) mediaComObject);
-                mediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
-                effectParams = new Params((IDirectSoundFXWavesReverb) mediaComObject);
+                MediaObject = new MediaObject((IMediaObject) mediaComObject);
+                MediaObjectInPlace = new MediaObjectInPlace((IMediaObjectInPlace) mediaComObject);
+                EffectParams = new Params((IDirectSoundFXWavesReverb) mediaComObject);
             }
         }
 
@@ -222,8 +218,8 @@ namespace NAudio.Dmo.Effect
         /// </summary>
         public void Dispose()
         {
-            mediaObjectInPlace?.Dispose();
-            mediaObject?.Dispose();
+            MediaObjectInPlace?.Dispose();
+            MediaObject?.Dispose();
         }
     }
 }

--- a/NAudio.Wasapi/MediaFoundation/MediaFoundationErrors.cs
+++ b/NAudio.Wasapi/MediaFoundation/MediaFoundationErrors.cs
@@ -316,7 +316,7 @@ namespace NAudio.MediaFoundation
         ///
         /// This callback and state had already been passed in to this event generator earlier.%0
         ///
-        public const int MF_S_MULTIPLE_BEGIN              = unchecked((int) 0x000D36D8);
+        public const int MF_S_MULTIPLE_BEGIN              = unchecked(0x000D36D8);
 
         ///
         /// MessageId: MF_E_MULTIPLE_BEGIN
@@ -640,7 +640,7 @@ namespace NAudio.MediaFoundation
         ///
         /// The activate could not be created in the remote process for some reason it was replaced with empty one.%0
         ///
-        public const int MF_S_ACTIVATE_REPLACED           = unchecked((int) 0x000D36FD);
+        public const int MF_S_ACTIVATE_REPLACED           = unchecked(0x000D36FD);
 
         ///
         /// MessageId: MF_E_FORMAT_CHANGE_NOT_SUPPORTED
@@ -715,7 +715,7 @@ namespace NAudio.MediaFoundation
         ///
         /// Parsing is still in progress and is not yet complete.%0
         ///
-        public const int MF_S_ASF_PARSEINPROGRESS         = unchecked((int) 0x400D3A98);
+        public const int MF_S_ASF_PARSEINPROGRESS         = unchecked(0x400D3A98);
         #endregion
 
         #region MEDIAFOUNDATION ASF Parsing Error Events
@@ -1093,7 +1093,7 @@ namespace NAudio.MediaFoundation
         ///
         /// The proxy setting is manual.%0
         ///
-        public const int MF_I_MANUAL_PROXY                = unchecked((int) 0x400D4272);
+        public const int MF_I_MANUAL_PROXY                = unchecked(0x400D4272);
 
         ///duplicate removed
         ///MessageId=17011 Severity=Informational Facility=MEDIAFOUNDATION SymbolicName=MF_E_INVALID_REQUEST
@@ -1581,7 +1581,7 @@ namespace NAudio.MediaFoundation
         ///
         /// The sink has not been finalized before shut down. This may cause sink generate a corrupted content.%0
         ///
-        public const int MF_S_SINK_NOT_FINALIZED          = unchecked((int) 0x000D4A42);
+        public const int MF_S_SINK_NOT_FINALIZED          = unchecked(0x000D4A42);
 
         ///
         /// MessageId: MF_E_METADATA_TOO_LONG
@@ -1832,7 +1832,7 @@ namespace NAudio.MediaFoundation
         ///
         /// The context was canceled.%0\n.
         ///
-        public const int MF_S_SEQUENCER_CONTEXT_CANCELED  = unchecked((int) 0x000D61AD);
+        public const int MF_S_SEQUENCER_CONTEXT_CANCELED  = unchecked(0x000D61AD);
 
         ///
         /// MessageId: MF_E_NO_SOURCE_IN_CACHE
@@ -1850,7 +1850,7 @@ namespace NAudio.MediaFoundation
         ///
         /// Cannot update topology flags.%0\n.
         ///
-        public const int MF_S_SEQUENCER_SEGMENT_AT_END_OF_STREAM = unchecked((int) 0x000D61AF);
+        public const int MF_S_SEQUENCER_SEGMENT_AT_END_OF_STREAM = unchecked(0x000D61AF);
         #endregion
         #region Transform errors
 
@@ -2041,7 +2041,7 @@ namespace NAudio.MediaFoundation
         ///
         /// The caller should not propagate this event to downstream components.%0
         ///
-        public const int MF_S_TRANSFORM_DO_NOT_PROPAGATE_EVENT = unchecked((int) 0x000D6D75);
+        public const int MF_S_TRANSFORM_DO_NOT_PROPAGATE_EVENT = unchecked(0x000D6D75);
 
         ///
         /// MessageId: MF_E_UNSUPPORTED_D3D_TYPE
@@ -2152,7 +2152,7 @@ namespace NAudio.MediaFoundation
         ///
         /// Protection for stream is not required.%0
         ///
-        public const int MF_S_PROTECTION_NOT_REQUIRED     = unchecked((int) 0x000D7150);
+        public const int MF_S_PROTECTION_NOT_REQUIRED     = unchecked(0x000D7150);
 
         ///
         /// MessageId: MF_E_COMPONENT_REVOKED
@@ -2350,7 +2350,7 @@ namespace NAudio.MediaFoundation
         ///
         /// Protection for this stream is not guaranteed to be enforced until the MEPolicySet event is fired.%0
         ///
-        public const int MF_S_WAIT_FOR_POLICY_SET         = unchecked((int) 0x000D7168);
+        public const int MF_S_WAIT_FOR_POLICY_SET         = unchecked(0x000D7168);
 
         ///
         /// MessageId: MF_S_VIDEO_DISABLED_WITH_UNKNOWN_SOFTWARE_OUTPUT
@@ -2359,7 +2359,7 @@ namespace NAudio.MediaFoundation
         ///
         /// This video stream is disabled because it is being sent to an unknown software output.%0
         ///
-        public const int MF_S_VIDEO_DISABLED_WITH_UNKNOWN_SOFTWARE_OUTPUT = unchecked((int) 0x000D7169);
+        public const int MF_S_VIDEO_DISABLED_WITH_UNKNOWN_SOFTWARE_OUTPUT = unchecked(0x000D7169);
 
         ///
         /// MessageId: MF_E_GRL_INVALID_FORMAT
@@ -2440,7 +2440,7 @@ namespace NAudio.MediaFoundation
         ///
         /// The Protected Environment is trusted.%0
         ///
-        public const int MF_S_PE_TRUSTED                  = unchecked((int) 0x000D7173);
+        public const int MF_S_PE_TRUSTED                  = unchecked(0x000D7173);
 
         ///
         /// MessageId: MF_E_PE_UNTRUSTED
@@ -2623,7 +2623,7 @@ namespace NAudio.MediaFoundation
         ///
         /// Timer::SetTimer returns this success code if called happened while timer is stopped. Timer is not going to be dispatched until clock is running%0
         ///
-        public const int MF_S_CLOCK_STOPPED               = unchecked((int) 0x000D9C44);
+        public const int MF_S_CLOCK_STOPPED               = unchecked(0x000D9C44);
         #endregion
         #region MF Quality Management errors
 

--- a/NAudio.Wasapi/WasapiOut.cs
+++ b/NAudio.Wasapi/WasapiOut.cs
@@ -453,8 +453,8 @@ namespace NAudio.Wave
 
                         // Calculate the new latency.
                         long newLatencyRefTimes = (long)(10000000.0 /
-                            (double)this.OutputWaveFormat.SampleRate *
-                            (double)this.audioClient.BufferSize + 0.5);
+                            this.OutputWaveFormat.SampleRate *
+                            this.audioClient.BufferSize + 0.5);
 
                         this.audioClient.Dispose();
                         this.audioClient = this.mmDevice.AudioClient;


### PR DESCRIPTION
- Moves reused Guids to the static scope (Other files do this already)
- Removes some redundant type casts in `NAudio.Wasapi`
- Removes redundant backing field usages in `NAudio.Wasapi`

Feel free to cherry pick commits ;)
I would like to ask for some clarification on code style. Perhaps add a `.editorconfig` for future contributors. There's a __lot__ of instances where `var` is used on simple types but then full type names are used in other places eg. `int`