### PR TITLE
Support 24-bit PCM input in AsioSampleConvertor (#1239)

### DIFF
--- a/NAudio.Asio/AsioSampleConvertor.cs
+++ b/NAudio.Asio/AsioSampleConvertor.cs
@@ -98,9 +98,7 @@ namespace NAudio.Wave.Asio
             }
             if (convertor == null)
                 throw new ArgumentException(
-                    String.Format("Not a supported conversion ({0}-bit {1} -> {2})",
-                                  waveFormat.BitsPerSample, waveFormat.Encoding,
-                                  Enum.GetName(typeof(AsioSampleType), asioType)));
+                    $"Not a supported conversion ({waveFormat.BitsPerSample}-bit {waveFormat.Encoding} -> {asioType})");
             return convertor;
         }
 

--- a/NAudio.Asio/AsioSampleConvertor.cs
+++ b/NAudio.Asio/AsioSampleConvertor.cs
@@ -30,6 +30,9 @@ namespace NAudio.Wave.Asio
                         case 16:
                             convertor = (is2Channels) ? ConvertorShortToInt2Channels : (SampleConvertor)ConvertorShortToIntGeneric;
                             break;
+                        case 24:
+                            convertor = Convertor24ToIntGeneric;
+                            break;
                         case 32:
                             if (waveFormat.Encoding == WaveFormatEncoding.IeeeFloat)
                                 convertor = (is2Channels) ? ConvertorFloatToInt2Channels : (SampleConvertor)ConvertorFloatToIntGeneric;
@@ -44,6 +47,9 @@ namespace NAudio.Wave.Asio
                         case 16:
                             convertor = (is2Channels) ? ConvertorShortToShort2Channels : (SampleConvertor)ConvertorShortToShortGeneric;
                             break;
+                        case 24:
+                            convertor = Convertor24ToShortGeneric;
+                            break;
                         case 32:
                             if (waveFormat.Encoding == WaveFormatEncoding.IeeeFloat)
                                 convertor = (is2Channels) ? ConvertorFloatToShort2Channels : (SampleConvertor)ConvertorFloatToShortGeneric;
@@ -57,6 +63,9 @@ namespace NAudio.Wave.Asio
                     {
                         case 16:
                             throw new ArgumentException("Not a supported conversion");
+                        case 24:
+                            convertor = Convertor24To24Generic;
+                            break;
                         case 32:
                             if (waveFormat.Encoding == WaveFormatEncoding.IeeeFloat)
                                 convertor = ConverterFloatTo24LSBGeneric;
@@ -70,6 +79,9 @@ namespace NAudio.Wave.Asio
                     {
                         case 16:
                             throw new ArgumentException("Not a supported conversion");
+                        case 24:
+                            convertor = Convertor24ToFloatGeneric;
+                            break;
                         case 32:
                             if (waveFormat.Encoding == WaveFormatEncoding.IeeeFloat)
                                 convertor = ConverterFloatToFloatGeneric;
@@ -84,6 +96,11 @@ namespace NAudio.Wave.Asio
                         String.Format("ASIO Buffer Type {0} is not yet supported.",
                                       Enum.GetName(typeof(AsioSampleType), asioType)));
             }
+            if (convertor == null)
+                throw new ArgumentException(
+                    String.Format("Not a supported conversion ({0}-bit {1} -> {2})",
+                                  waveFormat.BitsPerSample, waveFormat.Encoding,
+                                  Enum.GetName(typeof(AsioSampleType), asioType)));
             return convertor;
         }
 
@@ -389,6 +406,113 @@ namespace NAudio.Wave.Asio
                     for (int j = 0; j < nbChannels; j++)
                     {
                         *(samples[j]++) = clampToShort(*inputSamples++);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generic convertor 24-bit PCM input to Int32LSB ASIO output
+        /// </summary>
+        public static void Convertor24ToIntGeneric(IntPtr inputInterleavedBuffer, IntPtr[] asioOutputBuffers, int nbChannels, int nbSamples)
+        {
+            unsafe
+            {
+                byte* inputSamples = (byte*)inputInterleavedBuffer;
+                int** samples = stackalloc int*[nbChannels];
+                for (int i = 0; i < nbChannels; i++)
+                {
+                    samples[i] = (int*)asioOutputBuffers[i];
+                }
+
+                for (int i = 0; i < nbSamples; i++)
+                {
+                    for (int j = 0; j < nbChannels; j++)
+                    {
+                        // 24-bit little-endian PCM with sign bit in the top byte; place into upper 24 bits of Int32
+                        int sample = (inputSamples[0] << 8) | (inputSamples[1] << 16) | (((sbyte)inputSamples[2]) << 24);
+                        *samples[j]++ = sample;
+                        inputSamples += 3;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generic convertor 24-bit PCM input to Int16LSB ASIO output
+        /// </summary>
+        public static void Convertor24ToShortGeneric(IntPtr inputInterleavedBuffer, IntPtr[] asioOutputBuffers, int nbChannels, int nbSamples)
+        {
+            unsafe
+            {
+                byte* inputSamples = (byte*)inputInterleavedBuffer;
+                short** samples = stackalloc short*[nbChannels];
+                for (int i = 0; i < nbChannels; i++)
+                {
+                    samples[i] = (short*)asioOutputBuffers[i];
+                }
+
+                for (int i = 0; i < nbSamples; i++)
+                {
+                    for (int j = 0; j < nbChannels; j++)
+                    {
+                        // Take the upper 16 bits of the 24-bit sample (top byte is signed MSB)
+                        *samples[j]++ = (short)((inputSamples[1]) | (((sbyte)inputSamples[2]) << 8));
+                        inputSamples += 3;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generic convertor 24-bit PCM input to Int24LSB ASIO output
+        /// </summary>
+        public static void Convertor24To24Generic(IntPtr inputInterleavedBuffer, IntPtr[] asioOutputBuffers, int nbChannels, int nbSamples)
+        {
+            unsafe
+            {
+                byte* inputSamples = (byte*)inputInterleavedBuffer;
+                byte** samples = stackalloc byte*[nbChannels];
+                for (int i = 0; i < nbChannels; i++)
+                {
+                    samples[i] = (byte*)asioOutputBuffers[i];
+                }
+
+                for (int i = 0; i < nbSamples; i++)
+                {
+                    for (int j = 0; j < nbChannels; j++)
+                    {
+                        *(samples[j]++) = inputSamples[0];
+                        *(samples[j]++) = inputSamples[1];
+                        *(samples[j]++) = inputSamples[2];
+                        inputSamples += 3;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generic convertor 24-bit PCM input to Float32LSB ASIO output
+        /// </summary>
+        public static void Convertor24ToFloatGeneric(IntPtr inputInterleavedBuffer, IntPtr[] asioOutputBuffers, int nbChannels, int nbSamples)
+        {
+            unsafe
+            {
+                byte* inputSamples = (byte*)inputInterleavedBuffer;
+                float** samples = stackalloc float*[nbChannels];
+                for (int i = 0; i < nbChannels; i++)
+                {
+                    samples[i] = (float*)asioOutputBuffers[i];
+                }
+
+                const float int24ToFloatScale = 1.0f / 8388608.0f;
+                for (int i = 0; i < nbSamples; i++)
+                {
+                    for (int j = 0; j < nbChannels; j++)
+                    {
+                        int sample = (inputSamples[0]) | (inputSamples[1] << 8) | (((sbyte)inputSamples[2]) << 16);
+                        *samples[j]++ = sample * int24ToFloatScale;
+                        inputSamples += 3;
                     }
                 }
             }

--- a/NAudioTests/Asio/AsioSampleConvertorTests.cs
+++ b/NAudioTests/Asio/AsioSampleConvertorTests.cs
@@ -16,12 +16,16 @@ namespace NAudioTests.Asio
 
         [TestCase(AsioSampleType.Int32LSB, 16, false, 2, "ConvertorShortToInt2Channels")]
         [TestCase(AsioSampleType.Int32LSB, 16, false, 3, "ConvertorShortToIntGeneric")]
+        [TestCase(AsioSampleType.Int32LSB, 24, false, 2, "Convertor24ToIntGeneric")]
         [TestCase(AsioSampleType.Int32LSB, 32, false, 2, "ConvertorIntToInt2Channels")]
         [TestCase(AsioSampleType.Int32LSB, 32, true, 3, "ConvertorFloatToIntGeneric")]
         [TestCase(AsioSampleType.Int16LSB, 16, false, 2, "ConvertorShortToShort2Channels")]
+        [TestCase(AsioSampleType.Int16LSB, 24, false, 2, "Convertor24ToShortGeneric")]
         [TestCase(AsioSampleType.Int16LSB, 32, true, 3, "ConvertorFloatToShortGeneric")]
         [TestCase(AsioSampleType.Int16LSB, 32, false, 3, "ConvertorIntToShortGeneric")]
+        [TestCase(AsioSampleType.Int24LSB, 24, false, 2, "Convertor24To24Generic")]
         [TestCase(AsioSampleType.Int24LSB, 32, true, 2, "ConverterFloatTo24LSBGeneric")]
+        [TestCase(AsioSampleType.Float32LSB, 24, false, 2, "Convertor24ToFloatGeneric")]
         [TestCase(AsioSampleType.Float32LSB, 32, true, 3, "ConverterFloatToFloatGeneric")]
         [TestCase(AsioSampleType.Float32LSB, 32, false, 3, "ConvertorIntToFloatGeneric")]
         public void SelectSampleConvertor_ReturnsExpectedMethod(AsioSampleType asioType, int bitsPerSample, bool ieeeFloat, int channels, string expectedMethod)
@@ -40,6 +44,100 @@ namespace NAudioTests.Asio
         {
             var waveFormat = new WaveFormat(48000, 16, 2);
             Assert.Throws<TargetInvocationException>(() => SelectSampleConvertor(waveFormat, AsioSampleType.Int32MSB));
+        }
+
+        [Test]
+        public void SelectSampleConvertor_ThrowsForUnsupportedBitsPerSample()
+        {
+            // Guards against the BitsPerSample inner switch silently falling through and returning a null delegate
+            // (the original cause of the NRE in issue #1239 for 24-bit input).
+            var waveFormat = new WaveFormat(48000, 20, 2);
+            Assert.Throws<TargetInvocationException>(() => SelectSampleConvertor(waveFormat, AsioSampleType.Int32LSB));
+        }
+
+        [Test]
+        public void Convertor24ToIntGeneric_PlacesSampleInUpper24BitsOfInt32()
+        {
+            // Two stereo samples of 24-bit little-endian PCM. Top byte carries the sign.
+            byte[] input =
+            {
+                0xFF, 0xFF, 0x7F, // L sample 0: +0x7FFFFF
+                0x00, 0x00, 0x80, // R sample 0: -0x800000
+                0x00, 0x00, 0x00, // L sample 1: 0
+                0xFF, 0xFF, 0xFF, // R sample 1: -1
+            };
+            int[] left = new int[2];
+            int[] right = new int[2];
+
+            var convertor = SelectSampleConvertor(new WaveFormat(48000, 24, 2), AsioSampleType.Int32LSB);
+            InvokeConvertor(convertor, input, new Array[] { left, right }, 2, 2);
+
+            Assert.That(left, Is.EqualTo(new[] { 0x7FFFFF00, 0 }));
+            Assert.That(right, Is.EqualTo(new[] { unchecked((int)0x80000000), unchecked((int)0xFFFFFF00) }));
+        }
+
+        [Test]
+        public void Convertor24ToShortGeneric_TakesUpper16Bits()
+        {
+            byte[] input =
+            {
+                0xFF, 0xFF, 0x7F, // +0x7FFFFF -> 0x7FFF
+                0x00, 0x00, 0x80, // -0x800000 -> -32768
+                0x12, 0x34, 0x56, // +0x563412 -> 0x5634
+                0xEE, 0xCC, 0xAA, // -0x553312 -> 0xAACC (sign extended)
+            };
+            short[] left = new short[2];
+            short[] right = new short[2];
+
+            var convertor = SelectSampleConvertor(new WaveFormat(48000, 24, 2), AsioSampleType.Int16LSB);
+            InvokeConvertor(convertor, input, new Array[] { left, right }, 2, 2);
+
+            Assert.That(left, Is.EqualTo(new short[] { 0x7FFF, 0x5634 }));
+            Assert.That(right, Is.EqualTo(new short[] { unchecked((short)0x8000), unchecked((short)0xAACC) }));
+        }
+
+        [Test]
+        public void Convertor24To24Generic_DeinterleavesByteForByte()
+        {
+            byte[] input =
+            {
+                0x11, 0x22, 0x33,
+                0x44, 0x55, 0x66,
+                0xAA, 0xBB, 0xCC,
+                0xDD, 0xEE, 0xFF,
+            };
+            byte[] left = new byte[6];
+            byte[] right = new byte[6];
+
+            var convertor = SelectSampleConvertor(new WaveFormat(48000, 24, 2), AsioSampleType.Int24LSB);
+            InvokeConvertor(convertor, input, new Array[] { left, right }, 2, 2);
+
+            Assert.That(left, Is.EqualTo(new byte[] { 0x11, 0x22, 0x33, 0xAA, 0xBB, 0xCC }));
+            Assert.That(right, Is.EqualTo(new byte[] { 0x44, 0x55, 0x66, 0xDD, 0xEE, 0xFF }));
+        }
+
+        [Test]
+        public void Convertor24ToFloatGeneric_NormalizesToMinusOneToOneRange()
+        {
+            byte[] input =
+            {
+                0xFF, 0xFF, 0x7F, // +0x7FFFFF -> ~+1
+                0x00, 0x00, 0x80, // -0x800000 -> -1
+                0x00, 0x00, 0x00, //  0
+            };
+            float[] c0 = new float[1];
+            float[] c1 = new float[1];
+            float[] c2 = new float[1];
+
+            var convertor = SelectSampleConvertor(new WaveFormat(48000, 24, 3), AsioSampleType.Float32LSB);
+            InvokeConvertor(convertor, input, new Array[] { c0, c1, c2 }, 3, 1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(c0[0], Is.EqualTo(0.99999988f).Within(1e-6));
+                Assert.That(c1[0], Is.EqualTo(-1f).Within(1e-6));
+                Assert.That(c2[0], Is.EqualTo(0f).Within(1e-6));
+            });
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- Adds 24-bit PCM input handling to `AsioSampleConvertor.SelectSampleConvertor` for all four ASIO output sample types (`Int32LSB`, `Int16LSB`, `Int24LSB`, `Float32LSB`), implemented as four new `Convertor24To*Generic` helpers.
- Adds a final null-conversion guard so any future missing combination throws `ArgumentException` at `Init` instead of silently returning `null` and crashing as an NRE on the ASIO buffer-switch callback.
- Adds NUnit coverage: dispatch-table rows for each new pairing, per-converter math tests (max-positive, max-negative, zero, sign-extension edges) and a guard test that uses an unsupported `BitsPerSample` of 20.

## Why
Fixes #1239. With a 24-bit PCM `IWaveProvider` fed to `AsioOut`, `SelectSampleConvertor`'s inner `switch (BitsPerSample)` had only `case 16` and `case 32`; the 24-bit path fell through, returned `null`, and `AsioOut.driver_BufferUpdate` then dereferenced a null delegate inside the audio thread (`NullReferenceException at AsioOut.cs:294`). The fall-through was silent (other unsupported pairings throw "Not a supported conversion"), which is why the failure surfaced in the callback rather than at `Init`.

## Test plan
- [x] `NAudio.Asio` builds clean (0/0).
- [x] `NAudioTests` builds clean.
- [x] All four new `Convertor24To*Generic` helpers verified end-to-end against the built `NAudio.Asio.dll` (max-positive `+0x7FFFFF`, max-negative `-0x800000`, zero, mid-range with sign extension).
- [x] Null-guard verified to throw `ArgumentException` for `BitsPerSample=20 + Int32LSB`.
- [ ] Reviewer to confirm on real ASIO hardware with a 24-bit PCM source (e.g. `Wave16To24Provider` from the issue).

## Backport
`master` carries the byte-identical `AsioSampleConvertor.cs` and is affected by the same bug; not included in this PR. Happy to open a separate backport PR on request — note the test file likely diverges between branches.

Fixes #1239

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMggEwAjvzAwV9ymqmEczE)_