### PR TITLE
Clarify BiQuadFilter q parameter docs and recommend Q ≈ 0.707 default

### DIFF
--- a/NAudio.Core/Dsp/BiQuadFilter.cs
+++ b/NAudio.Core/Dsp/BiQuadFilter.cs
@@ -78,7 +78,11 @@ namespace NAudio.Dsp
         /// </summary>
         /// <param name="sampleRate">Sample Rate</param>
         /// <param name="cutoffFrequency">Cut-off Frequency</param>
-        /// <param name="q">Bandwidth</param>
+        /// <param name="q">Q (quality factor). Use 1/sqrt(2) ≈ 0.707 for a Butterworth response
+        /// (maximally flat passband, no peaking) — the recommended default for a clean low-pass.
+        /// Larger values produce a resonant peak at the cutoff; smaller values give a more
+        /// gradual roll-off into the cutoff. The slope above the cutoff is ~12 dB/octave
+        /// regardless of Q — cascade biquads in series for a steeper roll-off.</param>
         public void SetLowPassFilter(float sampleRate, float cutoffFrequency, float q)
         {
             // H(s) = 1 / (s^2 + s/Q + 1)
@@ -100,7 +104,8 @@ namespace NAudio.Dsp
         /// </summary>
         /// <param name="sampleRate">Sample Rate</param>
         /// <param name="centreFrequency">Centre Frequency</param>
-        /// <param name="q">Bandwidth (Q)</param>
+        /// <param name="q">Q (quality factor). Higher Q gives a narrower peak around the centre
+        /// frequency; lower Q gives a wider, gentler bell.</param>
         /// <param name="dbGain">Gain in decibels</param>
         public void SetPeakingEq(float sampleRate, float centreFrequency, float q, float dbGain)
         {
@@ -123,6 +128,13 @@ namespace NAudio.Dsp
         /// <summary>
         /// Set this as a high pass filter
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="cutoffFrequency">Cut-off Frequency</param>
+        /// <param name="q">Q (quality factor). Use 1/sqrt(2) ≈ 0.707 for a Butterworth response
+        /// (maximally flat passband, no peaking) — the recommended default for a clean high-pass.
+        /// Larger values produce a resonant peak at the cutoff; smaller values give a more
+        /// gradual roll-off into the cutoff. The slope below the cutoff is ~12 dB/octave
+        /// regardless of Q — cascade biquads in series for a steeper roll-off.</param>
         public void SetHighPassFilter(float sampleRate, float cutoffFrequency, float q)
         {
             // H(s) = s^2 / (s^2 + s/Q + 1)
@@ -142,6 +154,11 @@ namespace NAudio.Dsp
         /// <summary>
         /// Create a low pass filter
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="cutoffFrequency">Cut-off Frequency</param>
+        /// <param name="q">Q (quality factor). Use 1/sqrt(2) ≈ 0.707 for a Butterworth response
+        /// (maximally flat passband, no peaking). The slope above the cutoff is ~12 dB/octave
+        /// regardless of Q — cascade biquads in series for a steeper roll-off.</param>
         public static BiQuadFilter LowPassFilter(float sampleRate, float cutoffFrequency, float q)
         {
             var filter = new BiQuadFilter();
@@ -152,6 +169,11 @@ namespace NAudio.Dsp
         /// <summary>
         /// Create a High pass filter
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="cutoffFrequency">Cut-off Frequency</param>
+        /// <param name="q">Q (quality factor). Use 1/sqrt(2) ≈ 0.707 for a Butterworth response
+        /// (maximally flat passband, no peaking). The slope below the cutoff is ~12 dB/octave
+        /// regardless of Q — cascade biquads in series for a steeper roll-off.</param>
         public static BiQuadFilter HighPassFilter(float sampleRate, float cutoffFrequency, float q)
         {
             var filter = new BiQuadFilter();
@@ -162,6 +184,10 @@ namespace NAudio.Dsp
         /// <summary>
         /// Create a bandpass filter with constant skirt gain
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="centreFrequency">Centre Frequency</param>
+        /// <param name="q">Q (quality factor). Higher Q gives a narrower band; lower Q gives a
+        /// wider band. Peak gain at the centre frequency equals Q.</param>
         public static BiQuadFilter BandPassFilterConstantSkirtGain(float sampleRate, float centreFrequency, float q)
         {
             // H(s) = s / (s^2 + s/Q + 1)  (constant skirt gain, peak gain = Q)
@@ -182,6 +208,10 @@ namespace NAudio.Dsp
         /// <summary>
         /// Create a bandpass filter with constant peak gain
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="centreFrequency">Centre Frequency</param>
+        /// <param name="q">Q (quality factor). Higher Q gives a narrower band; lower Q gives a
+        /// wider band. Peak gain at the centre frequency is 0 dB regardless of Q.</param>
         public static BiQuadFilter BandPassFilterConstantPeakGain(float sampleRate, float centreFrequency, float q)
         {
             // H(s) = (s/Q) / (s^2 + s/Q + 1)      (constant 0 dB peak gain)
@@ -202,6 +232,10 @@ namespace NAudio.Dsp
         /// <summary>
         /// Creates a notch filter
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="centreFrequency">Centre Frequency</param>
+        /// <param name="q">Q (quality factor). Higher Q gives a narrower notch; lower Q gives a
+        /// wider notch.</param>
         public static BiQuadFilter NotchFilter(float sampleRate, float centreFrequency, float q)
         {
             // H(s) = (s^2 + 1) / (s^2 + s/Q + 1)
@@ -220,8 +254,12 @@ namespace NAudio.Dsp
         }
 
         /// <summary>
-        /// Creaes an all pass filter
+        /// Creates an all pass filter
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="centreFrequency">Centre Frequency</param>
+        /// <param name="q">Q (quality factor). Controls how sharply the phase transitions
+        /// around the centre frequency.</param>
         public static BiQuadFilter AllPassFilter(float sampleRate, float centreFrequency, float q)
         {
             //H(s) = (s^2 - s/Q + 1) / (s^2 + s/Q + 1)
@@ -242,6 +280,11 @@ namespace NAudio.Dsp
         /// <summary>
         /// Create a Peaking EQ
         /// </summary>
+        /// <param name="sampleRate">Sample Rate</param>
+        /// <param name="centreFrequency">Centre Frequency</param>
+        /// <param name="q">Q (quality factor). Higher Q gives a narrower peak around the centre
+        /// frequency; lower Q gives a wider, gentler bell.</param>
+        /// <param name="dbGain">Gain in decibels</param>
         public static BiQuadFilter PeakingEQ(float sampleRate, float centreFrequency, float q, float dbGain)
         {
             var filter = new BiQuadFilter();


### PR DESCRIPTION
Fixes #1264 (and unblocks future confusion of the kind seen in #895).

## Summary

- Replaced the misleading `<param name="q">Bandwidth</param>` / `Bandwidth (Q)` doc comments on `BiQuadFilter` with accurate "Q (quality factor)" descriptions.
- For `SetLowPassFilter` / `SetHighPassFilter` and their static factories, added guidance that **Q ≈ 1/√2 ≈ 0.707** gives a Butterworth (maximally flat) response and is the recommended default, plus a note that the slope is ~12 dB/octave regardless of Q (cascade biquads for a steeper roll-off).
- Added the missing `<param>` docs on the BPF / Notch / AllPass / PeakingEQ factories.
- Fixed an incidental typo: `Creaes` → `Creates` on `AllPassFilter`.

Doc-only change — no behaviour or coefficient math is affected.

## Test plan

- [ ] Visually confirm the rendered XML docs in IDE intellisense look reasonable
- [ ] Confirm no build warnings introduced (doc comments only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCqvrznybV5QRKWV4DVvni)_