### PR TITLE
Fix running status across meta events when reading MIDI files (#205)

### DIFF
--- a/NAudio.Midi/Midi/MidiEvent.cs
+++ b/NAudio.Midi/Midi/MidiEvent.cs
@@ -88,9 +88,11 @@ namespace NAudio.Midi
         /// Constructs a MidiEvent from a BinaryStream
         /// </summary>
         /// <param name="br">The binary stream of MIDI data</param>
-        /// <param name="previous">The previous MIDI event (pass null for first event)</param>
+        /// <param name="previous">The previous channel-voice MIDI event used to resolve
+        /// running status. Pass null if no channel-voice event has been read yet; meta and
+        /// sysex events do not update running status and should not be passed here.</param>
         /// <returns>A new MidiEvent</returns>
-        public static MidiEvent ReadNextEvent(BinaryReader br, MidiEvent previous) 
+        public static MidiEvent ReadNextEvent(BinaryReader br, MidiEvent previous)
         {
             int deltaTime = ReadVarInt(br);
             MidiCommandCode commandCode;

--- a/NAudio.Midi/Midi/MidiFile.cs
+++ b/NAudio.Midi/Midi/MidiFile.cs
@@ -97,12 +97,16 @@ namespace NAudio.Midi
 
                     long startPos = br.BaseStream.Position;
                     MidiEvent me = null;
+                    // Only channel-voice messages (NoteOn/Off, ControlChange, etc.) establish
+                    // running status; meta and sysex events leave the running status anchor intact
+                    // (issue #205).
+                    MidiEvent runningStatus = null;
                     var outstandingNoteOns = new List<NoteOnEvent>();
-                    while(br.BaseStream.Position < startPos + chunkSize) 
+                    while(br.BaseStream.Position < startPos + chunkSize)
                     {
                         try
                         {
-                            me = MidiEvent.ReadNextEvent(br, me);
+                            me = MidiEvent.ReadNextEvent(br, runningStatus);
                         }
                         catch (InvalidDataException)
                         {
@@ -115,6 +119,10 @@ namespace NAudio.Midi
                             continue;
                         }
 
+                        if (me.CommandCode < MidiCommandCode.Sysex)
+                        {
+                            runningStatus = me;
+                        }
                         absoluteTime += me.DeltaTime;
                         me.AbsoluteTime = absoluteTime;
                         events[track].Add(me);

--- a/NAudioTests/Midi/MidiFileTests.cs
+++ b/NAudioTests/Midi/MidiFileTests.cs
@@ -135,6 +135,39 @@ namespace NAudioTests.Midi
         }
 
         [Test]
+        public void RunningStatusSurvivesAcrossMetaEvents()
+        {
+            // Issue #205: a meta event embedded between channel-voice messages must not
+            // clobber running status, otherwise the next high-bit-clear byte gets reparsed
+            // as a meta event type.
+            var track = new byte[]
+            {
+                0x00, 0x90, 0x3C, 0x64,             // NoteOn ch1 note 0x3C vel 100 (sets running status)
+                0x00, 0xFF, 0x01, 0x01, (byte)'x',  // Text meta event "x"
+                0x00, 0x40, 0x64,                   // running-status NoteOn ch1 note 0x40 vel 100
+                0x00, 0x3C, 0x00,                   // running-status NoteOn vel 0 (note off for 0x3C)
+                0x00, 0x40, 0x00,                   // running-status NoteOn vel 0 (note off for 0x40)
+                0x00, 0xFF, 0x2F, 0x00              // EndTrack
+            };
+            var bytes = CreateMidiFileBytes(0, 480, track);
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var midiFile = new MidiFile(stream, true);
+
+                Assert.That(midiFile.Events[0].Count, Is.EqualTo(6));
+                Assert.That(midiFile.Events[0][0], Is.TypeOf<NoteOnEvent>());
+                Assert.That(midiFile.Events[0][1], Is.TypeOf<TextEvent>());
+                Assert.That(midiFile.Events[0][2], Is.TypeOf<NoteOnEvent>());
+
+                var runningNoteOn = (NoteEvent)midiFile.Events[0][2];
+                Assert.That(runningNoteOn.NoteNumber, Is.EqualTo(0x40));
+                Assert.That(runningNoteOn.Velocity, Is.EqualTo(0x64));
+                Assert.That(runningNoteOn.Channel, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
         public void Type1TracksUseIndependentAbsoluteTimeBases()
         {
             var track1 = new byte[]


### PR DESCRIPTION
## Summary

Fixes #205. Parsing files where running-status channel-voice messages followed an embedded meta event (e.g. a `TextEvent` marker) failed with `Read too far` or `Invalid SMPTE Offset length` errors. The parser was adopting the previous event's command code as the running-status anchor even when that event was a meta or sysex event, so subsequent high-bit-clear bytes were reparsed as meta event types and the parse went off the rails.

`MidiFile` now tracks the last channel-voice event separately and only that anchor is passed to `MidiEvent.ReadNextEvent` for running-status resolution. Meta and sysex events no longer disturb running status, matching the leniency the SMF spec recommends.

The attached `notes.mid` from the original issue now parses cleanly under both strict and non-strict modes (8 tracks, ~34k events). DryWetMIDI handled this file fine, which lined up with the suspicion that the file was valid and NAudio was wrong.

## Changes

- `NAudio.Midi/Midi/MidiFile.cs` — track a separate `runningStatus` anchor in the per-track read loop, updated only when `CommandCode < MidiCommandCode.Sysex`.
- `NAudio.Midi/Midi/MidiEvent.cs` — updated the `<param>` doc on `ReadNextEvent` to describe the refined contract for `previous` (last channel-voice event, not literal previous event).
- `NAudioTests/Midi/MidiFileTests.cs` — new `RunningStatusSurvivesAcrossMetaEvents` regression test (NoteOn → TextEvent → running-status NoteOn → matched note-offs → EndTrack), runs under strict checking.

## Test plan

- [x] New unit test `RunningStatusSurvivesAcrossMetaEvents` passes
- [x] All 179 existing MIDI tests still pass
- [x] Original `notes.mid` from issue #205 parses cleanly under both `strict=true` and `strict=false`
- [ ] Reviewer to consider whether sysex events should also reset running status (current change leaves them alone, matching the meta-event leniency)

## Notes for reviewer

A few judgement calls worth a second opinion:

1. The `<param>` doc change for `ReadNextEvent` documents a subtler contract but doesn't enforce it. External callers who pass the literal last event will still hit the same wrong behaviour. An alternative is to change `ReadNextEvent` to own the running-status state itself (out-param or struct), but that's a public-API change.
2. I left running status untouched across sysex (`F0`/`F7`) as well as meta. The MIDI 1.0 spec says System Common cancels running status; arguably sysex should too. Kept it lenient for symmetry with the meta fix and to match what real-world files seem to expect — happy to tighten if preferred.
3. The `CommandCode < MidiCommandCode.Sysex` predicate relies on `Sysex = 0xF0` being the lower boundary of non-channel events in the enum; stable today but an implicit assumption.

https://claude.ai/code/session_01NetR2iPH6r1znXyujMiAWE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NetR2iPH6r1znXyujMiAWE)_