### PR TITLE
Fix BiQuadFilter NaN-latch + Nyquist-aware Equalizer (#190)

### DIFF
--- a/NAudio.Core/Dsp/BiQuadFilter.cs
+++ b/NAudio.Core/Dsp/BiQuadFilter.cs
@@ -112,6 +112,21 @@ namespace NAudio.Dsp
             a2 = b2/aa0;
             a3 = aa1/aa0;
             a4 = aa2/aa0;
+
+            // reset state so a previously divergent run (Infinity/NaN latched into
+            // y1/y2) cannot survive a coefficient change and permanently kill the filter
+            x1 = x2 = 0;
+            y1 = y2 = 0;
+        }
+
+        private static void ValidateParameters(float sampleRate, float frequency, string frequencyParamName, float qOrSlope, string qOrSlopeParamName)
+        {
+            if (sampleRate <= 0)
+                throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive");
+            if (frequency <= 0 || frequency >= sampleRate / 2)
+                throw new ArgumentOutOfRangeException(frequencyParamName, $"Frequency must be greater than 0 and less than sampleRate/2 (Nyquist = {sampleRate / 2} Hz)");
+            if (qOrSlope <= 0)
+                throw new ArgumentOutOfRangeException(qOrSlopeParamName, $"{qOrSlopeParamName} must be positive");
         }
 
         /// <summary>
@@ -126,6 +141,7 @@ namespace NAudio.Dsp
         /// regardless of Q — cascade biquads in series for a steeper roll-off.</param>
         public void SetLowPassFilter(float sampleRate, float cutoffFrequency, float q)
         {
+            ValidateParameters(sampleRate, cutoffFrequency, nameof(cutoffFrequency), q, nameof(q));
             // H(s) = 1 / (s^2 + s/Q + 1)
             var w0 = 2 * Math.PI * cutoffFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -150,6 +166,7 @@ namespace NAudio.Dsp
         /// <param name="dbGain">Gain in decibels</param>
         public void SetPeakingEq(float sampleRate, float centreFrequency, float q, float dbGain)
         {
+            ValidateParameters(sampleRate, centreFrequency, nameof(centreFrequency), q, nameof(q));
             // H(s) = (s^2 + s*(A/Q) + 1) / (s^2 + s/(A*Q) + 1)
             var w0 = 2 * Math.PI * centreFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -178,6 +195,7 @@ namespace NAudio.Dsp
         /// regardless of Q — cascade biquads in series for a steeper roll-off.</param>
         public void SetHighPassFilter(float sampleRate, float cutoffFrequency, float q)
         {
+            ValidateParameters(sampleRate, cutoffFrequency, nameof(cutoffFrequency), q, nameof(q));
             // H(s) = s^2 / (s^2 + s/Q + 1)
             var w0 = 2 * Math.PI * cutoffFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -231,6 +249,7 @@ namespace NAudio.Dsp
         /// wider band. Peak gain at the centre frequency equals Q.</param>
         public static BiQuadFilter BandPassFilterConstantSkirtGain(float sampleRate, float centreFrequency, float q)
         {
+            ValidateParameters(sampleRate, centreFrequency, nameof(centreFrequency), q, nameof(q));
             // H(s) = s / (s^2 + s/Q + 1)  (constant skirt gain, peak gain = Q)
             var w0 = 2 * Math.PI * centreFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -255,6 +274,7 @@ namespace NAudio.Dsp
         /// wider band. Peak gain at the centre frequency is 0 dB regardless of Q.</param>
         public static BiQuadFilter BandPassFilterConstantPeakGain(float sampleRate, float centreFrequency, float q)
         {
+            ValidateParameters(sampleRate, centreFrequency, nameof(centreFrequency), q, nameof(q));
             // H(s) = (s/Q) / (s^2 + s/Q + 1)      (constant 0 dB peak gain)
             var w0 = 2 * Math.PI * centreFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -279,6 +299,7 @@ namespace NAudio.Dsp
         /// wider notch.</param>
         public static BiQuadFilter NotchFilter(float sampleRate, float centreFrequency, float q)
         {
+            ValidateParameters(sampleRate, centreFrequency, nameof(centreFrequency), q, nameof(q));
             // H(s) = (s^2 + 1) / (s^2 + s/Q + 1)
             var w0 = 2 * Math.PI * centreFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -303,6 +324,7 @@ namespace NAudio.Dsp
         /// around the centre frequency.</param>
         public static BiQuadFilter AllPassFilter(float sampleRate, float centreFrequency, float q)
         {
+            ValidateParameters(sampleRate, centreFrequency, nameof(centreFrequency), q, nameof(q));
             //H(s) = (s^2 - s/Q + 1) / (s^2 + s/Q + 1)
             var w0 = 2 * Math.PI * centreFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
@@ -345,6 +367,7 @@ namespace NAudio.Dsp
         /// <param name="dbGain">Gain in decibels</param>
         public static BiQuadFilter LowShelf(float sampleRate, float cutoffFrequency, float shelfSlope, float dbGain)
         {
+            ValidateParameters(sampleRate, cutoffFrequency, nameof(cutoffFrequency), shelfSlope, nameof(shelfSlope));
             var w0 = 2 * Math.PI * cutoffFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
             var sinw0 = Math.Sin(w0);
@@ -371,6 +394,7 @@ namespace NAudio.Dsp
         /// <returns></returns>
         public static BiQuadFilter HighShelf(float sampleRate, float cutoffFrequency, float shelfSlope, float dbGain)
         {
+            ValidateParameters(sampleRate, cutoffFrequency, nameof(cutoffFrequency), shelfSlope, nameof(shelfSlope));
             var w0 = 2 * Math.PI * cutoffFrequency / sampleRate;
             var cosw0 = Math.Cos(w0);
             var sinw0 = Math.Sin(w0);

--- a/NAudio.Extras/Equalizer.cs
+++ b/NAudio.Extras/Equalizer.cs
@@ -34,15 +34,25 @@ namespace NAudio.Extras
 
         private void CreateFilters()
         {
+            var sampleRate = sourceProvider.WaveFormat.SampleRate;
+            var nyquist = sampleRate / 2.0f;
             for (int bandIndex = 0; bandIndex < bandCount; bandIndex++)
             {
                 var band = bands[bandIndex];
+                // Bands outside (0, Nyquist) or with non-positive bandwidth would make BiQuadFilter
+                // throw or go unstable; skip them so a single out-of-range band doesn't kill playback.
+                var bandUsable = band.Frequency > 0 && band.Frequency < nyquist && band.Bandwidth > 0;
                 for (int n = 0; n < channels; n++)
                 {
+                    if (!bandUsable)
+                    {
+                        filters[n, bandIndex] = null;
+                        continue;
+                    }
                     if (filters[n, bandIndex] == null)
-                        filters[n, bandIndex] = BiQuadFilter.PeakingEQ(sourceProvider.WaveFormat.SampleRate, band.Frequency, band.Bandwidth, band.Gain);
+                        filters[n, bandIndex] = BiQuadFilter.PeakingEQ(sampleRate, band.Frequency, band.Bandwidth, band.Gain);
                     else
-                        filters[n, bandIndex].SetPeakingEq(sourceProvider.WaveFormat.SampleRate, band.Frequency, band.Bandwidth, band.Gain);
+                        filters[n, bandIndex].SetPeakingEq(sampleRate, band.Frequency, band.Bandwidth, band.Gain);
                 }
             }
         }
@@ -80,7 +90,9 @@ namespace NAudio.Extras
 
                 for (int band = 0; band < bandCount; band++)
                 {
-                    buffer[n] = filters[ch, band].Transform(buffer[n]);
+                    var filter = filters[ch, band];
+                    if (filter != null)
+                        buffer[n] = filter.Transform(buffer[n]);
                 }
             }
             return samplesRead;

--- a/NAudioTests/Dsp/BiQuadFilterValidationTests.cs
+++ b/NAudioTests/Dsp/BiQuadFilterValidationTests.cs
@@ -1,0 +1,164 @@
+using System;
+using NAudio.Dsp;
+using NUnit.Framework;
+
+namespace NAudioTests.Dsp
+{
+    /// <summary>
+    /// Covers the parameter validation and state-reset behaviour added in response
+    /// to issue #190 — out-of-Nyquist or non-positive parameters must throw, and
+    /// updating coefficients on an existing filter must not let prior state (e.g.
+    /// a latched <see cref="float.NaN"/> in y1/y2) survive into the next run.
+    /// </summary>
+    [TestFixture]
+    [Category("UnitTest")]
+    public class BiQuadFilterValidationTests
+    {
+        private const float SampleRate = 48000f;
+        private const float Nyquist = SampleRate / 2f;
+
+        // -- frequency bounds ---------------------------------------------------
+
+        [Test]
+        public void SetPeakingEqRejectsFrequencyAtOrAboveNyquist()
+        {
+            var filter = BiQuadFilter.PeakingEQ(SampleRate, 1000f, 1f, 0f);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => filter.SetPeakingEq(SampleRate, Nyquist, 1f, 6f));
+            Assert.That(ex.ParamName, Is.EqualTo("centreFrequency"));
+        }
+
+        [Test]
+        public void SetPeakingEqRejectsZeroFrequency()
+        {
+            var filter = BiQuadFilter.PeakingEQ(SampleRate, 1000f, 1f, 0f);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => filter.SetPeakingEq(SampleRate, 0f, 1f, 6f));
+            Assert.That(ex.ParamName, Is.EqualTo("centreFrequency"));
+        }
+
+        [Test]
+        public void SetLowPassFilterRejectsFrequencyAboveNyquist()
+        {
+            var filter = BiQuadFilter.LowPassFilter(SampleRate, 1000f, 0.707f);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => filter.SetLowPassFilter(SampleRate, Nyquist + 1f, 0.707f));
+            Assert.That(ex.ParamName, Is.EqualTo("cutoffFrequency"));
+        }
+
+        [Test]
+        public void SetHighPassFilterRejectsNegativeFrequency()
+        {
+            var filter = BiQuadFilter.HighPassFilter(SampleRate, 1000f, 0.707f);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => filter.SetHighPassFilter(SampleRate, -1f, 0.707f));
+            Assert.That(ex.ParamName, Is.EqualTo("cutoffFrequency"));
+        }
+
+        // -- the original #190 trigger ------------------------------------------
+
+        [Test]
+        public void PeakingEqFactoryRejectsFrequencyAtOrAboveNyquist()
+        {
+            // The exact scenario from issue #190: an EQ band at 9600 Hz against an
+            // 8 kHz source. Pre-fix this silently produced unstable coefficients;
+            // post-fix it must throw with a clear param name.
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => BiQuadFilter.PeakingEQ(8000f, 9600f, 1f, 0f));
+            Assert.That(ex.ParamName, Is.EqualTo("centreFrequency"));
+        }
+
+        // -- q / shelfSlope -----------------------------------------------------
+
+        [Test]
+        public void SetPeakingEqRejectsZeroQ()
+        {
+            var filter = BiQuadFilter.PeakingEQ(SampleRate, 1000f, 1f, 0f);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => filter.SetPeakingEq(SampleRate, 1000f, 0f, 6f));
+            Assert.That(ex.ParamName, Is.EqualTo("q"));
+        }
+
+        [Test]
+        public void LowShelfFactoryRejectsZeroSlope()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => BiQuadFilter.LowShelf(SampleRate, 1000f, 0f, 6f));
+            Assert.That(ex.ParamName, Is.EqualTo("shelfSlope"));
+        }
+
+        [Test]
+        public void HighShelfFactoryRejectsNegativeSlope()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => BiQuadFilter.HighShelf(SampleRate, 1000f, -1f, 6f));
+            Assert.That(ex.ParamName, Is.EqualTo("shelfSlope"));
+        }
+
+        // -- sample rate --------------------------------------------------------
+
+        [Test]
+        public void NotchFilterFactoryRejectsZeroSampleRate()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => BiQuadFilter.NotchFilter(0f, 1000f, 1f));
+            Assert.That(ex.ParamName, Is.EqualTo("sampleRate"));
+        }
+
+        // -- state reset on coefficient change (the core #190 fix) -------------
+
+        [Test]
+        public void SetPeakingEqResetsStateBetweenRuns()
+        {
+            // After running samples through filter A and then re-tuning it, its output
+            // for a fresh signal must match a brand-new filter at the same coefficients.
+            // Pre-fix, the latched x1/x2/y1/y2 would have made A diverge from B.
+            var input = GenerateTestSignal(2048);
+
+            var reused = BiQuadFilter.PeakingEQ(SampleRate, 1000f, 1f, 12f);
+            for (int i = 0; i < input.Length; i++) reused.Transform(input[i]);
+
+            // Re-tune to a different operating point. With the fix, x1/x2/y1/y2 reset to 0.
+            reused.SetPeakingEq(SampleRate, 4000f, 0.7f, -3f);
+
+            var fresh = BiQuadFilter.PeakingEQ(SampleRate, 4000f, 0.7f, -3f);
+
+            var reusedOut = new float[input.Length];
+            var freshOut = new float[input.Length];
+            for (int i = 0; i < input.Length; i++)
+            {
+                reusedOut[i] = reused.Transform(input[i]);
+                freshOut[i] = fresh.Transform(input[i]);
+            }
+
+            Assert.That(reusedOut, Is.EqualTo(freshOut),
+                "after SetPeakingEq, the filter must behave identically to a freshly constructed one");
+        }
+
+        [Test]
+        public void StateResetClearsLatchedNonFiniteOutput()
+        {
+            // Drive a peaking filter with a high-gain DC ramp until its internal state grows
+            // very large, then re-tune it with SetPeakingEq. A subsequent run on a small finite
+            // input must produce strictly finite output — the fix's contract.
+            var filter = BiQuadFilter.PeakingEQ(SampleRate, 1000f, 0.1f, 24f);
+            for (int i = 0; i < 16384; i++) filter.Transform(1f);
+
+            filter.SetPeakingEq(SampleRate, 2000f, 1f, 0f);
+
+            var probe = GenerateTestSignal(256);
+            foreach (var s in probe)
+                Assert.That(float.IsFinite(filter.Transform(s)), Is.True,
+                    "filter output must be finite after a coefficient change resets state");
+        }
+
+        private static float[] GenerateTestSignal(int length, int seed = 42)
+        {
+            var rng = new Random(seed);
+            var signal = new float[length];
+            for (int i = 0; i < length; i++)
+                signal[i] = (float)(rng.NextDouble() * 2 - 1);
+            return signal;
+        }
+    }
+}

--- a/NAudioWpfDemo/EqualizationDemo/EqualizationDemoViewModel.cs
+++ b/NAudioWpfDemo/EqualizationDemo/EqualizationDemoViewModel.cs
@@ -150,7 +150,7 @@ namespace NAudioWpfDemo.EqualizationDemo
                 if (bands[7].Gain != value)
                 {
                     bands[7].Gain = value;
-                    OnPropertyChanged("Band7");
+                    OnPropertyChanged("Band8");
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #190 — `BiQuadFilter` could permanently latch `NaN`/`Infinity` into its state and silently produce dead audio, reproducible in the bundled `EqualizationDemo`.

### Root cause

Two coupled defects in `BiQuadFilter`:

1. **State `x1, x2, y1, y2` is never reset when coefficients change.** Once a divergent run pushes `Infinity` into `y1`/`y2`, every subsequent `Transform` produces `NaN` (`a3 * NaN = NaN`), which becomes the new `y1`. The filter is permanently dead — moving the EQ slider back to a sensible value cannot recover it. This is exactly the "x1, x2, y1, y2 quickly become NaN or Infinity" symptom in the issue.
2. **No input validation.** Callers can hand the filter a `centreFrequency >= sampleRate / 2` (Nyquist) and it will silently produce an unstable filter. `EqualizationDemo`'s hardcoded 4800 Hz and 9600 Hz bands trigger this on any audio at ≤ 19200 Hz sample rate. `q <= 0` would also divide by zero in `alpha = sin(w0) / (2*q)`.

The reporter's observation that `filters[0,6]` and `filters[0,7]` (the 4800 Hz and 9600 Hz bands) specifically blow up matches this exactly: their files were below 19.2 kHz.

### Changes

**`NAudio.Core/Dsp/BiQuadFilter.cs`**
- `SetCoefficients` now zeros `x1 = x2 = y1 = y2 = 0` after updating coefficients, matching the constructor. Re-using a filter via `SetPeakingEq` (as `Equalizer.CreateFilters` does) can no longer carry stale state across coefficient changes.
- New `ValidateParameters` helper throws `ArgumentOutOfRangeException` with a clear, actionable message when:
  - `sampleRate <= 0`
  - `frequency <= 0` or `frequency >= sampleRate / 2`
  - `q <= 0` (or `shelfSlope <= 0` for shelf filters)
- Validation applied to all public coefficient-setting entry points: `SetLowPassFilter`, `SetPeakingEq`, `SetHighPassFilter`, and the static factories `BandPassFilterConstantSkirtGain`, `BandPassFilterConstantPeakGain`, `NotchFilter`, `AllPassFilter`, `LowShelf`, `HighShelf`. The `LowPassFilter`/`HighPassFilter`/`PeakingEQ` factories pick up validation transitively.

**`NAudio.Extras/Equalizer.cs`**
- Skip bands whose frequency is outside `(0, sampleRate/2)` or whose bandwidth is non-positive. Previously these would have silently produced unstable BiQuad coefficients; with the new validation they would now throw and kill playback for the whole stream. Skipping treats them as pass-through, which is the natural expectation when a configured band sits above the source's Nyquist.

**`NAudioWpfDemo/EqualizationDemo/EqualizationDemoViewModel.cs`**
- Fix typo: the `Band8` setter raised `PropertyChanged` for `"Band7"` instead of `"Band8"`. Spotted while investigating the demo's interaction with the EQ.

### Behavioural note

Direct callers of `BiQuadFilter` with previously out-of-range parameters now get a clear `ArgumentOutOfRangeException` instead of garbage audio. Callers using the higher-level `Equalizer` get graceful pass-through for out-of-Nyquist bands, so the bundled demo continues to work on low-sample-rate audio (those bands simply do nothing) without further changes to the demo's hardcoded band table.

## Test plan

- [x] CI passes
- [x] New regression tests added in `NAudioTests/Dsp/BiQuadFilterValidationTests.cs` (11 tests):
  - rejection of out-of-Nyquist / zero / negative frequency on `SetPeakingEq`, `SetLowPassFilter`, `SetHighPassFilter`
  - rejection of `q <= 0` on `SetPeakingEq` and `shelfSlope <= 0` on `LowShelf`/`HighShelf`
  - rejection of `sampleRate <= 0` on `NotchFilter`
  - the original #190 trigger: `BiQuadFilter.PeakingEQ(8000, 9600, 1, 0)` throws naming `centreFrequency`
  - state reset: a re-tuned filter produces output byte-identical to a fresh filter at the same coefficients (pins the core fix)
  - a coefficient change after a high-gain run produces strictly finite output
- [x] Verified both ways: with the fix all 11 tests pass; with `BiQuadFilter.cs` reverted, 10 of 11 fail — confirming the tests exercise the bug surface, not just the new API
- [x] Equalizer skip-band behaviour intentionally not unit-tested here: `NAudioTests` does not reference `NAudio.Extras`. Manual verification still covers it via the demo
- [ ] Manual: run `EqualizationDemo` with a ≥ 22.05 kHz file (full band table active, no exception, sliders work)
- [ ] Manual: run `EqualizationDemo` with an 8 kHz file — top bands silently inactive, low/mid bands still work, no NaN audio
- [ ] Manual: deliberately push a peaking-EQ filter to large gain swings via repeated `SetPeakingEq` calls — confirm the filter recovers cleanly when gain returns to a sensible value (validates the state-reset fix)