### PR TITLE
Enhance MIDI In demo panel

### DIFF
--- a/NAudioDemo/MidiInDemo/MidiInPanel.Designer.cs
+++ b/NAudioDemo/MidiInDemo/MidiInPanel.Designer.cs
@@ -35,6 +35,7 @@ namespace NAudioDemo.MidiInDemo
             this.checkBoxFilterAutoSensing = new System.Windows.Forms.CheckBox();
             this.progressLog1 = new NAudio.Utils.ProgressLog();
             this.buttonClearLog = new System.Windows.Forms.Button();
+            this.buttonRefreshDevices = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.checkBoxMidiOutMessages = new System.Windows.Forms.CheckBox();
             this.comboBoxMidiOutDevices = new System.Windows.Forms.ComboBox();
@@ -73,6 +74,8 @@ namespace NAudioDemo.MidiInDemo
             // checkBoxFilterAutoSensing
             // 
             this.checkBoxFilterAutoSensing.AutoSize = true;
+            this.checkBoxFilterAutoSensing.Checked = true;
+            this.checkBoxFilterAutoSensing.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxFilterAutoSensing.Location = new System.Drawing.Point(384, 47);
             this.checkBoxFilterAutoSensing.Name = "checkBoxFilterAutoSensing";
             this.checkBoxFilterAutoSensing.Size = new System.Drawing.Size(114, 17);
@@ -91,16 +94,26 @@ namespace NAudioDemo.MidiInDemo
             this.progressLog1.Padding = new System.Windows.Forms.Padding(1);
             this.progressLog1.Size = new System.Drawing.Size(486, 258);
             this.progressLog1.TabIndex = 3;
-            // 
+            //
             // buttonClearLog
-            // 
-            this.buttonClearLog.Location = new System.Drawing.Point(94, 41);
+            //
+            this.buttonClearLog.Location = new System.Drawing.Point(175, 41);
             this.buttonClearLog.Name = "buttonClearLog";
             this.buttonClearLog.Size = new System.Drawing.Size(75, 23);
             this.buttonClearLog.TabIndex = 5;
             this.buttonClearLog.Text = "Clear Log";
             this.buttonClearLog.UseVisualStyleBackColor = true;
             this.buttonClearLog.Click += new System.EventHandler(this.buttonClearLog_Click);
+            //
+            // buttonRefreshDevices
+            //
+            this.buttonRefreshDevices.Location = new System.Drawing.Point(94, 41);
+            this.buttonRefreshDevices.Name = "buttonRefreshDevices";
+            this.buttonRefreshDevices.Size = new System.Drawing.Size(75, 23);
+            this.buttonRefreshDevices.TabIndex = 7;
+            this.buttonRefreshDevices.Text = "Refresh";
+            this.buttonRefreshDevices.UseVisualStyleBackColor = true;
+            this.buttonRefreshDevices.Click += new System.EventHandler(this.buttonRefreshDevices_Click);
             // 
             // groupBox1
             // 
@@ -124,6 +137,7 @@ namespace NAudioDemo.MidiInDemo
             this.checkBoxMidiOutMessages.TabIndex = 0;
             this.checkBoxMidiOutMessages.Text = "Send Test MIDI Out Messages";
             this.checkBoxMidiOutMessages.UseVisualStyleBackColor = true;
+            this.checkBoxMidiOutMessages.CheckedChanged += new System.EventHandler(this.checkBoxMidiOutMessages_CheckedChanged);
             // 
             // comboBoxMidiOutDevices
             // 
@@ -146,6 +160,7 @@ namespace NAudioDemo.MidiInDemo
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(510, 399);
             this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.buttonRefreshDevices);
             this.Controls.Add(this.buttonClearLog);
             this.Controls.Add(this.checkBoxFilterAutoSensing);
             this.Controls.Add(this.progressLog1);
@@ -171,6 +186,7 @@ namespace NAudioDemo.MidiInDemo
         private NAudio.Utils.ProgressLog progressLog1;
         private System.Windows.Forms.CheckBox checkBoxFilterAutoSensing;
         private System.Windows.Forms.Button buttonClearLog;
+        private System.Windows.Forms.Button buttonRefreshDevices;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox checkBoxMidiOutMessages;
         private System.Windows.Forms.ComboBox comboBoxMidiOutDevices;

--- a/NAudioDemo/MidiInDemo/MidiInPanel.cs
+++ b/NAudioDemo/MidiInDemo/MidiInPanel.cs
@@ -11,6 +11,7 @@ namespace NAudioDemo.MidiInDemo
         MidiIn midiIn;
         MidiOut midiOut;
         bool monitoring;
+        bool sendingMidiOut;
         List<MidiEvent> events;
         int midiOutIndex;
 
@@ -21,22 +22,7 @@ namespace NAudioDemo.MidiInDemo
 
         private void MidiInForm_Load(object sender, EventArgs e)
         {
-            for (int device = 0; device < MidiIn.NumberOfDevices; device++)
-            {
-                comboBoxMidiInDevices.Items.Add(MidiIn.DeviceInfo(device).ProductName);
-            }
-            if (comboBoxMidiInDevices.Items.Count > 0)
-            {
-                comboBoxMidiInDevices.SelectedIndex = 0;
-            }
-            for (int device = 0; device < MidiOut.NumberOfDevices; device++)
-            {
-                comboBoxMidiOutDevices.Items.Add(MidiOut.DeviceInfo(device).ProductName);
-            }
-            if (comboBoxMidiOutDevices.Items.Count > 0)
-            {
-                comboBoxMidiOutDevices.SelectedIndex = 0;
-            }
+            PopulateDeviceLists();
             events = new List<MidiEvent>();
             for (int note = 50; note < 62; note++)
             {
@@ -44,9 +30,37 @@ namespace NAudioDemo.MidiInDemo
             }
         }
 
+        private void PopulateDeviceLists()
+        {
+            string selectedIn = comboBoxMidiInDevices.SelectedItem as string;
+            string selectedOut = comboBoxMidiOutDevices.SelectedItem as string;
+
+            comboBoxMidiInDevices.Items.Clear();
+            for (int device = 0; device < MidiIn.NumberOfDevices; device++)
+            {
+                comboBoxMidiInDevices.Items.Add(MidiIn.DeviceInfo(device).ProductName);
+            }
+            if (comboBoxMidiInDevices.Items.Count > 0)
+            {
+                int index = selectedIn != null ? comboBoxMidiInDevices.Items.IndexOf(selectedIn) : -1;
+                comboBoxMidiInDevices.SelectedIndex = index >= 0 ? index : 0;
+            }
+
+            comboBoxMidiOutDevices.Items.Clear();
+            for (int device = 0; device < MidiOut.NumberOfDevices; device++)
+            {
+                comboBoxMidiOutDevices.Items.Add(MidiOut.DeviceInfo(device).ProductName);
+            }
+            if (comboBoxMidiOutDevices.Items.Count > 0)
+            {
+                int index = selectedOut != null ? comboBoxMidiOutDevices.Items.IndexOf(selectedOut) : -1;
+                comboBoxMidiOutDevices.SelectedIndex = index >= 0 ? index : 0;
+            }
+        }
+
         private void AddNoteEvent(int noteNumber)
         {
-            int channel = 2;
+            int channel = 1;
             NoteOnEvent noteOnEvent = new NoteOnEvent(0, channel, noteNumber, 100, 50);
             events.Add(noteOnEvent);
             events.Add(noteOnEvent.OffEvent);
@@ -73,21 +87,18 @@ namespace NAudioDemo.MidiInDemo
             }
             if (midiIn != null)
             {
-                midiIn.Dispose();
                 midiIn.MessageReceived -= midiIn_MessageReceived;
                 midiIn.ErrorReceived -= midiIn_ErrorReceived;
+                midiIn.Dispose();
                 midiIn = null;
             }
-            if (midiIn == null)
-            {
-                midiIn = new MidiIn(comboBoxMidiInDevices.SelectedIndex);
-                midiIn.MessageReceived += midiIn_MessageReceived;
-                midiIn.ErrorReceived += midiIn_ErrorReceived;
-            }
+            midiIn = new MidiIn(comboBoxMidiInDevices.SelectedIndex);
+            midiIn.MessageReceived += midiIn_MessageReceived;
+            midiIn.ErrorReceived += midiIn_ErrorReceived;
             midiIn.Start();
             monitoring = true;
             buttonMonitor.Text = "Stop";
-            comboBoxMidiInDevices.Enabled = false;
+            UpdateDeviceListEnabledState();
         }
 
         void midiIn_ErrorReceived(object sender, MidiInMessageEventArgs e)
@@ -98,13 +109,17 @@ namespace NAudioDemo.MidiInDemo
 
         private void StopMonitoring()
         {
-            if (monitoring)
+            if (monitoring && midiIn != null)
             {
                 midiIn.Stop();
-                monitoring = false;
-                buttonMonitor.Text = "Monitor";
-                comboBoxMidiInDevices.Enabled = true;
+                midiIn.MessageReceived -= midiIn_MessageReceived;
+                midiIn.ErrorReceived -= midiIn_ErrorReceived;
+                midiIn.Dispose();
+                midiIn = null;
             }
+            monitoring = false;
+            buttonMonitor.Text = "Monitor";
+            UpdateDeviceListEnabledState();
         }
 
         void midiIn_MessageReceived(object sender, MidiInMessageEventArgs e)
@@ -121,16 +136,7 @@ namespace NAudioDemo.MidiInDemo
         {
             timer1.Enabled = false;
             StopMonitoring();
-            if (midiIn != null)
-            {
-                midiIn.Dispose();
-                midiIn = null;
-            }
-            if (midiOut != null)
-            {
-                midiOut.Dispose();
-                midiOut = null;
-            }
+            StopSendingMidiOut();
         }
 
         private void buttonClearLog_Click(object sender, EventArgs e)
@@ -138,9 +144,64 @@ namespace NAudioDemo.MidiInDemo
             progressLog1.ClearLog();
         }
 
-        private void timer1_Tick(object sender, EventArgs e)
+        private void buttonRefreshDevices_Click(object sender, EventArgs e)
+        {
+            PopulateDeviceLists();
+        }
+
+        private void checkBoxMidiOutMessages_CheckedChanged(object sender, EventArgs e)
         {
             if (checkBoxMidiOutMessages.Checked)
+            {
+                StartSendingMidiOut();
+            }
+            else
+            {
+                StopSendingMidiOut();
+            }
+        }
+
+        private void StartSendingMidiOut()
+        {
+            if (comboBoxMidiOutDevices.Items.Count == 0)
+            {
+                MessageBox.Show("No MIDI output devices available");
+                checkBoxMidiOutMessages.Checked = false;
+                return;
+            }
+            if (midiOut == null)
+            {
+                midiOut = new MidiOut(comboBoxMidiOutDevices.SelectedIndex);
+            }
+            midiOutIndex = 0;
+            sendingMidiOut = true;
+            UpdateDeviceListEnabledState();
+        }
+
+        private void StopSendingMidiOut()
+        {
+            sendingMidiOut = false;
+            if (midiOut != null)
+            {
+                // Make sure any currently playing note is silenced.
+                midiOut.Reset();
+                midiOut.Dispose();
+                midiOut = null;
+            }
+            midiOutIndex = 0;
+            UpdateDeviceListEnabledState();
+        }
+
+        private void UpdateDeviceListEnabledState()
+        {
+            comboBoxMidiInDevices.Enabled = !monitoring;
+            comboBoxMidiOutDevices.Enabled = !sendingMidiOut;
+            buttonRefreshDevices.Enabled = !monitoring && !sendingMidiOut;
+        }
+
+        private void timer1_Tick(object sender, EventArgs e)
+        {
+            if (sendingMidiOut)
             {
                 SendNextMidiOutMessage();
             }
@@ -148,10 +209,7 @@ namespace NAudioDemo.MidiInDemo
 
         private void SendNextMidiOutMessage()
         {
-            if (midiOut == null)
-            {
-                midiOut = new MidiOut(comboBoxMidiOutDevices.SelectedIndex);
-            }
+            if (midiOut == null) return;
             MidiEvent eventToSend = events[midiOutIndex++];
             midiOut.Send(eventToSend.GetAsShortMessage());
             progressLog1.LogMessage(Color.Green, String.Format("Sent {0}", eventToSend));
@@ -161,7 +219,7 @@ namespace NAudioDemo.MidiInDemo
             }
         }
     }
-    
+
     public class MidiInPanelPlugin : INAudioDemoPlugin
     {
         public string Name

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,9 +35,16 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * **DSP:** new `FftProcessor` with real-input specialisation and precomputed windowing
  * **WAV chunks:** new `IWaveChunkInterpreter<T>` extension point, with built-in interpreters for cue lists, BWF `bext` (v1 and v2), and LIST/INFO metadata. RF64 promotion is now an explicit `WaveFileWriterOption`
  * **`Span<T>` overloads:** added on `BiQuadFilter.Transform`, `ALawDecoder.Decode`, `MuLawDecoder.Decode`, and `IMp3FrameDecompressor.DecompressFrame` (default interface method preserves backward compatibility with `NLayer` and other third-party decoders)
+
+#### Demo apps and Test Harnesses
+
+ * **NAudioConsoleTest:** new CLI test harness for driving various NAudio features without the need for GUI.
  * **WPF demos:** spectrum analyser rewritten with corrected dB formula (20·log₁₀), log-frequency mapping, real-input full-scale calibration, bars instead of polylines, peak-decay markers, and per-band smoothing. New `LiveWaveformControl` with configurable render styles, vertical scaling, and fill-between rendering
  * **WAV recording demo:** added loopback support and a multi-API device combo with provenance embedding
-
+ * **MIDI In demo:** Refresh button for hot-plugged devices, device combos disabled while in use, test MIDI Out plays on channel 1 (was 2), Filter Auto-Sensing on by default, stopping test output now sends note-off so notes don't hang, and cleaner panel disposal
+ * **MfStressTest:** Reliability tests for the new Media Foundation interop implementation in NAudio 3.
+ * Replaced vendored NSpeex (deprecated) with Opus (Concentus) in the network chat demo; added round-trip unit tests
+ 
 #### Performance
 
  * Vectorised mix-add and volume kernels via `System.Numerics.Tensors` — significantly faster on AVX2 hardware for typical buffer sizes
@@ -69,7 +76,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 
 #### Modernisation (Native AOT, source-generated COM)
 
- * `NAudio.Core`, `NAudio.Midi`, and `NAudio.Wasapi` are now `IsAotCompatible=true`. AOT compatibility is exercised end-to-end by `NAudioAotSmokeTest` in CI
+ * `NAudio.Core`, `NAudio.Midi`, and `NAudio.Wasapi` are now `IsAotCompatible=true`. AOT compatibility is enforced at build-time by `NAudioAotSmokeTest`, which fails CI on any new trim or AOT analyzer warning
  * Most COM interop migrated from `[ComImport]` to `[GeneratedComInterface]` / `ComWrappers`. Affected interfaces include the WASAPI / Core Audio activation chain (`IActivateAudioInterfaceCompletionHandler`, `IMMNotificationClient`, `IAudioSessionNotification`, `IAudioSessionEvents`, `IAudioEndpointVolumeCallback`, `IAgileObject`, `IPropertyStore`), the Media Foundation cascade, the DMO interfaces, DirectSound, and the `ComStream` CCW (now source-generated `IStream`)
  * DirectSound P/Invokes migrated to `[LibraryImport]` with `[UnmanagedCallersOnly]` thunks; `BufferDescription` and `BufferCaps` converted from class to struct
  * `AcmDriver` ported from legacy `NativeMethods` to `NativeLibrary`
@@ -78,7 +85,6 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 #### Packaging and dependencies
 
  * Each NAudio package now ships its own README in the NuGet payload
- * Replaced vendored NSpeex (deprecated) with Opus (Concentus) in the network chat demo; added round-trip unit tests
  * Test project migrated from VSTest to `Microsoft.Testing.Platform`
  * Migrated to the modern `.slnx` solution format
  * Renamed `license.txt` to `LICENSE` for GitHub license detection; refreshed copyright year to 2008–2026


### PR DESCRIPTION
## Summary
- MIDI In demo panel polish: Filter Auto-Sensing on by default, new Refresh button (preserves selection by product name), device combos disabled while in use, test MIDI Out plays on channel 1 (was 2), stopping the test sender now calls `MidiOut.Reset()` so notes don't hang, and panel disposal cleanly stops/disposes both `MidiIn` and `MidiOut`.
- Reworded the AOT release note to match what CI actually does. `NAudioAotSmokeTest` enforces AOT compatibility at build time via analyzer warnings treated as errors (`PublishAot=true` + `IsAotCompatible=true` + `TreatWarningsAsErrors=true`). CI builds the solution but does not run `dotnet publish`, so the previous "end-to-end" wording overstated it.

## Test plan
- [ ] Open NAudio Demo, switch to MIDI In panel, confirm Filter Auto-Sensing is checked on first load
- [ ] Click Refresh with no devices plugged or unplugged - selection should be preserved
- [ ] Plug/unplug a MIDI device, click Refresh, confirm the list updates
- [ ] Start Monitor - confirm the MIDI In device combo and Refresh button are disabled, click Stop and confirm both re-enable
- [ ] Tick "Send Test MIDI Out Messages" - confirm the MIDI Out device combo and Refresh button are disabled, and notes play on channel 1
- [ ] Untick "Send Test MIDI Out Messages" mid-note - confirm the note is silenced (no hanging note) and the combo/Refresh re-enable
- [ ] Switch away from the MIDI In panel (or close the demo) while monitoring and sending - confirm clean disposal (no exceptions, devices released)

🤖 Generated with [Claude Code](https://claude.com/claude-code)