### PR TITLE
Fix release push step: expand .nupkg glob explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,12 +146,29 @@ jobs:
         with:
           user: ${{ vars.NUGET_USER }}
 
+      # dotnet nuget push does not expand globs on its own, and PowerShell
+      # does not expand wildcards in arguments to external commands. So loop
+      # over the artifacts explicitly. This also gives per-package error
+      # reporting.
       - name: Push to NuGet
-        run: >
-          dotnet nuget push artifacts/*.nupkg
-          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-          --source https://api.nuget.org/v3/index.json
-          --skip-duplicate
+        shell: pwsh
+        run: |
+          $packages = Get-ChildItem -Path artifacts -Filter *.nupkg
+          if (-not $packages) {
+            Write-Error "No .nupkg files found in artifacts/"
+            exit 1
+          }
+          foreach ($pkg in $packages) {
+            Write-Host "Pushing $($pkg.Name)"
+            dotnet nuget push $pkg.FullName `
+              --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} `
+              --source https://api.nuget.org/v3/index.json `
+              --skip-duplicate
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Failed to push $($pkg.Name)"
+              exit $LASTEXITCODE
+            }
+          }
 
       # GitHub Release only on final tag-driven runs. Pre-releases just
       # ship to NuGet — no GitHub Release noise for every preview.


### PR DESCRIPTION
First Phase 7 smoke test (run [25640303551](https://github.com/naudio/NAudio/actions/runs/25640303551)) got as far as the NuGet push step before failing with:

> error: File does not exist (artifacts/*.nupkg).

PowerShell (the default shell on `windows-latest`) does not expand wildcards in arguments to external commands the way bash does, and `dotnet nuget push` does not expand globs itself — so the literal string `artifacts/*.nupkg` was passed and rejected.

This PR replaces the single `dotnet nuget push artifacts/*.nupkg` call with an explicit `Get-ChildItem` loop. As a bonus, individual push failures now report which package failed, rather than aborting the whole step opaquely.

Trusted publishing auth, pack, and artifact upload all worked on the first attempt — the failed run's artifacts are still downloadable from the GitHub Actions run page for inspection.

After merging, dispatching again will produce `3.0.0-preview.2` (run_number is monotonic per workflow regardless of outcome).