### PR TITLE
Phase 4: release-notes plumbing, PR template, CLAUDE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Release notes
+
+<!--
+Tick one. The maintainer may rewrite or remove your entry at release time;
+the goal here is to ensure user-visible changes don't slip through.
+-->
+
+- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
+- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
+- [ ] Leave the release-notes entry for the maintainer to write
+
+## Testing
+
+<!-- How did you verify this works? -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+# Configuration for the auto-generated changelog produced by
+# `gh release create --generate-notes` and the GitHub Releases UI.
+# PRs are categorised by their labels; the maintainer applies labels
+# at review/merge time. Untagged PRs fall into "Other changes".
+# See Docs/Architecture/ReleaseStrategy.md for the broader release flow.
+changelog:
+  exclude:
+    labels:
+      - release-notes-skip
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+    - title: New features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug fixes
+      labels:
+        - bug
+        - bugfix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other changes
+      labels:
+        - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Working in NAudio
+
+This file gives AI agents (Claude, etc.) the conventions for contributing to NAudio. Humans should read [README.md](README.md) and [Docs/Architecture/](Docs/Architecture/) instead.
+
+## Orientation
+
+- **NAudio 3 is in pre-release on the `naudio3dev` branch** (renamed to `main` in a future phase). NAudio 2 maintenance happens on `master` (renamed to `release/2.x` in the same future phase). Default to targeting `naudio3dev` unless explicitly told otherwise.
+- **Architecture docs** in [Docs/Architecture/](Docs/Architecture/) are the source of truth for cross-cutting decisions:
+  - [ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md) — release/branch/version flow
+  - [NAudio3AssemblyLayoutPlan.md](Docs/Architecture/NAudio3AssemblyLayoutPlan.md) — package structure
+  - [MODERNIZATION.md](Docs/Architecture/MODERNIZATION.md) — modernisation phases
+
+## Release notes
+
+When you make a **user-visible change** — new public API, behaviour change, bug fix, deprecation, packaging change — add a one-line bullet to the `### Unreleased` section at the top of [RELEASE_NOTES.md](RELEASE_NOTES.md). Match the style of existing entries:
+
+- Past tense (`Fixed X`, `Added Y`, `Updated Z`)
+- Mention the GitHub PR or issue number if known: `(#1234)`
+- One line, no prose paragraphs — the maintainer will edit at release time
+
+**Skip the release-notes entry only for:** purely internal refactors, test-only changes, dependency bumps with no observable effect, docs/comment fixes. If unsure whether a change is user-visible, **add the entry** and let the maintainer remove it if not needed.
+
+## PR labelling
+
+When opening a PR (where you have permission), apply one of: `breaking`, `enhancement`, `bug`, `documentation`. These feed the auto-generated changelog at release time. Use `release-notes-skip` for PRs that should not appear in the changelog at all.
+
+## Versioning
+
+Package versions are centralised in [Directory.Build.props](Directory.Build.props) as `<VersionPrefix>`. Do **not** add a per-csproj `<Version>` to NAudio packages — they're meant to stay in lockstep. The tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` and are exempt.
+
+## CI
+
+Every PR runs build + test on `windows-latest` via [.github/workflows/build.yml](.github/workflows/build.yml). Tests requiring real audio hardware should be marked with `TestCategory=IntegrationTest` so they're filtered out of the headless run.

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -11,8 +11,8 @@
 | 0. Validate GitHub Actions | ✅ done | Green build on `windows-latest`. 2028 passing / 0 failed / 7 skipped, 1m49s (Azure was 2m51s). Draft PR closed unmerged; throwaway branch `ci/validate-github-actions` retained for reference. |
 | 1. Merge `origin/master` into `naudio3dev` | ✅ done | Auto-merged via ORT strategy with no conflicts. The expected `Mp3FileReader` clash didn't materialise — master's MP3 sample-rate fix touched different lines from the lazy-TOC work. Local tests post-merge: 2037/0/6. Pushed. |
 | 2. Land build workflow on `naudio3dev` | ✅ done | Workflow merged. Azure Pipelines kept running in parallel as a safety net per step 12. |
-| 3. Centralize version in `Directory.Build.props` | ⏳ in progress | `<VersionPrefix>3.0.0</VersionPrefix>` set at root, `<Version>2.3.0</Version>` removed from all 8 NAudio package csprojs. Tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` which still overrides. Local build now produces `*.3.0.0.nupkg`. |
-| 4. Release-notes plumbing + labels + `CLAUDE.md` | not started | |
+| 3. Centralize version in `Directory.Build.props` | ✅ done | `<VersionPrefix>3.0.0</VersionPrefix>` set at root, `<Version>2.3.0</Version>` removed from all 8 NAudio package csprojs. All NAudio packages now build as `*.3.0.0.nupkg`. Tool/sample apps keep their own explicit `<Version>`. |
+| 4. Release-notes plumbing + labels + `CLAUDE.md` | ⏳ in progress | Adds `.github/release.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, `CLAUDE.md`, and an `### Unreleased` placeholder section in `RELEASE_NOTES.md`. Two new labels (`breaking`, `release-notes-skip`) need to be created in the GitHub UI alongside this PR. |
 | 5. Backfill `RELEASE_NOTES.md` | not started | |
 | 6. Release workflow | not started | |
 | 7. NuGet trusted publishing + smoke test | not started | |
@@ -156,14 +156,14 @@ Goal: prove that GitHub Actions can build and test NAudio with the same coverage
 
 **Outcome:** PR opened, CI green on the PR's own diff, merged. Azure Pipelines kept running in parallel as the safety net per step 12; will be retired in phase 9.
 
-### Phase 3 — Centralize the version
+### Phase 3 — Centralize the version ✅
 
 13. Add `<VersionPrefix>3.0.0</VersionPrefix>` to `Directory.Build.props`.
 14. Remove `<Version>2.3.0</Version>` from all 8 `.csproj` files (and the 3 NAudio 3 packages once they exist).
 15. Build locally, confirm all packages produce `3.0.0.nupkg` filenames.
 16. PR + merge.
 
-**Exit criterion:** version is declared in exactly one place.
+**Outcome:** PR #1268 merged. All 8 NAudio packages now produce `*.3.0.0.nupkg` from a single `<VersionPrefix>` declaration. Tool/sample apps left untouched and continue to override with their own explicit `<Version>`.
 
 ### Phase 4 — Add release-notes plumbing and contributor docs
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+### Unreleased
+
+<!--
+Bullets land here as PRs merge. The maintainer renames this section to
+"### 3.0.0 (date)" at release time. See CLAUDE.md and
+Docs/Architecture/ReleaseStrategy.md for the release-notes process.
+-->
+
 ### 2.3.0 (12 Mar 2026)
 
  * Performance improvements for `PropertyStore` and Core Audio property access (#1206)


### PR DESCRIPTION
Adds the lightweight, layered release-notes machinery from [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md):

- **`.github/release.yml`** — categorises auto-generated changelogs by PR label (breaking / enhancement / bug / documentation / other).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — release-notes checkbox with an explicit *leave for maintainer* escape hatch. Note: this template will apply to every future PR.
- **`CLAUDE.md`** — conventions for AI agents working in this repo (release notes, PR labels, versioning, CI).
- **`### Unreleased`** placeholder at the top of `RELEASE_NOTES.md` — contributors and agents land bullets here as PRs merge; the maintainer renames it to `### 3.0.0 (date)` at release time.

Two new labels (`breaking`, `release-notes-skip`) added in the GitHub UI alongside this PR.

Phase 5 (backfilling `### Unreleased` from the post-2.3.0 commits) follows next.