### PR TITLE
SourceLink, symbol packages, deterministic CI + release instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nupkg-${{ steps.version.outputs.version }}
-          path: artifacts/*.nupkg
+          path: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg
           if-no-files-found: error
 
       # NuGet trusted publishing via OIDC. The trusted-publisher policy
@@ -149,11 +151,13 @@ jobs:
       # dotnet nuget push does not expand globs on its own, and PowerShell
       # does not expand wildcards in arguments to external commands. So loop
       # over the artifacts explicitly. This also gives per-package error
-      # reporting.
+      # reporting. We iterate .nupkg files only; the matching .snupkg
+      # symbol packages sitting next to each .nupkg are pushed automatically
+      # by `dotnet nuget push` in the same call.
       - name: Push to NuGet
         shell: pwsh
         run: |
-          $packages = Get-ChildItem -Path artifacts -Filter *.nupkg
+          $packages = Get-ChildItem -Path "artifacts\*.nupkg"
           if (-not $packages) {
             Write-Error "No .nupkg files found in artifacts/"
             exit 1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,19 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)NAudioStrongNameKey.snk</AssemblyOriginatorKeyFile>
 
+    <!-- SourceLink + symbol packages + reproducible CI builds.
+         .NET 8+ ships SourceLink in the SDK; PublishRepositoryUrl=true
+         activates it for GitHub-hosted repos without any PackageReference.
+         Symbol packages (.snupkg) sit next to .nupkg and are pushed
+         alongside automatically by `dotnet nuget push`. CI sets
+         ContinuousIntegrationBuild=true for reproducible binaries; local
+         dev builds keep absolute paths for easier debugging. -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <!-- Enable analyzers but don't set default severities - .globalconfig controls rule severities -->

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -17,8 +17,9 @@
 | 6. Release workflow | ✅ done | PR #1271 merged. Two triggers (`workflow_dispatch` for previews, `push tags v*` for finals), version resolution from `<VersionPrefix>`, validation guards, pack of all 8 NAudio packages, NuGet trusted-publishing push, and a final-only GitHub Release with body extracted from `RELEASE_NOTES.md`. |
 | 7. NuGet trusted publishing + smoke test | ✅ done | Trusted publisher configured on NuGet.org; `vars.NUGET_USER` set in repo. First dispatch (`preview.1`) burned at the push step on a PowerShell glob-expansion bug, fixed in PR #1273. Re-dispatch shipped all 8 packages as `3.0.0-preview.2`. |
 | 8. Branch flip + protection | ✅ done | `master` → `release/2.x` and `naudio3dev` → `main`. `main` is default. Ruleset "Protected branches" on default + `release/*` (require PR, require `build` status check, require linear history, block force-push, block deletion). Cleanup PR #1272 followed up workflow files and doc/README links. |
-| 9. First public preview + retire Azure Pipelines | ⏳ in progress | `3.0.0-preview.2` already shipped to NuGet as part of Phase 7's smoke test (counts as step 40). This phase's cleanup PR deletes `azure-pipelines.yml` and `publish.ps1`, drops `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` from all 8 NAudio package csprojs, swaps the Azure Pipelines build badge in `README.md` for a GitHub Actions one, and refreshes the seven per-package READMEs to mention `net9.0` instead of `net8.0`. Announcement to contributors is a separate manual step (see §"Communication" below). |
-| 10. First final release | future | |
+| 9. First public preview + retire Azure Pipelines | ✅ done | `3.0.0-preview.2` shipped to NuGet via the new flow. PR #1274 deleted `azure-pipelines.yml` and `publish.ps1`, dropped `<GeneratePackageOnBuild>` from all 8 NAudio packages, refreshed badges and READMEs, and consolidated duplicated csproj boilerplate into `Directory.Build.props` and `Directory.Build.targets`. Contributor announcement and stale-PR triage remain as non-blocking manual steps (see §"Communication"). Azure DevOps cleanup is in §"Retiring Azure DevOps". |
+| 10. SourceLink + symbol packages + deterministic CI | ⏳ in progress | Adds `<PublishRepositoryUrl>`, `<EmbedUntrackedSources>`, `<IncludeSymbols>`, `<SymbolPackageFormat>snupkg`, and a CI-only `<ContinuousIntegrationBuild>` to `Directory.Build.props`. .NET 8+ ships SourceLink in the SDK so no `Microsoft.SourceLink.GitHub` PackageReference is needed. Release workflow updated to upload both `.nupkg` and `.snupkg` artifacts; `dotnet nuget push` auto-pushes symbol packages alongside their nupkg. |
+| 11. First final 3.0.0 release | future | |
 
 ### Findings carried forward from Phase 0
 
@@ -258,9 +259,28 @@ When the time comes for `3.0.0` proper:
 46. Update `<VersionPrefix>` to `3.0.0` (no suffix needed — handled by the workflow).
 47. Push tag `v3.0.0`. The release workflow does the rest.
 
+## Retiring Azure DevOps
+
+The `azure-pipelines.yml` and `publish.ps1` files are gone in Phase 9, but the Azure DevOps project at `dev.azure.com/naudio` and its associated GitHub access still exist. Recommended order:
+
+### GitHub side
+
+1. Settings → Integrations → Installed GitHub Apps → uninstall the **Azure Pipelines** app if present.
+2. Settings → Webhooks → delete any pointing at `dev.azure.com`.
+3. Settings → Branches → Ruleset → required status checks → confirm no Azure Pipelines check is required (would block PRs indefinitely).
+4. Personal settings → Applications → Authorized OAuth Apps → revoke **Azure DevOps** / **Azure Pipelines** if present.
+
+### Azure DevOps side
+
+1. Pipelines → NAudio pipeline → `...` menu → **Disable** (preserves history) or **Delete**.
+2. Project Settings → Service connections → delete any GitHub connection.
+3. *(Optional)* Project Settings → Overview → **Delete project** — recoverable for 28 days, then permanently gone. Frees the `naudio` name in the ADO org.
+
+The pragmatic path: disable the pipeline first, wait a couple of weeks, then delete the project.
+
 ## Out of scope
 
 - Migrating CHANGELOG generation tooling beyond the GitHub built-in (`.github/release.yml`). If we outgrow it, swap in something heavier later.
 - Per-package independent versioning. Lockstep is the chosen model; revisit only if it becomes painful.
-- Symbol packages (`snupkg`) and SourceLink — recommended best practices, but tracked separately so they don't bloat this rollout.
 - Automatic changelog enforcement via CI block. Explicitly rejected as friction without value.
+- Appending the auto-generated PR list to GitHub Release bodies. `gh release create` makes `--notes-file` and `--generate-notes` mutually exclusive; adding both would require fetching auto-notes via `gh api` and concatenating. Possible follow-up if the curated notes alone prove insufficient.

--- a/ReleaseInstructions.md
+++ b/ReleaseInstructions.md
@@ -1,0 +1,80 @@
+# Release instructions
+
+Quick reminder card for cutting NAudio releases. Full design rationale and history is in [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md).
+
+Prerequisites: `gh` CLI authenticated, working directory inside the repo, on `main` for the local-clone steps.
+
+## 1. Auto-numbered preview
+
+```sh
+gh workflow run release.yml
+```
+
+Produces `<VersionPrefix>-preview.<run_number>` — e.g. `3.0.0-preview.5`. Watch in the [Actions tab](https://github.com/naudio/NAudio/actions/workflows/release.yml). On success, all 8 packages (`.nupkg` + `.snupkg`) appear on NuGet within a few minutes.
+
+## 2. Named pre-release milestone
+
+Override the suffix via the `milestone` input. Use for alpha / beta / rc progression:
+
+```sh
+gh workflow run release.yml -f milestone=rc.1
+```
+
+Suffix ordering on NuGet: `alpha.N < beta.N < preview.N < rc.N < (final)`. Always use the **dotted** form (`rc.1`, not `rc1`) so the trailing integer compares numerically — `rc.10 > rc.9` only works with the dot.
+
+## 3. Full release
+
+### a. Pre-flight PR
+
+1. Bump `<VersionPrefix>` in [Directory.Build.props](Directory.Build.props) to the target version (e.g. `3.0.0`).
+2. In [RELEASE_NOTES.md](RELEASE_NOTES.md): rename `### Unreleased` → `### 3.0.0 (DD MMM YYYY)`, curate the bullets, add PR numbers where useful.
+3. Add a fresh empty `### Unreleased` section above the renamed one so post-release contributors have a place to land bullets.
+
+Merge via the usual protected-branch flow.
+
+### b. Tag and push
+
+From local `main` synced to the merge commit:
+
+```sh
+git fetch origin
+git checkout main
+git pull --ff-only
+git tag v3.0.0
+git push origin v3.0.0
+```
+
+The tag push triggers `release.yml`, which:
+
+- Validates the tag matches `<VersionPrefix>` in `Directory.Build.props`.
+- Validates `RELEASE_NOTES.md` has a matching `### 3.0.0` section.
+- Packs all 8 NAudio packages (+ matching `.snupkg` symbol packages).
+- Pushes everything to NuGet via trusted publishing.
+- Creates a GitHub Release titled `NAudio 3.0.0` with body extracted from the `RELEASE_NOTES.md` section.
+
+No further action required for the publish itself. Both validations are fail-fast — if `VersionPrefix` or release notes don't match the tag, the workflow errors before packing.
+
+### c. Post-release version bump PR
+
+Open a small follow-up PR bumping `<VersionPrefix>` in `Directory.Build.props` to the next development version (e.g. `3.0.1` or `3.1.0`). Without this, the next preview dispatch produces a version *lower* than the just-shipped final (since `3.0.0-preview.N < 3.0.0`).
+
+### d. Announce
+
+GitHub Release + NuGet are the canonical channels. Optionally:
+
+- Blog post on markheath.net
+- Social media
+- Pin a GitHub Discussion for major-version announcements
+
+## Troubleshooting
+
+- **`gh workflow run` returns "workflow not found":** the workflow file must exist on the default branch. After Phase 8 the default is `main`; should always work.
+- **NuGet push fails with auth error:** the trusted-publisher policy on NuGet.org has a 7-day temporarily-active window. After a successful publish it becomes permanent, but if no publish happens for 7 days it goes inactive. Re-activate at NuGet.org → username → Trusted Publishing.
+- **`Tag v3.0.0 does not match VersionPrefix 3.0.0-alpha`** (or similar): you're tagging a commit whose `Directory.Build.props` doesn't have `<VersionPrefix>3.0.0</VersionPrefix>`. Either retag after the pre-flight PR merges, or push a fixup commit and tag that.
+- **`RELEASE_NOTES.md has no '### 3.0.0' section`:** the pre-flight PR didn't rename `### Unreleased`. Push a fix to `main` and delete + re-create the tag.
+
+## See also
+
+- Full release strategy and decision rationale: [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md)
+- Release workflow file: [.github/workflows/release.yml](.github/workflows/release.yml)
+- Build workflow file: [.github/workflows/build.yml](.github/workflows/build.yml)


### PR DESCRIPTION
Two commits, separable for revert.

## 1. SourceLink + symbol packages + deterministic CI builds ([`36dd45b`](https://github.com/naudio/NAudio/commit/36dd45b))

Adds best-practice debugging and reproducibility to every NAudio package:

**[Directory.Build.props](Directory.Build.props)** — five properties:

- `<PublishRepositoryUrl>true</PublishRepositoryUrl>` + `<EmbedUntrackedSources>true</EmbedUntrackedSources>` — activate SourceLink. .NET 8+ ships SourceLink in the SDK, so no `Microsoft.SourceLink.GitHub` PackageReference is required.
- `<IncludeSymbols>true</IncludeSymbols>` + `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` — produce `.snupkg` alongside each `.nupkg`. NuGet.org auto-accepts the symbol package via the same push.
- `<ContinuousIntegrationBuild Condition=\"'\$(GITHUB_ACTIONS)' == 'true'\">true</ContinuousIntegrationBuild>` — reproducible binaries on CI; local builds keep absolute paths for easier debugging.

**[.github/workflows/release.yml](.github/workflows/release.yml)**:

- Upload-artifact pattern broadened to capture both \`.nupkg\` and \`.snupkg\`.
- Push step's \`Get-ChildItem\` switched to a path glob (\`artifacts\\*.nupkg\`) to be unambiguous about iterating \`.nupkg\` only — the matching \`.snupkg\` next to each is auto-pushed by \`dotnet nuget push\` in the same call.

**[Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md)**:

- Phase 9 marked done (preview.2 shipped, PR #1274 merged).
- New Phase 10 entry tracking this work; final-release phase renumbered to 11.
- New \"Retiring Azure DevOps\" section with the GitHub-side and ADO-side cleanup checklist (uninstall the Azure Pipelines GitHub App, revoke OAuth, disable then delete the ADO pipeline / project).
- \"Out of scope\" list refreshed: SourceLink/snupkg/deterministic removed (now done); appending an auto-generated PR list to GitHub Release bodies added as a deferred item.

Local verification: \`dotnet pack NAudio.Core ...\` produced both \`NAudio.Core.3.0.0-preview.test.nupkg\` and \`NAudio.Core.3.0.0-preview.test.snupkg\`. Build clean across the solution.

## 2. ReleaseInstructions.md ([`c208fa7`](https://github.com/naudio/NAudio/commit/c208fa7))

Succinct operational reminder card at the repo root, peer to \`RELEASE_NOTES.md\`. Three numbered scenarios — auto-numbered preview, named pre-release milestone, full release — plus a troubleshooting section covering the gotchas the rollout surfaced (workflow visibility on default branch, NuGet 7-day trusted-publisher window, tag/VersionPrefix mismatch, missing RELEASE_NOTES section).

Design rationale and history remains in [Docs/Architecture/ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md) — the new doc just gives future-you a copy-pasteable reminder.