### PR TITLE
Phase 6: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,191 @@
+name: release
+
+# Two triggers:
+#   - workflow_dispatch (manual): cuts a pre-release. By default produces
+#     "<VersionPrefix>-preview.<run_number>"; an optional `milestone` input
+#     overrides the suffix (e.g. "alpha.1", "beta.2", "rc.1").
+#   - push of a v* tag: cuts a final release matching <VersionPrefix>.
+# See Docs/Architecture/ReleaseStrategy.md for the broader release flow.
+on:
+  workflow_dispatch:
+    inputs:
+      milestone:
+        description: "Optional pre-release label (e.g. alpha.1, beta.2, rc.1). Leave blank for auto preview.<run_number>."
+        required: false
+        type: string
+  push:
+    tags: ['v*']
+
+permissions:
+  id-token: write    # for NuGet trusted publishing (OIDC)
+  contents: write    # for `gh release create`
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so gh release --generate-notes can diff against the previous tag
+
+      # Dispatch must come from main (or naudio3dev during the rollout).
+      # Tag pushes are unrestricted because the tag itself is the gate.
+      - name: Verify branch (dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          $allowed = @('refs/heads/main', 'refs/heads/naudio3dev')
+          if ($env:GITHUB_REF -notin $allowed) {
+            Write-Error "Release dispatch must be from main or naudio3dev (got $env:GITHUB_REF)."
+            exit 1
+          }
+
+      - name: Determine version
+        id: version
+        shell: pwsh
+        run: |
+          [xml]$props = Get-Content Directory.Build.props
+          $prefix = $props.Project.PropertyGroup.VersionPrefix
+          if (-not $prefix) {
+            Write-Error "VersionPrefix not found in Directory.Build.props"
+            exit 1
+          }
+
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            $tagVersion = $env:GITHUB_REF -replace 'refs/tags/v',''
+            if ($tagVersion -ne $prefix) {
+              Write-Error "Tag v$tagVersion does not match VersionPrefix $prefix in Directory.Build.props. Bump the prefix and retag."
+              exit 1
+            }
+            $version = $tagVersion
+            $packArgs = ""
+            $isFinal = 'true'
+          } else {
+            $milestone = '${{ inputs.milestone }}'
+            if ([string]::IsNullOrWhiteSpace($milestone)) {
+              $suffix = "preview.${{ github.run_number }}"
+            } else {
+              $suffix = $milestone.Trim()
+            }
+            $version = "$prefix-$suffix"
+            $packArgs = "-p:VersionSuffix=$suffix"
+            $isFinal = 'false'
+          }
+
+          Write-Host "Resolved version: $version (is_final=$isFinal)"
+          "version=$version"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "is_final=$isFinal"    | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "pack_args=$packArgs"  | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Validate RELEASE_NOTES.md has a matching section (final only)
+        if: steps.version.outputs.is_final == 'true'
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $pattern = "^### $([regex]::Escape($version))(\s|$)"
+          if (-not (Select-String -Path RELEASE_NOTES.md -Pattern $pattern -Quiet)) {
+            Write-Error "RELEASE_NOTES.md has no '### $version (...)' section. Rename '### Unreleased' to '### $version (DD MMM YYYY)' before tagging."
+            exit 1
+          }
+
+      - name: Restore
+        run: dotnet restore NAudio.slnx
+
+      - name: Build
+        run: dotnet build NAudio.slnx --configuration Release --no-restore ${{ steps.version.outputs.pack_args }}
+
+      - name: Test
+        run: >
+          dotnet test --project NAudioTests/NAudioTests.csproj
+          --configuration Release
+          --no-build
+          --filter "TestCategory!=IntegrationTest"
+
+      # Pack the 8 NAudio NuGet packages explicitly so we don't accidentally
+      # ship the tool/sample apps. Tools (MixDiff, AudioFileInspector,
+      # MidiFileConverter) keep their own <Version> in csproj but we never
+      # publish them to NuGet.
+      - name: Pack
+        shell: pwsh
+        run: |
+          $packages = @(
+            'NAudio.Core',
+            'NAudio.Asio',
+            'NAudio.WinForms',
+            'NAudio.Midi',
+            'NAudio.WinMM',
+            'NAudio.Wasapi',
+            'NAudio',
+            'NAudio.Extras'
+          )
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          foreach ($pkg in $packages) {
+            dotnet pack "$pkg/$pkg.csproj" `
+              --configuration Release `
+              --no-build `
+              --output artifacts `
+              ${{ steps.version.outputs.pack_args }}
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg-${{ steps.version.outputs.version }}
+          path: artifacts/*.nupkg
+          if-no-files-found: error
+
+      # NuGet trusted publishing via OIDC. The trusted-publisher policy
+      # is configured on NuGet.org per Phase 7 of the release strategy.
+      # If this step needs adjustment after Phase 7's smoke test, update
+      # here — the rest of the workflow is independent of the auth method.
+      - name: NuGet login (trusted publishing)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push to NuGet
+        run: >
+          dotnet nuget push artifacts/*.nupkg
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate
+
+      # GitHub Release only on final tag-driven runs. Pre-releases just
+      # ship to NuGet — no GitHub Release noise for every preview.
+      - name: Extract RELEASE_NOTES.md section (final only)
+        if: steps.version.outputs.is_final == 'true'
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $lines = Get-Content RELEASE_NOTES.md
+          $start = -1
+          $end = $lines.Length
+          for ($i = 0; $i -lt $lines.Length; $i++) {
+            if ($lines[$i] -match "^### $([regex]::Escape($version))(\s|$)") {
+              $start = $i + 1
+            } elseif ($start -ge 0 -and $lines[$i] -match "^### ") {
+              $end = $i
+              break
+            }
+          }
+          if ($start -lt 0) {
+            Write-Error "Could not extract '### $version' section."
+            exit 1
+          }
+          $body = ($lines[$start..($end - 1)] -join "`n").Trim()
+          $body | Out-File -FilePath release-body.md -Encoding utf8
+
+      - name: Create GitHub Release (final only)
+        if: steps.version.outputs.is_final == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" `
+            --title "NAudio ${{ steps.version.outputs.version }}" `
+            --notes-file release-body.md `
+            --verify-tag

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -13,8 +13,8 @@
 | 2. Land build workflow on `naudio3dev` | ✅ done | Workflow merged. Azure Pipelines kept running in parallel as a safety net per step 12. |
 | 3. Centralize version in `Directory.Build.props` | ✅ done | `<VersionPrefix>3.0.0</VersionPrefix>` set at root, `<Version>2.3.0</Version>` removed from all 8 NAudio package csprojs. All NAudio packages now build as `*.3.0.0.nupkg`. Tool/sample apps keep their own explicit `<Version>`. |
 | 4. Release-notes plumbing + labels + `CLAUDE.md` | ✅ done | PR #1269 merged. `.github/release.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, `CLAUDE.md`, and `### Unreleased` placeholder all live. `breaking` and `release-notes-skip` labels added in the UI. |
-| 5. Backfill `RELEASE_NOTES.md` | ⏳ in progress | Walked `git log v2.3.0..naudio3dev` (174 commits), categorised user-visible changes into Breaking / New features / Performance / Reliability / Modernisation / Packaging sub-sections with ~60 bullets. |
-| 6. Release workflow | not started | |
+| 5. Backfill `RELEASE_NOTES.md` | ✅ done | PR #1270 merged. ~60 categorised bullets across six sub-sections under `### Unreleased`, ready for the maintainer to curate further as PRs land. |
+| 6. Release workflow | ⏳ in progress | `.github/workflows/release.yml` drafted with two triggers (`workflow_dispatch` for previews, `push tags v*` for finals), version resolution from `<VersionPrefix>`, validation guards, pack of all 8 NAudio packages, NuGet trusted-publishing push, and a final-only GitHub Release with body extracted from `RELEASE_NOTES.md`. NuGet auth wiring will be exercised end-to-end in Phase 7. |
 | 7. NuGet trusted publishing + smoke test | not started | |
 | 8. Branch flip + protection | not started | |
 | 9. First public preview + retire Azure Pipelines | not started | |
@@ -175,14 +175,14 @@ Goal: prove that GitHub Actions can build and test NAudio with the same coverage
 
 **Outcome:** PR #1269 merged. Plumbing in place; new PRs render the template, the auto-changelog config will categorise correctly when invoked, and `CLAUDE.md` documents the release-notes process for AI agents.
 
-### Phase 5 — Backfill `RELEASE_NOTES.md`
+### Phase 5 — Backfill `RELEASE_NOTES.md` ✅
 
-22. Walk `git log master..naudio3dev` (now empty after phase 1, so use the divergence point — roughly the post-2.3.0 commits on `naudio3dev`).
+22. Walk `git log v2.3.0..naudio3dev` (174 commits).
 23. Group commits into themes: WASAPI modernization, NAudio 3 layout, MF reliability, AOT compatibility, ACM hardening, Mp3FileReader lazy-TOC, DirectSound modernization, etc.
-24. Draft an `### Unreleased` section at the top of `RELEASE_NOTES.md` with one bullet per user-visible change. Estimate: 30–40 bullets.
+24. Draft an `### Unreleased` section at the top of `RELEASE_NOTES.md` with one bullet per user-visible change.
 25. PR + merge.
 
-**Exit criterion:** `RELEASE_NOTES.md` reflects everything landed on `naudio3dev` since 2.3.0.
+**Outcome:** PR #1270 merged. ~60 bullets under `### Unreleased` organised into six sub-sections (Breaking changes, New features, Performance, Reliability and bug fixes, Modernisation, Packaging). Bullets carry no PR numbers — those can be added selectively before final release.
 
 ### Phase 6 — Add the release workflow
 


### PR DESCRIPTION
Adds [.github/workflows/release.yml](.github/workflows/release.yml) — the release pipeline described in [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md).

**Triggers:**
- `workflow_dispatch` (manual) → cuts a pre-release. Optional `milestone` input overrides the default suffix; otherwise produces `<VersionPrefix>-preview.<run_number>`.
- Push of a `v*` tag → cuts a final release matching `<VersionPrefix>`.

**Validation guards:**
- Dispatch must come from `main` or `naudio3dev`.
- Tag must equal `<VersionPrefix>` in [Directory.Build.props](Directory.Build.props).
- Final releases require a matching `### <version>` section in [RELEASE_NOTES.md](RELEASE_NOTES.md).

**Pipeline:** restore → build → test → pack the 8 NAudio packages by name → upload artifacts → NuGet trusted-publishing push → (final only) create GitHub Release with body extracted from `RELEASE_NOTES.md`.

**Notes for review:**
- This PR adds the workflow but doesn't fire it (only `workflow_dispatch` and tag pushes trigger; the merge itself is safe).
- NuGet auth uses `NuGet/login@v1` with `${{ vars.NUGET_USER }}`. The trusted-publisher policy on NuGet.org is configured in Phase 7, where the auth wiring gets exercised end-to-end.
- The pack list (8 packages) will need three additions when the NAudio 3 `Wasapi` split into `MediaFoundation` / `Dmo` / `DirectSound` lands.
- `--generate-notes` was dropped from `gh release create` because it's mutually exclusive with `--notes-file`. If we later want the auto-PR list appended, that's a separate follow-up.