### PR TITLE
Strip HTML comments from extracted release-notes section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,10 @@ jobs:
               "" | Out-File -FilePath release-body.md -Encoding utf8
             }
           } else {
-            $body = ($lines[$start..($end - 1)] -join "`n").Trim()
+            $body = $lines[$start..($end - 1)] -join "`n"
+            # Strip HTML comments — useful for contributors editing
+            # RELEASE_NOTES.md but noisy on the NuGet page / GitHub Release.
+            $body = [regex]::Replace($body, '<!--[\s\S]*?-->', '').Trim()
             $body | Out-File -FilePath release-body.md -Encoding utf8
             Write-Host "Extracted '$label' ($($body.Length) chars) to release-body.md."
           }


### PR DESCRIPTION
Follow-up to #1276. The `### Unreleased` section in [RELEASE_NOTES.md](RELEASE_NOTES.md) has an HTML-comment placeholder explaining the section's role:

```html
<!--
Bullets land here as PRs merge. The maintainer renames this section to
\"### 3.0.0 (date)\" at release time. See CLAUDE.md and
Docs/Architecture/ReleaseStrategy.md for the release-notes process.
-->
```

It was being copied verbatim into `release-body.md` and then into both the embedded `<PackageReleaseNotes>` on each nupkg and (for finals) the GitHub Release body. Useful for editors of `RELEASE_NOTES.md`, noisy for consumers.

This PR strips HTML comments (`<!-- ... -->`, multi-line) from the extracted content after the section extract and before writing the file. One `[regex]::Replace` + a `Trim()` to clean up any leftover leading blank line.

## Verification

Tested locally against the current `### Unreleased` content — the comment is removed and the file now starts cleanly at `#### Breaking changes`. The actual extraction logic is unchanged; only the post-extract sanitisation is new.

After merge, the next preview dispatch should produce a NuGet page sidebar that opens directly with the breaking-changes bullets rather than the placeholder text.