### PR TITLE
Cleanup after main/release/2.x rename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: build
 
-# Build & test on every PR, every push to naudio3dev (the NAudio 3 dev branch),
-# and on demand. The .NET 10 SDK is preinstalled on windows-latest, so no
-# explicit setup-dotnet step is needed today — see Docs/Architecture/ReleaseStrategy.md
-# for the trade-off if the runner image ever rotates and drops it.
+# Build & test on every PR, every push to main, and on demand. The .NET 10
+# SDK is preinstalled on windows-latest, so no explicit setup-dotnet step is
+# needed today — see Docs/Architecture/ReleaseStrategy.md for the trade-off
+# if the runner image ever rotates and drops it.
 on:
   pull_request:
   push:
-    branches: [naudio3dev]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,14 @@ jobs:
         with:
           fetch-depth: 0   # full history so gh release --generate-notes can diff against the previous tag
 
-      # Dispatch must come from main (or naudio3dev during the rollout).
-      # Tag pushes are unrestricted because the tag itself is the gate.
+      # Dispatch must come from main. Tag pushes are unrestricted because
+      # the tag itself is the gate.
       - name: Verify branch (dispatch only)
         if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
-          $allowed = @('refs/heads/main', 'refs/heads/naudio3dev')
-          if ($env:GITHUB_REF -notin $allowed) {
-            Write-Error "Release dispatch must be from main or naudio3dev (got $env:GITHUB_REF)."
+          if ($env:GITHUB_REF -ne 'refs/heads/main') {
+            Write-Error "Release dispatch must be from main (got $env:GITHUB_REF)."
             exit 1
           }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file gives AI agents (Claude, etc.) the conventions for contributing to NAu
 
 ## Orientation
 
-- **NAudio 3 is in pre-release on the `naudio3dev` branch** (renamed to `main` in a future phase). NAudio 2 maintenance happens on `master` (renamed to `release/2.x` in the same future phase). Default to targeting `naudio3dev` unless explicitly told otherwise.
+- **NAudio 3 development happens on `main`.** NAudio 2 maintenance happens on `release/2.x`. Default to targeting `main` unless explicitly told otherwise. `main` and `release/*` are protected — all changes go through PRs.
 - **Architecture docs** in [Docs/Architecture/](Docs/Architecture/) are the source of truth for cross-cutting decisions:
   - [ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md) — release/branch/version flow
   - [NAudio3AssemblyLayoutPlan.md](Docs/Architecture/NAudio3AssemblyLayoutPlan.md) — package structure

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -2,7 +2,7 @@
 
 **Goal:** Replace the current manual `publish.ps1` flow with an automated GitHub Actions pipeline that publishes both regular pre-release builds (cheap, frequent, on demand) and final releases (tag-driven, with GitHub Releases attached). Rebrand `naudio3dev` as the default branch, retire NAudio 2 to a maintenance branch, and put a lightweight discipline around release notes that keeps the maintainer in control without blocking PRs.
 
-**Branch:** work continues on `naudio3dev` until step 8 of the plan, at which point it is renamed to `main`.
+**Branch:** work continues on `main` (renamed from `naudio3dev` in step 8). NAudio 2 maintenance lives on `release/2.x` (renamed from `master`). Both are protected; all changes via PR.
 
 ## Status
 
@@ -14,9 +14,9 @@
 | 3. Centralize version in `Directory.Build.props` | ✅ done | `<VersionPrefix>3.0.0</VersionPrefix>` set at root, `<Version>2.3.0</Version>` removed from all 8 NAudio package csprojs. All NAudio packages now build as `*.3.0.0.nupkg`. Tool/sample apps keep their own explicit `<Version>`. |
 | 4. Release-notes plumbing + labels + `CLAUDE.md` | ✅ done | PR #1269 merged. `.github/release.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, `CLAUDE.md`, and `### Unreleased` placeholder all live. `breaking` and `release-notes-skip` labels added in the UI. |
 | 5. Backfill `RELEASE_NOTES.md` | ✅ done | PR #1270 merged. ~60 categorised bullets across six sub-sections under `### Unreleased`, ready for the maintainer to curate further as PRs land. |
-| 6. Release workflow | ⏳ in progress | `.github/workflows/release.yml` drafted with two triggers (`workflow_dispatch` for previews, `push tags v*` for finals), version resolution from `<VersionPrefix>`, validation guards, pack of all 8 NAudio packages, NuGet trusted-publishing push, and a final-only GitHub Release with body extracted from `RELEASE_NOTES.md`. NuGet auth wiring will be exercised end-to-end in Phase 7. |
-| 7. NuGet trusted publishing + smoke test | not started | |
-| 8. Branch flip + protection | not started | |
+| 6. Release workflow | ✅ done | PR #1271 merged. Two triggers (`workflow_dispatch` for previews, `push tags v*` for finals), version resolution from `<VersionPrefix>`, validation guards, pack of all 8 NAudio packages, NuGet trusted-publishing push, and a final-only GitHub Release with body extracted from `RELEASE_NOTES.md`. |
+| 7. NuGet trusted publishing + smoke test | ⏳ in progress | Reordered to follow Phase 8 because `workflow_dispatch` only shows in the GitHub UI for workflows on the default branch; the smoke test couldn't run until the rename. |
+| 8. Branch flip + protection | ⏳ in progress | `master` → `release/2.x` and `naudio3dev` → `main` done; `main` is default; ruleset "Protected branches" applied to default + `release/*` (require PR, require `build` status check, require linear history, block force-push, block deletion). Cleanup PR pending to update workflow files and doc/README links. |
 | 9. First public preview + retire Azure Pipelines | not started | |
 | 10. First final release | future | |
 
@@ -210,20 +210,23 @@ Goal: prove that GitHub Actions can build and test NAudio with the same coverage
 
 **Exit criterion:** a valid pre-release exists on NuGet.org and installs cleanly into a test project.
 
-### Phase 8 — Branch flip and protection
+### Phase 8 — Branch flip and protection ⏳
 
-34. In GitHub Settings → Branches, **rename `master` → `release/2.x`**. Confirm any open PRs are re-targeted (they probably aren't any).
+> **Note on order:** in practice this phase ran *before* Phase 7. The Phase 7 smoke test requires `workflow_dispatch` to be visible in the GitHub UI, which only happens for workflows on the default branch. The rename to `main` was therefore prerequisite, not subsequent.
+
+34. In GitHub Settings → Branches, **rename `master` → `release/2.x`**. Confirm any open PRs are re-targeted (open PRs against `master` follow automatically).
 35. In GitHub Settings → Branches, **rename `naudio3dev` → `main`**. Confirm open PRs are re-targeted.
 36. In GitHub Settings → General, set `main` as the default branch.
-37. Add branch protection rules to `main`:
-    - Require pull request reviews before merging (1 approval).
-    - Require status checks to pass before merging — select the build workflow.
-    - Require linear history (recommended).
-    - Block direct pushes (apply to administrators too — the maintainer included).
-38. Add the same protection to `release/2.x`.
-39. Notify any active contributors to update their local clones (`git branch -m master main`, `git fetch`, `git branch -u origin/main main`, `git remote set-head origin -a`).
+37. Add a Ruleset "Protected branches" targeting Default + `release/*`:
+    - Require a pull request before merging (approvals: 0 for solo).
+    - Require status checks to pass — `build`.
+    - Require linear history.
+    - Block force pushes; restrict deletions.
+    - Disable "Allow merge commits" in repo settings (incompatible with linear history).
+38. Cleanup PR follow-up: update `build.yml` push trigger to `[main]`, drop `naudio3dev` from `release.yml` branch allowlist, refresh `CLAUDE.md` and `README.md` links, update `ReleaseStrategy.md` status.
+39. Notify any active contributors to update their local clones (`git fetch origin --prune`, `git branch -m naudio3dev main`, `git branch -u origin/main main`, `git remote set-head origin -a`).
 
-**Exit criterion:** `main` is the default; both protected branches block direct pushes; CI is required on every PR.
+**Exit criterion:** `main` is the default; both protected branches block direct pushes; CI is required on every PR; the cleanup PR has merged so workflow files reflect the new branch names.
 
 ### Phase 9 — Cut a real preview and retire the old flow
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NAudio
 
-[![GitHub](https://img.shields.io/github/license/naudio/NAudio)](https://github.com/naudio/NAudio/blob/master/LICENSE) [![Nuget](https://img.shields.io/nuget/v/NAudio)](https://www.nuget.org/packages/NAudio/) [![Build Status](https://dev.azure.com/naudio/NAudio/_apis/build/status/naudio.NAudio)](https://dev.azure.com/naudio/NAudio/_build)
+[![GitHub](https://img.shields.io/github/license/naudio/NAudio)](https://github.com/naudio/NAudio/blob/main/LICENSE) [![Nuget](https://img.shields.io/nuget/v/NAudio)](https://www.nuget.org/packages/NAudio/) [![Build Status](https://dev.azure.com/naudio/NAudio/_apis/build/status/naudio.NAudio)](https://dev.azure.com/naudio/NAudio/_build)
 
 NAudio is an open source .NET audio library written by [Mark Heath](https://markheath.net)
 
@@ -55,7 +55,7 @@ NAudio is an open source .NET audio library written by [Mark Heath](https://mark
 
 The easiest way to install NAudio into your project is to install the latest [NAudio NuGet package](https://www.nuget.org/packages/NAudio/). Prerelease versions of NAudio are also often made available on NuGet.
 
-NAudio comes with several demo applications which are the quickest way to see how to use the various features of NAudio. You can explore the source code [here](https://github.com/naudio/NAudio/tree/master/NAudioDemo).
+NAudio comes with several demo applications which are the quickest way to see how to use the various features of NAudio. You can explore the source code [here](https://github.com/naudio/NAudio/tree/main/NAudioDemo).
 
 ## Tutorials
 
@@ -153,7 +153,7 @@ To be successful developing applications that process digital audio, there are s
 
 ## How do I...?
 
-The best way to learn how to use NAudio is to download the source code and look at the two demo applications - [NAudioDemo](https://github.com/naudio/NAudio/tree/master/NAudioDemo) and [NAudioWpfDemo](https://github.com/naudio/NAudio/tree/master/NAudioWpfDemo). These demonstrate several of the key capabilities of the NAudio framework. They also have the advantage of being kept up to date, whilst some of the tutorials you will find on the internet refer to old versions of NAudio.
+The best way to learn how to use NAudio is to download the source code and look at the two demo applications - [NAudioDemo](https://github.com/naudio/NAudio/tree/main/NAudioDemo) and [NAudioWpfDemo](https://github.com/naudio/NAudio/tree/main/NAudioWpfDemo). These demonstrate several of the key capabilities of the NAudio framework. They also have the advantage of being kept up to date, whilst some of the tutorials you will find on the internet refer to old versions of NAudio.
 
 ## FAQ
 


### PR DESCRIPTION
Post-rename cleanup. With `naudio3dev` → `main` and `master` → `release/2.x` done in the GitHub UI, this PR updates the in-repo references that need to follow.

**Workflow files**
- `.github/workflows/build.yml`: push trigger updated from `[naudio3dev]` to `[main]`.
- `.github/workflows/release.yml`: branch allowlist tightened to `main` only (`naudio3dev` no longer exists; tag pushes remain unrestricted).

**Docs**
- [CLAUDE.md](CLAUDE.md) branches section reflects `main` as default + protection.
- [README.md](README.md) `/tree/master/` and `/blob/master/` links updated to `/main/` (3 occurrences).
- [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md) records the actual phase order — 8 ran before 7 because `workflow_dispatch` only surfaces in the GitHub UI for workflows on the default branch; the smoke test couldn't run until the rename.

This is the first PR going to `main` with branch protection enabled, so it also exercises the new ruleset end-to-end.