### PR TITLE
Phase 3: centralize version in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup>
+    <!-- Lockstep version for all NAudio NuGet packages. CI overrides
+         <VersionSuffix> on pre-release builds (e.g. preview.NN). Sample/tool
+         apps with their own <Version> in the csproj override this. -->
+    <VersionPrefix>3.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <!-- Enable analyzers but don't set default severities - .globalconfig controls rule severities -->

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -10,8 +10,8 @@
 | --- | --- | --- |
 | 0. Validate GitHub Actions | ✅ done | Green build on `windows-latest`. 2028 passing / 0 failed / 7 skipped, 1m49s (Azure was 2m51s). Draft PR closed unmerged; throwaway branch `ci/validate-github-actions` retained for reference. |
 | 1. Merge `origin/master` into `naudio3dev` | ✅ done | Auto-merged via ORT strategy with no conflicts. The expected `Mp3FileReader` clash didn't materialise — master's MP3 sample-rate fix touched different lines from the lazy-TOC work. Local tests post-merge: 2037/0/6. Pushed. |
-| 2. Land build workflow on `naudio3dev` | ⏳ in progress | YAML already validated in Phase 0 — reintroduced with an added `push: branches: [naudio3dev]` trigger. PR will exercise the workflow on its own diff before merging. |
-| 3. Centralize version in `Directory.Build.props` | not started | |
+| 2. Land build workflow on `naudio3dev` | ✅ done | Workflow merged. Azure Pipelines kept running in parallel as a safety net per step 12. |
+| 3. Centralize version in `Directory.Build.props` | ⏳ in progress | `<VersionPrefix>3.0.0</VersionPrefix>` set at root, `<Version>2.3.0</Version>` removed from all 8 NAudio package csprojs. Tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` which still overrides. Local build now produces `*.3.0.0.nupkg`. |
 | 4. Release-notes plumbing + labels + `CLAUDE.md` | not started | |
 | 5. Backfill `RELEASE_NOTES.md` | not started | |
 | 6. Release workflow | not started | |
@@ -148,13 +148,13 @@ Goal: prove that GitHub Actions can build and test NAudio with the same coverage
 
 **Outcome:** clean ORT-strategy merge with zero conflicts. Auto-merged files: `BiQuadFilter.cs`, `WaveStream.cs`, `MidiEvent.cs`, `MidiFile.cs`. New files: `WaveStreamTests.cs`, additions to `MidiFileTests.cs`. Local test run post-merge: 2037 passing / 0 failed / 6 skipped — the +9 vs Phase 0 corresponds to the new regression tests from master.
 
-### Phase 2 — Land the build workflow on `naudio3dev`
+### Phase 2 — Land the build workflow on `naudio3dev` ✅
 
 10. Open a real PR adding `.github/workflows/build.yml` (the validated version from phase 0, with `--project` arg fix and no `setup-dotnet`). Add `push: branches: [naudio3dev]` to the existing `pull_request` and `workflow_dispatch` triggers so post-merge pushes also run CI.
 11. Merge.
 12. Optional: leave Azure Pipelines running in parallel for one or two more PRs as a safety net before deleting in phase 9.
 
-**Exit criterion:** every push to `naudio3dev` runs CI on GitHub Actions.
+**Outcome:** PR opened, CI green on the PR's own diff, merged. Azure Pipelines kept running in parallel as the safety net per step 12; will be retired in phase 9.
 
 ### Phase 3 — Centralize the version
 

--- a/NAudio.Asio/NAudio.Asio.csproj
+++ b/NAudio.Asio/NAudio.Asio.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Core/NAudio.Core.csproj
+++ b/NAudio.Core/NAudio.Core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Authors>Mark Heath</Authors>
-    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/NAudio.Extras/NAudio.Extras.csproj
+++ b/NAudio.Extras/NAudio.Extras.csproj
@@ -12,7 +12,6 @@
     <RepositoryUrl>https://github.com/naudio/NAudio</RepositoryUrl>
     <Copyright>© Mark Heath 2026</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.3.0</Version>
     <PackageIcon>naudio-icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/NAudio.Midi/NAudio.Midi.csproj
+++ b/NAudio.Midi/NAudio.Midi.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Wasapi/NAudio.Wasapi.csproj
+++ b/NAudio.Wasapi/NAudio.Wasapi.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
-    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.WinForms/NAudio.WinForms.csproj
+++ b/NAudio.WinForms/NAudio.WinForms.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.WinMM/NAudio.WinMM.csproj
+++ b/NAudio.WinMM/NAudio.WinMM.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
-    <Version>2.3.0</Version>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>NAudio, an audio library for .NET</Description>


### PR DESCRIPTION
Adds `<VersionPrefix>3.0.0</VersionPrefix>` at the repo root and removes the per-csproj `<Version>2.3.0</Version>` declarations from all 8 NAudio packages. From this point onwards, every build produces `*.3.0.0.nupkg` files — the symbolic version flip to NAudio 3 at the build-artefact level. Nothing reaches NuGet.org until the Phase 7 trusted-publishing smoke test.

Tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` which still overrides the inherited prefix.

Local verification:
- `dotnet build NAudio.slnx --configuration Release` — succeeded, 0 warnings, 0 errors
- All 8 packages produce `*.3.0.0.nupkg`
- Grep for `<Version>2.3.0</Version>` across `**/*.csproj` returns no results

Part of the rollout described in [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md).