### PR TITLE
Fix WaveStream.CurrentTime setter to land on a block boundary (#106)

### DIFF
--- a/NAudio.Core/Wave/WaveStreams/WaveStream.cs
+++ b/NAudio.Core/Wave/WaveStreams/WaveStream.cs
@@ -95,17 +95,20 @@ namespace NAudio.Wave
         }
 
         /// <summary>
-        /// The current position in the stream in Time format
+        /// The current position in the stream in Time format.
+        /// On set, the resulting byte position is rounded down to a multiple of
+        /// <see cref="BlockAlign"/> so the stream stays on a valid block boundary.
         /// </summary>
         public virtual TimeSpan CurrentTime
         {
             get
             {
-                return TimeSpan.FromSeconds((double)Position / WaveFormat.AverageBytesPerSecond);                
+                return TimeSpan.FromSeconds((double)Position / WaveFormat.AverageBytesPerSecond);
             }
             set
             {
-                Position = (long) (value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
+                long bytePosition = (long)(value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
+                Position = bytePosition - (bytePosition % BlockAlign);
             }
         }
 

--- a/NAudioTests/WaveStreams/WaveStreamTests.cs
+++ b/NAudioTests/WaveStreams/WaveStreamTests.cs
@@ -1,0 +1,66 @@
+using System;
+using NAudio.Wave;
+using NAudioTests.Utils;
+using NUnit.Framework;
+
+namespace NAudioTests.WaveStreams
+{
+    [TestFixture]
+    [Category("UnitTest")]
+    public class WaveStreamTests
+    {
+        [Test]
+        public void CurrentTimeSetterAlignsToBlockBoundary_AlreadyAligned()
+        {
+            // 16-bit mono 8 kHz: BlockAlign = 2, AverageBytesPerSecond = 16000.
+            // 100 ms -> 1600 bytes, already a multiple of BlockAlign.
+            var stream = new NullWaveStream(new WaveFormat(8000, 16, 1), 1_000_000);
+
+            stream.CurrentTime = TimeSpan.FromMilliseconds(100);
+
+            Assert.That(stream.Position, Is.EqualTo(1600));
+            Assert.That(stream.Position % stream.BlockAlign, Is.Zero);
+        }
+
+        [Test]
+        public void CurrentTimeSetterAlignsToBlockBoundary_RoundsDownMidSample()
+        {
+            // 16-bit mono 8 kHz: AverageBytesPerSecond = 16000, BlockAlign = 2.
+            // A duration that maps to an odd byte count must be rounded down so we
+            // don't land in the middle of a sample (the bug from #106).
+            // 9.9375 ms -> 0.0099375 * 16000 = 159 bytes -> should snap down to 158.
+            var stream = new NullWaveStream(new WaveFormat(8000, 16, 1), 1_000_000);
+
+            stream.CurrentTime = TimeSpan.FromTicks(99375); // 9.9375 ms
+
+            Assert.That(stream.Position % stream.BlockAlign, Is.Zero);
+            Assert.That(stream.Position, Is.EqualTo(158));
+        }
+
+        [Test]
+        public void CurrentTimeSetterAlignsToBlockBoundary_NonPcmFormat()
+        {
+            // GSM 6.10: 8 kHz, AverageBytesPerSecond = 1625, BlockAlign = 65.
+            // For non-PCM formats AverageBytesPerSecond != SampleRate * BlockAlign,
+            // so the only correct rounding is bytePosition - (bytePosition % BlockAlign).
+            // 1 second -> 1625 bytes -> snap down to 1625 - (1625 % 65) = 1625 - 0 = 1625? No:
+            // 1625 % 65 = 0, so use 1.5s: 2437 bytes -> 2437 % 65 = 32 -> 2405.
+            var gsm = WaveFormat.CreateCustomFormat(
+                WaveFormatEncoding.Gsm610,
+                sampleRate: 8000,
+                channels: 1,
+                averageBytesPerSecond: 1625,
+                blockAlign: 65,
+                bitsPerSample: 0);
+            var stream = new NullWaveStream(gsm, 1_000_000);
+
+            stream.CurrentTime = TimeSpan.FromMilliseconds(1500);
+
+            Assert.That(stream.Position % stream.BlockAlign, Is.Zero);
+            Assert.That(stream.Position, Is.EqualTo(2405));
+            // Sanity-check that the buggy "SampleRate * BlockAlign" formula from #754
+            // would NOT match here (it would yield 8000 * 1.5 * 65 = 780000).
+            Assert.That(stream.Position, Is.Not.EqualTo(780_000));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #106 — `WaveStream.CurrentTime` setter could land `Position` mid-sample (e.g. 159 instead of 160 for 16-bit PCM at 8 kHz), producing audible noise on seek for any custom `WaveStream` subclass that doesn't defensively round in its own `Position` setter.

The setter now rounds the computed byte position down to a multiple of `BlockAlign`, matching the rounding pattern already used in [`WaveFileReader.Position`](https://github.com/naudio/NAudio/blob/master/NAudio.Core/Wave/WaveStreams/WaveFileReader.cs#L155-L171) and [`RawSourceWaveStream.Position`](https://github.com/naudio/NAudio/blob/master/NAudio.Core/Wave/WaveStreams/RawSourceWaveStream.cs#L53-L63).

### Why this formula

```csharp
long bytePosition = (long)(value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
Position = bytePosition - (bytePosition % BlockAlign);
```

Two earlier PRs proposed fixes for the same bug:

- #754 (still open) — `Position = (long)(TotalSeconds * SampleRate) * BlockAlign;`
- #587 (closed) — round byte position by `% BlockAlign` (the approach used here)

For PCM (where `AverageBytesPerSecond = SampleRate × BlockAlign`) both formulas produce **identical** results. They diverge for non-PCM / compressed formats (ADPCM, IMA, GSM…) where `BlockAlign` is the codec's compressed-block size:

- `% BlockAlign` rounding stays correct — preserves the time→byte mapping then snaps to a valid block boundary.
- `SampleRate × BlockAlign` is incorrect — multiplies a sample count by a compressed-block size and lands far past the intended position.

This PR therefore takes the `% BlockAlign` approach, which is also consistent with the rest of the codebase.

Supersedes #587 and #754. Co-authors credited.

## Test plan

- [x] CI build passes on all targets
- [x] Existing `NAudioTests` suite passes
- [x] New regression tests added in `NAudioTests/WaveStreams/WaveStreamTests.cs`:
  - aligned PCM duration round-trips unchanged
  - a duration that maps mid-sample for 16-bit PCM is rounded down to `BlockAlign` (the #106 regression)
  - a non-PCM format where `AverageBytesPerSecond != SampleRate * BlockAlign` (GSM 6.10) lands on a valid block — fails against the #754 formula, locking in why this approach was chosen
- [x] Verified both ways: with the fix all three new tests pass; with the fix reverted, the mid-sample and non-PCM tests fail (the aligned baseline still passes), confirming they exercise the bug surface

---
_Generated by [Claude Code](https://claude.ai/code/session_01UK1mLKfbW1XFK8X8LZ4hKN)_