### PR TITLE
Implement Wasapi Process Specific Audio Capture

### DIFF
--- a/NAudio.Wasapi/WasapiCapture.cs
+++ b/NAudio.Wasapi/WasapiCapture.cs
@@ -18,6 +18,7 @@ namespace NAudio.CoreAudioApi
     {
         private const long ReftimesPerSec = 10000000;
         private const long ReftimesPerMillisec = 10000;
+        private const int FALLBACK_BUFFER_LENGTH = 10000;
         private volatile CaptureState captureState;
         private byte[] recordBuffer;
         private Thread captureThread;
@@ -227,7 +228,17 @@ namespace NAudio.CoreAudioApi
 
             var bufferFrameCount = audioClient.BufferSize;
             bytesPerFrame = waveFormat.Channels * waveFormat.BitsPerSample / 8;
-            recordBuffer = new byte[bufferFrameCount * bytesPerFrame];
+            var bufferSize = bufferFrameCount * bytesPerFrame;
+
+            if (bufferSize < 1)
+            {
+                var fallbackSize = FALLBACK_BUFFER_LENGTH * bytesPerFrame;
+                // System.Diagnostics.Debug.WriteLine("Buffer Size is faulted, The size is {0}, using fallback size instead {1}", bufferSize, fallbackSize);
+                // Console.WriteLine("[!] Playback Buffer is Faulted");
+                bufferSize = fallbackSize;
+            }
+            
+            recordBuffer = new byte[bufferSize];
             
             //Debug.WriteLine(string.Format("record buffer size = {0}", this.recordBuffer.Length));
 
@@ -291,6 +302,8 @@ namespace NAudio.CoreAudioApi
         {
             //Debug.WriteLine(String.Format("Client buffer frame count: {0}", client.BufferSize));
             var bufferFrameCount = client.BufferSize;
+            if (bufferFrameCount < 1) // BufferSize is faulted
+                bufferFrameCount = FALLBACK_BUFFER_LENGTH;
 
             // Calculate the actual duration of the allocated buffer.
             var actualDuration = (long)((double)ReftimesPerSec *

--- a/NAudio.Wasapi/WasapiCapture.cs
+++ b/NAudio.Wasapi/WasapiCapture.cs
@@ -78,6 +78,7 @@ namespace NAudio.CoreAudioApi
         public WasapiCapture(MMDevice captureDevice, bool useEventSync, int audioBufferMillisecondsLength)
             : this(captureDevice.AudioClient, useEventSync, audioBufferMillisecondsLength)
         {
+            waveFormat = audioClient.MixFormat;
         }
 
 
@@ -90,7 +91,6 @@ namespace NAudio.CoreAudioApi
             this.audioBufferMillisecondsLength = audioBufferMillisecondsLength;
             // enable auto-convert PCM
             this.audioClientStreamFlags = AudioClientStreamFlags.AutoConvertPcm | AudioClientStreamFlags.SrcDefaultQuality;
-            waveFormat = audioClient.MixFormat;
         }
 
         public static async Task<WasapiCapture> CreateForProcessCaptureAsync(int processId, bool includeProcessTree)

--- a/NAudio.Wasapi/WasapiCapture.cs
+++ b/NAudio.Wasapi/WasapiCapture.cs
@@ -189,7 +189,7 @@ namespace NAudio.CoreAudioApi
             if (initialized)
                 return;
 
-            long requestedDuration = ReftimesPerMillisec * audioBufferMillisecondsLength;
+            var requestedDuration = ReftimesPerMillisec * audioBufferMillisecondsLength;
 
             var streamFlags = GetAudioClientStreamFlags();
 
@@ -225,7 +225,7 @@ namespace NAudio.CoreAudioApi
                 Guid.Empty);
             }
 
-            int bufferFrameCount = audioClient.BufferSize;
+            var bufferFrameCount = audioClient.BufferSize;
             bytesPerFrame = waveFormat.Channels * waveFormat.BitsPerSample / 8;
             recordBuffer = new byte[bufferFrameCount * bytesPerFrame];
             
@@ -290,13 +290,13 @@ namespace NAudio.CoreAudioApi
         private void DoRecording(AudioClient client)
         {
             //Debug.WriteLine(String.Format("Client buffer frame count: {0}", client.BufferSize));
-            int bufferFrameCount = client.BufferSize;
+            var bufferFrameCount = client.BufferSize;
 
             // Calculate the actual duration of the allocated buffer.
-            long actualDuration = (long)((double)ReftimesPerSec *
+            var actualDuration = (long)((double)ReftimesPerSec *
                              bufferFrameCount / waveFormat.SampleRate);
-            int sleepMilliseconds = (int)(actualDuration / ReftimesPerMillisec / 2);
-            int waitMilliseconds = (int)(3 * actualDuration / ReftimesPerMillisec);
+            var sleepMilliseconds = (int)(actualDuration / ReftimesPerMillisec / 2);
+            var waitMilliseconds = (int)(3 * actualDuration / ReftimesPerMillisec);
 
             var capture = client.AudioCaptureClient;
             client.Start();
@@ -339,19 +339,19 @@ namespace NAudio.CoreAudioApi
 
         private void ReadNextPacket(AudioCaptureClient capture)
         {
-            int packetSize = capture.GetNextPacketSize();
-            int recordBufferOffset = 0;
+            var packetSize = capture.GetNextPacketSize();
+            var recordBufferOffset = 0;
             //Debug.WriteLine(string.Format("packet size: {0} samples", packetSize / 4));
 
             while (packetSize != 0)
             {
-                IntPtr buffer = capture.GetBuffer(out int framesAvailable, out AudioClientBufferFlags flags);
+                var buffer = capture.GetBuffer(out var framesAvailable, out var flags);
 
-                int bytesAvailable = framesAvailable * bytesPerFrame;
+                var bytesAvailable = framesAvailable * bytesPerFrame;
 
                 // apparently it is sometimes possible to read more frames than we were expecting?
                 // fix suggested by Michael Feld:
-                int spaceRemaining = Math.Max(0, recordBuffer.Length - recordBufferOffset);
+                var spaceRemaining = Math.Max(0, recordBuffer.Length - recordBufferOffset);
                 if (spaceRemaining < bytesAvailable && recordBufferOffset > 0)
                 {
                     DataAvailable?.Invoke(this, new WaveInEventArgs(recordBuffer, recordBufferOffset));


### PR DESCRIPTION
This work follows off-of @markheath's [process-audio-capture](https://github.com/naudio/NAudio/tree/process-audio-capture) branch and so, the PR **targets the same branch** for merging instead of master.

Modified files:

- #### `NAudio.Wasapi\CoreAudioApi\AudioClient.cs`
During tests for process specific audio capture, I stumbled on BufferSize returning invalid values sometimes. The change allows you to set a breakpoint to monitor for these invalid values. i.e negative buffer sizes or 0 sized buffer sizes. This is an issue that presents itself in the current implementation of it but is mitigated by detecting this and setting a fallback size buffer. We'll continue on this issue in the next modified file excerpt. 

MixFormat bugfix:
The `HRESULT` check prevents an access violation if the MixFormat is not supported.
0x80004001 (`E_NOTIMPL`) is larger than an int  and overflows into the negative (`-2147467263`). We check for `-0x7FFFBFFF` which is simply the hex version of `-0x7FFFBFFF` as an int.

- #### `NAudio.Wasapi\WasapiCapture.cs`

The `waveFormat` is unsupported in Wasapi Process Capture. We simply remove it from the root constructor and put it into the closest reasonable constructor that does need it (Wasapi Capture uses the root constructor that other public constructors forward into).

The fallback buffer implementation: During testing, very rarely, I would get a negative or zero buffer size for Wasapi Capture. I believe this could have been a bug in certain Windows builds as I haven't experienced it on build 26100 going forward. If I remember correctly the largest observed size the buffer needed was somewhere upwards of 10k bytes. The fallback buffer is considerably larger (around 2.4mb). This mitigation prevents process specific audio capture from simply playing back nothing and saving nothing when recording process audio. The reason for such a large fallback buffer is because the type for `audioClient.BufferSize` is int while the underlying COM implementation is a uint. Any negative buffer sizes can be accounted as a really large buffer size (bigger than int.MaxValue) This is still believed to be a bug on certain Windows builds and would certainly break C# builds if we use uint for array sizes since we can't even do `new byte[int.MaxValue]` let alone something bigger than that.
Sticking with int is a good call here and just to use a fallback buffer.

Lastly, we change from using AllocHGlobal in `public static async Task<WasapiCapture> CreateForProcessCaptureAsync(int processId, bool includeProcessTree)` to using GCHandle.Alloc instead. We also use the GUID attached to the IAudioClient interface as we don't need to re-create GUIDS every single time.

```diff
- var IID_IAudioClient = new Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2");
- NativeMethods.ActivateAudioInterfaceAsync(VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK, IID_IAudioClient, propVariant, icbh, out var activationOperation);
+ NativeMethods.ActivateAudioInterfaceAsync(VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK, typeof(IAudioClient).GUID, hActivateParams.AddrOfPinnedObject(), icbh, out var activationOperation);
```

Addresses #878 in which we go into more detail on the reasoning behind much of what this PR addresses.

---
Feel free to cherry pick commits ;)
