### PR TITLE
Fix false MP3 sample rate change errors near end of file

### DIFF
--- a/NAudio.Core/FileFormats/Mp3/Mp3Frame.cs
+++ b/NAudio.Core/FileFormats/Mp3/Mp3Frame.cs
@@ -143,14 +143,17 @@ namespace NAudio.Wave
                     var nextFrame = new Mp3Frame();
                     if (!IsValidHeader(headerBytes, nextFrame))
                     {
-                        return false;
+                        // If there isn't enough room for another frame of similar size,
+                        // we're likely at the last audio frame and have hit non-audio data
+                        // (e.g. an ID3v1 tag at the end of the file)
+                        return nextFrameOffset + firstFrame.FrameLength >= input.Length;
                     }
 
                     if (nextFrame.MpegVersion != firstFrame.MpegVersion ||
                         nextFrame.MpegLayer != firstFrame.MpegLayer ||
                         nextFrame.SampleRate != firstFrame.SampleRate)
                     {
-                        return false;
+                        return nextFrameOffset + firstFrame.FrameLength >= input.Length;
                     }
 
                     previousFrame = nextFrame;


### PR DESCRIPTION
## Summary
- Fixes a long-standing bug where `Mp3FileReader` throws "Mp3FileReader does not support sample rate changes" on valid MP3 files
- The `IsLikelyAudioFrameSequence` consecutive-frame validation (added in ffda5488) rejected valid frames near the end of the file when its look-ahead landed on non-audio data (e.g. an ID3v1 tag), causing the byte scanner to find a false frame header with a different sample rate
- The fix accepts the candidate frame when there isn't room for another full frame in the remaining stream, correctly distinguishing end-of-audio-data from a false positive mid-stream

## Root cause
For the last 1-2 frames in a file with an ID3v1 tag, `IsLikelyAudioFrameSequence` seeks forward by `FrameLength` to verify consecutive frames. When that lands on the 128-byte ID3v1 tag instead of another MP3 frame:
1. The valid frame is rejected
2. The byte scanner searches forward through compressed audio data
3. It finds random bytes (e.g. `FF FF 8B 88`) that parse as a valid header with a different sample rate (e.g. 32kHz Layer 1)
4. That false header's large calculated frame length extends past the end of the file, so the consecutive-frame check early-returns true
5. `ValidateFrameFormat` sees the sample rate mismatch and throws

Fixes #229, #292, #583, #763, #1172

## Test plan
- [x] Verified fix against the specific file that triggered the bug (CBR 192kbps 44.1kHz with ID3v1 tag)
- [x] Tested against 6 user-reported problem MP3 files — all pass (M2M.mp3 was actively failing before the fix)
- [x] 5 of 6 files now correctly read 2 additional frames at the end that were previously silently dropped
- [x] All 52 existing MP3 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)