### PR TITLE
Wasapi PropertyStore - Significantly improve performance on accessing properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,10 @@ _ReSharper*/
 *.ncrunchproject
 *.orig
 *.lock.json
+# Jetbrains
+*.idea
 .vs/
 .fake/
 # cake:
 Tools/
+*.DotSettings

--- a/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
@@ -187,12 +187,10 @@ namespace NAudio.CoreAudioApi
                 {
                     GetPropertyInformation();
                 }
-                if (propertyStore.Contains(PropertyKeys.PKEY_Device_FriendlyName))
-                {
-                    return (string)propertyStore[PropertyKeys.PKEY_Device_FriendlyName].Value;
-                }
-                else
-                    return "Unknown";
+
+                return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_Device_FriendlyName, out var value) 
+                    ? value 
+                    : "Unknown";
             }
         }
 
@@ -207,14 +205,10 @@ namespace NAudio.CoreAudioApi
                 {
                     GetPropertyInformation();
                 }
-                if (propertyStore.Contains(PropertyKeys.PKEY_DeviceInterface_FriendlyName))
-                {
-                    return (string)propertyStore[PropertyKeys.PKEY_DeviceInterface_FriendlyName].Value;
-                }
-                else
-                {
-                    return "Unknown";
-                }
+                
+                return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_DeviceInterface_FriendlyName, out var value)
+                    ? value
+                    : "Unknown";
             }
         }
 
@@ -229,12 +223,10 @@ namespace NAudio.CoreAudioApi
                 {
                     GetPropertyInformation();
                 }
-                if (propertyStore.Contains(PropertyKeys.PKEY_Device_IconPath))
-                {
-                    return (string)propertyStore[PropertyKeys.PKEY_Device_IconPath].Value;
-                }
-
-                return "Unknown";
+                
+                return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_Device_IconPath, out var value)
+                    ? value
+                    : "Unknown";
             }
         }
 
@@ -249,12 +241,10 @@ namespace NAudio.CoreAudioApi
                 {
                     GetPropertyInformation();
                 }
-                if (propertyStore.Contains(PropertyKeys.PKEY_Device_InstanceId))
-                {
-                    return (string)propertyStore[PropertyKeys.PKEY_Device_InstanceId].Value;
-                }
-
-                return "Unknown";
+                
+                return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_Device_InstanceId, out var value)
+                    ? value
+                    : "Unknown";
             }
         }
 

--- a/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
@@ -170,10 +170,15 @@ namespace NAudio.CoreAudioApi
         {
             get
             {
-                if (propertyStore == null)
-                    GetPropertyInformation();
+                EnsurePropertyStoreExists();
                 return propertyStore;
             }
+        }
+
+        private void EnsurePropertyStoreExists()
+        {
+            if (propertyStore == null)
+                GetPropertyInformation();
         }
 
         /// <summary>
@@ -183,10 +188,7 @@ namespace NAudio.CoreAudioApi
         {
             get
             {
-                if (propertyStore == null)
-                {
-                    GetPropertyInformation();
-                }
+                EnsurePropertyStoreExists();
 
                 return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_Device_FriendlyName, out var value) 
                     ? value 
@@ -201,10 +203,7 @@ namespace NAudio.CoreAudioApi
         {
             get
             {
-                if (propertyStore == null)
-                {
-                    GetPropertyInformation();
-                }
+                EnsurePropertyStoreExists();
                 
                 return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_DeviceInterface_FriendlyName, out var value)
                     ? value
@@ -219,10 +218,7 @@ namespace NAudio.CoreAudioApi
         {
             get
             {
-                if (propertyStore == null)
-                {
-                    GetPropertyInformation();
-                }
+                EnsurePropertyStoreExists();
                 
                 return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_Device_IconPath, out var value)
                     ? value
@@ -237,10 +233,7 @@ namespace NAudio.CoreAudioApi
         {
             get
             {
-                if (propertyStore == null)
-                {
-                    GetPropertyInformation();
-                }
+                EnsurePropertyStoreExists();
                 
                 return propertyStore.TryGetValue<string>(PropertyKeys.PKEY_Device_InstanceId, out var value)
                     ? value

--- a/NAudio.Wasapi/CoreAudioApi/PropertyStoreProperty.cs
+++ b/NAudio.Wasapi/CoreAudioApi/PropertyStoreProperty.cs
@@ -28,7 +28,7 @@ namespace NAudio.CoreAudioApi
     /// <summary>
     /// Property Store Property
     /// </summary>
-    public class PropertyStoreProperty
+    public struct PropertyStoreProperty
     {
         private PropVariant propertyValue;
 


### PR DESCRIPTION
Addresses #1205.

- 650-1250x improvement (130 - 250ms -> 0.2ms) on accessing properties from the [PropertyStore](https://github.com/naudio/NAudio/blob/master/NAudio.Wasapi/CoreAudioApi/PropertyStore.c) which is used by [MMDevice](https://github.com/naudio/NAudio/blob/master/NAudio.Wasapi/CoreAudioApi/MMDevice.cs)

Feel free to cherry pick commits ;)