### PR TITLE
Phase 2: add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: build
+
+# Build & test on every PR, every push to naudio3dev (the NAudio 3 dev branch),
+# and on demand. The .NET 10 SDK is preinstalled on windows-latest, so no
+# explicit setup-dotnet step is needed today — see Docs/Architecture/ReleaseStrategy.md
+# for the trade-off if the runner image ever rotates and drops it.
+on:
+  pull_request:
+  push:
+    branches: [naudio3dev]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore
+        run: dotnet restore NAudio.slnx
+
+      - name: Build
+        run: dotnet build NAudio.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: >
+          dotnet test --project NAudioTests/NAudioTests.csproj
+          --configuration Release
+          --no-build
+          --filter "TestCategory!=IntegrationTest"
+          --report-trx
+          --results-directory ${{ runner.temp }}/TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ${{ runner.temp }}/TestResults/*.trx
+          if-no-files-found: warn

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -9,8 +9,8 @@
 | Phase | State | Notes |
 | --- | --- | --- |
 | 0. Validate GitHub Actions | ✅ done | Green build on `windows-latest`. 2028 passing / 0 failed / 7 skipped, 1m49s (Azure was 2m51s). Draft PR closed unmerged; throwaway branch `ci/validate-github-actions` retained for reference. |
-| 1. Merge `origin/master` into `naudio3dev` | ⏳ in progress | |
-| 2. Land build workflow on `naudio3dev` | not started | YAML already validated in Phase 0 — reintroduce as-is. |
+| 1. Merge `origin/master` into `naudio3dev` | ✅ done | Auto-merged via ORT strategy with no conflicts. The expected `Mp3FileReader` clash didn't materialise — master's MP3 sample-rate fix touched different lines from the lazy-TOC work. Local tests post-merge: 2037/0/6. Pushed. |
+| 2. Land build workflow on `naudio3dev` | ⏳ in progress | YAML already validated in Phase 0 — reintroduced with an added `push: branches: [naudio3dev]` trigger. PR will exercise the workflow on its own diff before merging. |
 | 3. Centralize version in `Directory.Build.props` | not started | |
 | 4. Release-notes plumbing + labels + `CLAUDE.md` | not started | |
 | 5. Backfill `RELEASE_NOTES.md` | not started | |
@@ -139,14 +139,14 @@ Goal: prove that GitHub Actions can build and test NAudio with the same coverage
 
 **Outcome:** green build on `windows-latest`. 2028 passing / 0 failed / 7 skipped, 1m49s (Azure baseline was 2m51s). Two YAML adjustments made during validation: dropped the now-redundant `setup-dotnet` step (.NET 10 is preinstalled), and switched to `dotnet test --project ...` to match the .NET 10 CLI's stricter argument parsing — see "Findings carried forward from Phase 0" above. Draft PR closed unmerged.
 
-### Phase 1 — Bring `naudio3dev` up to date with `master`
+### Phase 1 — Bring `naudio3dev` up to date with `master` ✅
 
 6. `git fetch origin`.
 7. `git checkout naudio3dev`, `git merge origin/master`. Resolve conflicts. Likely affected files: `Mp3FileReader.cs` (overlaps with the lazy-TOC work), possibly `WaveStream.cs` (block-alignment fix), and MIDI files (running-status fix). Conflicts in `RELEASE_NOTES.md` are unlikely because `master` hasn't touched it since 2.3.0 shipped.
 8. Run the full test suite locally to confirm the merge is sound.
 9. Push `naudio3dev`.
 
-**Exit criterion:** `naudio3dev` contains all of `origin/master`'s commits; tests pass.
+**Outcome:** clean ORT-strategy merge with zero conflicts. Auto-merged files: `BiQuadFilter.cs`, `WaveStream.cs`, `MidiEvent.cs`, `MidiFile.cs`. New files: `WaveStreamTests.cs`, additions to `MidiFileTests.cs`. Local test run post-merge: 2037 passing / 0 failed / 6 skipped — the +9 vs Phase 0 corresponds to the new regression tests from master.
 
 ### Phase 2 — Land the build workflow on `naudio3dev`
 


### PR DESCRIPTION
Reintroduces the build workflow validated in Phase 0 (#<phase-0-pr-num>), now with a push trigger for naudio3dev so post-merge commits run CI. Also updates Docs/Architecture/ReleaseStrategy.md to track progress.

Once this is green and merged, Azure Pipelines and the new GitHub Actions workflow will run in parallel for one or two more PRs as a safety net (per Phase 2 step 12) before Azure is retired in Phase 9.