### PR TITLE
Add WinRT MIDI in/out backend

### DIFF
--- a/Docs/Architecture/NAudio3AssemblyLayoutPlan.md
+++ b/Docs/Architecture/NAudio3AssemblyLayoutPlan.md
@@ -4,14 +4,12 @@
 
 This design fixes two of the inherited problems from NAudio 1.x/2.x: `NAudio.Midi` mixing portable file I/O with winmm-only `MidiIn`/`MidiOut`, and `NAudio.Core` carrying Win32-shaped types (`MmResult`, `MmException`, `Manufacturers`) it never used. The first round of work covers exactly those two problems plus a multi-targeted meta-package — the bits we're already certain about. Other v3 candidates (splitting `NAudio.Wasapi`, landing `NAudio.Midi.WinRT`, rehousing `NAudio.Extras`) are sequenced as **subsequent phases** (see §"Subsequent phases") to be attempted *after* the first round is committed. They're not definitely-out-of-scope for NAudio 3 — but each is a separate piece of work that may run into unexpected coupling or homeless types, and we want the option to back any of them out without rolling back the certain wins.
 
-**Branch:** continues on `naudio3dev`.
-
 ## Problems with the current layout
 
 1. **`NAudio.Midi` is dishonestly portable.** It targets `net9.0` (no platform suffix) but `MidiIn` / `MidiOut` P/Invoke `winmm.dll`, so a Linux consumer who only wants `.mid` file parsing still gets a `DllNotFoundException` waiting to happen if they reach for the wrong type.
 2. **`NAudio.Core` carries Win32-shaped types it doesn't use.** `MmResult`, `MmException`, and the `Manufacturers` enum are all winmm/MIDI concepts. They're consumed only by `NAudio.WinMM`, `NAudio.Midi`, and `NAudio.WinForms` — never by `NAudio.Core` itself. Their presence in Core is a historical accident from the era when everything lived in one assembly.
 3. **No coherent meta-package story.** `NAudio` is currently a Windows umbrella by accident, not by design. Cross-platform users have no clear "pick this" recommendation, and the package's transitive deps include things they cannot use.
-4. **`NAudio.Wasapi` is misnamed.** It contains four distinct Windows APIs — WASAPI/CoreAudio, Media Foundation, DMO, and DirectSound — each with its own SDK history, deprecation curve, and audience. A user who only wants WASAPI playback in 2026 drags in MF codecs and DMO interop they will never call. *(Acknowledged but **deferred** beyond the first round — see §"Subsequent phases".)*
+4. **`NAudio.Wasapi` is misnamed.** It contains four distinct Windows APIs — WASAPI/CoreAudio, Media Foundation, DMO, and DirectSound (and also currently the WinRT Midi)— each with its own SDK history, deprecation curve, and audience. *(Acknowledged but **deferred** beyond the first round — see §"Subsequent phases".)*
 
 ## Design principles
 
@@ -113,36 +111,21 @@ The only ways to break the cycle (a third "common" assembly, or leaving the type
 
 ## Resolved decisions
 
-1. **Meta-package versioning: lockstep, not independent.** The `NAudio` meta-package and every constituent package share a single version number, bumped together on every release. Rationale:
-   - **One number for users to talk about.** "I'm on NAudio 3.2.0" is a coherent statement; "I'm on NAudio 3.0.0 with NAudio.Wasapi 3.4.1 and NAudio.Midi 3.1.0" is not. Lockstep matches the historical NAudio experience and matches how comparable .NET ecosystem packages behave (e.g. `Microsoft.AspNetCore.App` constituents move in lockstep).
-   - **Avoids dependency-resolution surprises.** Independent versioning makes it easy to ship a Wasapi bump that nobody picks up because the meta-package still pins the old version. Lockstep means a release of any constituent forces a meta-package bump that pulls everyone forward.
-   - **Trivial to enforce.** A single `<Version>` property in `Directory.Build.props` (or a shared `Version.props`) wins this without ceremony — already the pattern NAudio uses today (everything is at `2.3.0`).
-   - **Cost is small.** Yes, you publish unchanged-content packages on every release. NuGet handles that fine and storage is cheap. The clarity gain dwarfs the cost.
-
-2. **Legacy winmm MIDI is the only MIDI device backend in the first round.** `MidiInCapabilities` and `MidiOutCapabilities` (with their `Manufacturer` property) remain `NAudio.WinMM`-specific. They stay shipped, unmodified, in `NAudio.WinMM`. The future direction is `IMidiInput` / `IMidiOutput` + a WinRT backend, but neither piece lands until the WinRT phase is attempted (see §"Subsequent phases").
-
-3. **`NAudio.WinForms` is keeping its future.** WinForms remains widely used and the package isn't going away. Its long-term value will increasingly skew from playback (where `WasapiPlayer` is the better answer) toward the custom UI controls it provides.
-
-## Out of scope for the first round
-
-- **Versioning.** Every project still has `<Version>2.3.0</Version>`. The first round does **not** bump versions — it's purely a structural reorg landing on `naudio3dev`. Pre-release versioning strategy (e.g. `3.0.0-preview.N`), centralising the property into `Directory.Build.props`, and any NuGet publish automation are tracked as a separate follow-on design step, run before the first NAudio 3 preview is published.
-- **NuGet publishes.** No package pushes happen during the first round. Local `dotnet pack` output is fine for validation; `GeneratePackageOnBuild` already produces `.nupkg`s in each project's `bin/` for inspection.
+1. **`NAudio.WinForms` is keeping its future.** WinForms remains widely used and the package isn't going away. Its long-term value will increasingly skew from playback (where `WasapiPlayer` is the better answer) toward the custom UI controls it provides.
 
 ## Subsequent phases
 
 Work that is **deferred from the first round, but still candidate for NAudio 3**. Each is a separate piece of work to attempt after the first round is committed; any that surfaces unexpected coupling, homeless types, or test-coverage gaps should be backed out without rolling back the first-round changes. Listed in roughly the order they should be attempted (cheapest first), but each is independent.
 
-1. **Land `NAudio.Midi.WinRT`.** Finish and test the prototype on the [`winrtmidi`](https://github.com/naudio/NAudio/tree/winrtmidi) branch. Promote `IMidiInput` / `IMidiOutput` / `MidiMessageConverter` into the portable `NAudio.Midi` assembly. Have legacy `MidiIn` / `MidiOut` (in `NAudio.WinMM`) implement `IMidiInput` / `IMidiOutput`. Ship `WinRTMidiIn` / `WinRTMidiOut` in a new `NAudio.Midi.WinRT` package targeting `net9.0-windows10.0.19041.0`. Add the new package to the meta-package's existing Windows leg (already at `net9.0-windows10.0.19041.0`, so no new TFM required). Risk: prototype isn't finished or tested, async device enumeration semantics may surprise consumers used to the synchronous winmm API.
-
-2. **Split `NAudio.Wasapi` into per-API packages.** Carve the current kitchen-sink assembly into `NAudio.Wasapi` (CoreAudio only), `NAudio.MediaFoundation`, `NAudio.Dmo`, and `NAudio.DirectSound`. Resolves the long-standing "I only want WASAPI but I get MF codec interop too" complaint. Considerations:
+1. **Split `NAudio.Wasapi` into per-API packages.** IMPORTANT: This step not yet certain - for NAudio3 we may accept that this package contains several Windows audio APIs and just has an odd name. Potentially in the future carve the current kitchen-sink assembly into `NAudio.Wasapi` (CoreAudio only), `NAudio.MediaFoundation`, `NAudio.Dmo`, `NAudio.Midi.WinRT`, and `NAudio.DirectSound`. Resolves the long-standing "I only want WASAPI but I get MF codec interop too" complaint. Considerations:
    - Direct package consumers may need new `<PackageReference>` entries (mitigated for source-level compatibility by namespace stability).
    - The previous `NAudio.Wasapi` will need `[TypeForwardedTo]` shims for at least one release so consumers don't get duplicate-type errors during the transition.
    - Meta-package consumers should be unaffected.
    - Risk: tighter-than-expected coupling between the four APIs (e.g. shared COM helpers), which would either force ugly internals-visible-to plumbing or push the split out further.
 
-3. **Rehouse `NAudio.Extras` contents.** Audit the package and move each piece to its most appropriate assembly (Core, Wasapi, WinMM, etc.). Risk: some items may have no natural home and should stay where they are — this is an evaluate-then-decide phase, not a foregone conclusion. If the audit comes back inconclusive, leave `NAudio.Extras` as-is.
+2. **Rehouse `NAudio.Extras` contents.** Audit the package and move each piece to its most appropriate assembly (Core, Wasapi, WinMM, etc.). Risk: some items may have no natural home and should stay where they are — this is an evaluate-then-decide phase, not a foregone conclusion. If the audit comes back inconclusive, leave `NAudio.Extras` as-is.
 
-4. **Behaviour / API hygiene work flagged in `Docs/Architecture/MODERNIZATION.md`.** Anything that would mean editing code (slimming `WasapiOut`'s built-in resampler, applying `[Obsolete]` annotations, removing legacy types) is its own concern, separate from the structural work above.
+3. **Behaviour / API hygiene work flagged in `Docs/Architecture/MODERNIZATION.md`.** Anything that would mean editing code (slimming `WasapiOut`'s built-in resampler, applying `[Obsolete]` annotations, removing legacy types) is its own concern, separate from the structural work above.
 
 ## Execution status — first round
 

--- a/Docs/MidiInAndOut.md
+++ b/Docs/MidiInAndOut.md
@@ -1,19 +1,50 @@
 # Sending and Receiving MIDI Events
 
-NAudio allows you to send and receive MIDI events from MIDI devices using the `MidiIn` and `MidiOut` classes.
+NAudio ships two MIDI backends on Windows. Both implement the same `IMidiInput` / `IMidiOutput` interfaces (in `NAudio.Midi`), so application code can target the interfaces and switch backends with one line of construction.
 
-## Enumerating MIDI Devices
+| Backend | Package | Class | Notes |
+| --- | --- | --- | --- |
+| WinRT (`Windows.Devices.Midi`) | `NAudio.Wasapi` | `WinRTMidiIn`, `WinRTMidiOut` | Recommended. Async device enumeration, full `TimeSpan` timestamp resolution. Requires `net9.0-windows10.0.19041.0` or later. |
+| Legacy winmm (`midiIn*` / `midiOut*`) | `NAudio.WinMM` | `MidiIn`, `MidiOut` | Synchronous, index-based device enumeration. Timestamps are millisecond-resolution. Also fires an `ErrorReceived` event for malformed messages. |
 
-To discover how many devices are present in your system, you can use `MidiIn.NumberOfDevices` and `MidiOut.NumberOfDevices`. Then you can ask for information about each device using `MidiIn.DeviceInfo(index)` and `MidiOut.DeviceInfo(index)`. The `ProductName` property is most useful as it can be used to populate a combo box allowing users to select the device they want.
+Application code can be backend-agnostic by referencing only the interfaces:
+
+```c#
+void Monitor(IMidiInput input)
+{
+    input.MessageReceived += (s, e) => Console.WriteLine($"{e.Timestamp:c} {e.MidiEvent}");
+    input.Start();
+}
+```
+
+## Enumerating MIDI devices
+
+### WinRT backend
+
+Device enumeration is asynchronous and returns `DeviceInformation` objects with `Id` and `Name` properties:
+
+```c#
+var inDevices = await WinRTMidiIn.GetDevicesAsync();
+foreach (var device in inDevices)
+{
+    comboBoxMidiInDevices.Items.Add(device.Name);
+}
+
+var outDevices = await WinRTMidiOut.GetDevicesAsync();
+foreach (var device in outDevices)
+{
+    comboBoxMidiOutDevices.Items.Add(device.Name);
+}
+```
+
+### Legacy winmm backend
+
+Synchronous, index-based:
 
 ```c#
 for (int device = 0; device < MidiIn.NumberOfDevices; device++)
 {
     comboBoxMidiInDevices.Items.Add(MidiIn.DeviceInfo(device).ProductName);
-}
-if (comboBoxMidiInDevices.Items.Count > 0)
-{
-    comboBoxMidiInDevices.SelectedIndex = 0;
 }
 for (int device = 0; device < MidiOut.NumberOfDevices; device++)
 {
@@ -23,32 +54,41 @@ for (int device = 0; device < MidiOut.NumberOfDevices; device++)
 
 ## Receiving MIDI events
 
-To start monitoring incoming MIDI messages we create a new instance of `MidiIn` passing in the selected device index (zero based). Then we subscribe to the `MessageReceived` and `ErrorReceived` properties. Then we call `Start` to actually start receiving messages from the device.
+### Opening a WinRT input port
 
 ```c#
-midiIn = new MidiIn(selectedDeviceIndex);
+IMidiInput midiIn = await WinRTMidiIn.CreateAsync(inDevices[selectedIndex].Id);
 midiIn.MessageReceived += midiIn_MessageReceived;
-midiIn.ErrorReceived += midiIn_ErrorReceived;
+midiIn.SysexMessageReceived += midiIn_SysexMessageReceived;
 midiIn.Start();
 ```
 
-Both event handlers provide us with a `MidiInMessageEventArgs` which provides a `Timestamp` (in milliseconds), the parsed `MidiEvent` as well as the `RawMessage` (which can be useful if NAudio couldn't interpret the message)
+### Opening a legacy winmm input port
 
 ```c#
-void midiIn_ErrorReceived(object sender, MidiInMessageEventArgs e)
-{
-    log.WriteError(String.Format("Time {0} Message 0x{1:X8} Event {2}",
-        e.Timestamp, e.RawMessage, e.MidiEvent));
-}
+IMidiInput midiIn = new MidiIn(selectedDeviceIndex);
+midiIn.MessageReceived += midiIn_MessageReceived;
+midiIn.SysexMessageReceived += midiIn_SysexMessageReceived;
+((MidiIn)midiIn).ErrorReceived += midiIn_ErrorReceived; // legacy-only event for malformed messages
+midiIn.Start();
+```
 
+### Handling messages
+
+Both backends deliver short messages as `MidiInMessageEventArgs`, which exposes a parsed `MidiEvent`, the original 32-bit `RawMessage`, and a `TimeSpan` `Timestamp` measured from when the port was opened:
+
+```c#
 void midiIn_MessageReceived(object sender, MidiInMessageEventArgs e)
 {
-    log.WriteInfo(String.Format("Time {0} Message 0x{1:X8} Event {2}",
-        e.Timestamp, e.RawMessage, e.MidiEvent));
+    Console.WriteLine($"Time {e.Timestamp:c} Message 0x{e.RawMessage:X8} Event {e.MidiEvent}");
 }
 ```
 
-To stop monitoring, simply call `Stop` on the MIDI in device. And also `Dispose` the device if you are finished with it.
+> **Note on timestamps:** the WinRT backend preserves the underlying 100 ns resolution. The winmm backend reports millisecond resolution because `winmm.dll` only delivers milliseconds in its callback.
+>
+> **Threading:** both backends raise `MessageReceived` on a non-UI thread. If you need to update WinForms / WPF controls in the handler, marshal back to the UI thread (e.g. `Control.Invoke`, `Dispatcher.Invoke`).
+
+To stop monitoring, call `Stop` and then `Dispose`:
 
 ```c#
 midiIn.Stop();
@@ -57,58 +97,65 @@ midiIn.Dispose();
 
 ## Sending MIDI events
 
-Sending MIDI events makes use of `MidiOut`. First, create an instance of `MidiOut` passing in the desired device number:
+Once a device is open, the same code works for either backend:
 
 ```c#
-midiOut = new MidiOut(comboBoxMidiOutDevices.SelectedIndex);
+var noteOnEvent = new NoteOnEvent(0, channel: 1, noteNumber: 60, velocity: 100, duration: 50);
+midiOut.Send(noteOnEvent); // extension method — calls GetAsShortMessage internally
 ```
 
-Then you can create any MIDI messages using classes derived from `MidiEvent`. For example, you could create a `NoteOnEvent`. Note that timestamps and durations are ignored in this scenario - they only apply to events in a MIDI file.
+`Send(MidiEvent)` is an extension method on `IMidiOutput` that handles short MIDI messages. For sysex, use `SendBuffer` (see below).
+
+Opening the device:
 
 ```c#
-int channel = 1;
-int noteNumber = 50;
-var noteOnEvent = new NoteOnEvent(0, channel, noteNumber, 100, 50);
+// WinRT:
+IMidiOutput midiOut = await WinRTMidiOut.CreateAsync(outDevices[selectedIndex].Id);
+
+// Legacy:
+IMidiOutput midiOut = new MidiOut(comboBoxMidiOutDevices.SelectedIndex);
 ```
 
-To send the MIDI event, we need to call `GetAsShortMessage` on the `MidiEvent` and pass the resulting value to `MidiOut.Send`
-
-```c#
-midiOut.Send(noteOnEvent.GetAsShortMessage());
-```
-
-When you're done with sending MIDI events, simply `Dispose` the device.
+When finished:
 
 ```c#
 midiOut.Dispose();
 ```
 
-## Sending and Receiving Sysex message events
+## Sending and Receiving Sysex Messages
 
-Sending a Sysex message can be done using MidiOut.SendBuffer(). It is not necessary to build and send an entire message as a single SendBuffer call as long as you ensure that the calls are not asynchronously interleaved.
+### Sending
+
+Sysex is sent via `SendBuffer` and works the same on both backends:
+
 ```c#
-private static void SendSysex(byte[] message)
-{
-    midiOut.SendBuffer(new byte[] { 0xF0, 0x00, 0x21, 0x1D, 0x01, 0x01 });
-    midiOut.SendBuffer(message);
-    midiOut.SendBuffer(new byte[] { 0xF7 });
-}
+byte[] message = { 0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7 };
+midiOut.SendBuffer(message);
 ```
 
-Receiving Sysex messages requires two actions in addition to the midiIn handling above: (1) Allocate a number of buffers each large enough to receive an expected Sysex message from the device. (2) Subscribe to the SysexMessageReceived EventHandler property:
-```c#
-midiIn = new MidiIn(selectedDeviceIndex);
-midiIn.MessageReceived += midiIn_MessageReceived;
-midiIn.ErrorReceived += midiIn_ErrorReceived;
-midiIn.CreateSysexBuffers(BufferSize, NumberOfBuffers);
-midiIn.SysexMessageReceived += midiIn_SysexMessageReceived;
-midiIn.Start();
-```
+On the winmm backend it's safe to break a long sysex message across multiple `SendBuffer` calls *as long as the calls are not asynchronously interleaved*. The WinRT backend expects the framing bytes (`0xF0` … `0xF7`) in a single buffer.
 
-The second parameter to the SysexMessageReceived EventHandler is of type MidiInSysexMessageEventArgs, which has a SysexBytes byte array property:
+### Receiving
+
+Subscribe to `SysexMessageReceived`. Both backends automatically allocate any receive buffers they need — the legacy winmm backend allocates 4 × 4 KB buffers internally when `Start()` is called:
+
 ```c#
-static void midiIn_SysexMessageReceived(object sender, MidiInSysexMessageEventArgs e)
+midiIn.SysexMessageReceived += (s, e) =>
 {
     byte[] sysexMessage = e.SysexBytes;
-    ....
+    Console.WriteLine($"Sysex {sysexMessage.Length} bytes at {e.Timestamp:c}");
+};
+```
+
+## Converting between NAudio and WinRT MIDI types
+
+`MidiMessageConverter` (in `NAudio.Wasapi`) provides bidirectional conversion between NAudio `MidiEvent` types and the WinRT `IMidiMessage` types from `Windows.Devices.Midi`. This is useful if you want to drop down to `Windows.Devices.Midi` directly (e.g. to use a WinRT-only feature) while keeping the rest of your code in NAudio:
+
+```c#
+// NAudio event → WinRT message
+var noteOn = new NoteOnEvent(0, 1, 60, 100, 50);
+IMidiMessage winRtMessage = MidiMessageConverter.ToWinRTMessage(noteOn.GetAsShortMessage());
+
+// WinRT message → NAudio event
+MidiEvent midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
 ```

--- a/NAudio.Midi/Midi/IMidiInput.cs
+++ b/NAudio.Midi/Midi/IMidiInput.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace NAudio.Midi
+{
+    /// <summary>
+    /// A device-agnostic MIDI input. Implemented by the legacy winmm-backed
+    /// <c>MidiIn</c> (in NAudio.WinMM) and the WinRT-backed <c>WinRTMidiIn</c>
+    /// (in NAudio.Wasapi).
+    /// </summary>
+    public interface IMidiInput : IDisposable
+    {
+        /// <summary>
+        /// Raised when a short MIDI message is received.
+        /// </summary>
+        event EventHandler<MidiInMessageEventArgs> MessageReceived;
+
+        /// <summary>
+        /// Raised when a sysex MIDI message is received.
+        /// </summary>
+        event EventHandler<MidiInSysexMessageEventArgs> SysexMessageReceived;
+
+        /// <summary>
+        /// Start receiving MIDI messages.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stop receiving MIDI messages.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/NAudio.Midi/Midi/IMidiOutput.cs
+++ b/NAudio.Midi/Midi/IMidiOutput.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace NAudio.Midi
+{
+    /// <summary>
+    /// A device-agnostic MIDI output. Implemented by the legacy winmm-backed
+    /// <c>MidiOut</c> (in NAudio.WinMM) and the WinRT-backed <c>WinRTMidiOut</c>
+    /// (in NAudio.Wasapi).
+    /// </summary>
+    public interface IMidiOutput : IDisposable
+    {
+        /// <summary>
+        /// Sends a short (1-3 byte) MIDI message packed as a 32-bit integer.
+        /// </summary>
+        /// <param name="message">The packed MIDI message (status byte, data1, data2).</param>
+        void Send(int message);
+
+        /// <summary>
+        /// Sends a long MIDI message (e.g. sysex) as a byte buffer.
+        /// </summary>
+        /// <param name="byteBuffer">The bytes to send, including any framing bytes (e.g. <c>0xF0</c>/<c>0xF7</c> for sysex).</param>
+        void SendBuffer(byte[] byteBuffer);
+    }
+}

--- a/NAudio.Midi/Midi/MidiInMessageEventArgs.cs
+++ b/NAudio.Midi/Midi/MidiInMessageEventArgs.cs
@@ -10,9 +10,9 @@ namespace NAudio.Midi
         /// <summary>
         /// Create a new MIDI In Message EventArgs
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="timestamp"></param>
-        public MidiInMessageEventArgs(int message, int timestamp)
+        /// <param name="message">The raw short MIDI message (status, data1, data2 packed into a 32-bit int).</param>
+        /// <param name="timestamp">The timestamp at which the message was received.</param>
+        public MidiInMessageEventArgs(int message, TimeSpan timestamp)
         {
             this.RawMessage = message;
             this.Timestamp = timestamp;
@@ -37,8 +37,9 @@ namespace NAudio.Midi
         public MidiEvent MidiEvent { get; private set; }
 
         /// <summary>
-        /// The timestamp in milliseconds for this message
+        /// The timestamp at which this message was received, measured from
+        /// when the input device was opened/started.
         /// </summary>
-        public int Timestamp { get; private set; }
+        public TimeSpan Timestamp { get; private set; }
     }
 }

--- a/NAudio.Midi/Midi/MidiInSysexMessageEventArgs.cs
+++ b/NAudio.Midi/Midi/MidiInSysexMessageEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NAudio.Midi
 {
@@ -10,9 +10,9 @@ namespace NAudio.Midi
         /// <summary>
         /// Create a new Sysex MIDI In Message EventArgs
         /// </summary>
-        /// <param name="sysexBytes">The Sysex byte array received</param>
-        /// <param name="timestamp">Milliseconds since MidiInStart</param>
-        public MidiInSysexMessageEventArgs(byte[] sysexBytes, int timestamp)
+        /// <param name="sysexBytes">The Sysex byte array received.</param>
+        /// <param name="timestamp">The timestamp at which the message was received.</param>
+        public MidiInSysexMessageEventArgs(byte[] sysexBytes, TimeSpan timestamp)
         {
             this.SysexBytes = sysexBytes;
             this.Timestamp = timestamp;
@@ -23,10 +23,10 @@ namespace NAudio.Midi
         /// </summary>
         public byte[] SysexBytes { get; private set; }
 
-
         /// <summary>
-        /// The timestamp in milliseconds (since MidiInStart) for this message
+        /// The timestamp at which this message was received, measured from
+        /// when the input device was opened/started.
         /// </summary>
-        public int Timestamp { get; private set; }
+        public TimeSpan Timestamp { get; private set; }
     }
 }

--- a/NAudio.Midi/Midi/MidiOutputExtensions.cs
+++ b/NAudio.Midi/Midi/MidiOutputExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace NAudio.Midi
+{
+    /// <summary>
+    /// Convenience extensions on <see cref="IMidiOutput"/>.
+    /// </summary>
+    public static class MidiOutputExtensions
+    {
+        /// <summary>
+        /// Sends a <see cref="MidiEvent"/> as a short MIDI message.
+        /// </summary>
+        /// <remarks>
+        /// Only valid for events that fit in a 1-3 byte short message (channel messages and system real-time messages).
+        /// Sysex events should be sent via <see cref="IMidiOutput.SendBuffer"/>.
+        /// </remarks>
+        public static void Send(this IMidiOutput output, MidiEvent midiEvent)
+        {
+            if (output == null) throw new ArgumentNullException(nameof(output));
+            if (midiEvent == null) throw new ArgumentNullException(nameof(midiEvent));
+            output.Send(midiEvent.GetAsShortMessage());
+        }
+    }
+}

--- a/NAudio.Wasapi/Midi/WinRT/MidiMessageConverter.cs
+++ b/NAudio.Wasapi/Midi/WinRT/MidiMessageConverter.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Devices.Midi;
+
+namespace NAudio.Midi
+{
+    /// <summary>
+    /// Converts between NAudio MIDI types (<see cref="MidiEvent"/>, packed short messages)
+    /// and the WinRT <see cref="IMidiMessage"/> types from <c>Windows.Devices.Midi</c>.
+    /// </summary>
+    public static class MidiMessageConverter
+    {
+        /// <summary>
+        /// Converts a WinRT MIDI message to an NAudio <see cref="MidiEvent"/>.
+        /// Returns <c>null</c> for sysex (handle those via the sysex event) and for any
+        /// message NAudio cannot decode.
+        /// </summary>
+        public static MidiEvent ToMidiEvent(IMidiMessage message)
+        {
+            switch (message.Type)
+            {
+                case MidiMessageType.NoteOn:
+                    var noteOn = (MidiNoteOnMessage)message;
+                    return new NoteOnEvent(0, noteOn.Channel + 1, noteOn.Note, noteOn.Velocity, 0);
+
+                case MidiMessageType.NoteOff:
+                    var noteOff = (MidiNoteOffMessage)message;
+                    return new NoteEvent(0, noteOff.Channel + 1, MidiCommandCode.NoteOff, noteOff.Note, noteOff.Velocity);
+
+                case MidiMessageType.ControlChange:
+                    var cc = (MidiControlChangeMessage)message;
+                    return new ControlChangeEvent(0, cc.Channel + 1, (MidiController)cc.Controller, cc.ControlValue);
+
+                case MidiMessageType.ProgramChange:
+                    var pc = (MidiProgramChangeMessage)message;
+                    return new PatchChangeEvent(0, pc.Channel + 1, pc.Program);
+
+                case MidiMessageType.ChannelPressure:
+                    var cp = (MidiChannelPressureMessage)message;
+                    return new ChannelAfterTouchEvent(0, cp.Channel + 1, cp.Pressure);
+
+                case MidiMessageType.PitchBendChange:
+                    var pb = (MidiPitchBendChangeMessage)message;
+                    return new PitchWheelChangeEvent(0, pb.Channel + 1, pb.Bend);
+
+                case MidiMessageType.PolyphonicKeyPressure:
+                    var poly = (MidiPolyphonicKeyPressureMessage)message;
+                    return new NoteEvent(0, poly.Channel + 1, MidiCommandCode.KeyAfterTouch, poly.Note, poly.Pressure);
+
+                case MidiMessageType.SystemExclusive:
+                    // Sysex is delivered via the dedicated sysex event, not as a MidiEvent.
+                    return null;
+
+                default:
+                    // System common / system real-time — let NAudio's parser handle them from the raw bytes.
+                    return TryParseRawMessage(message);
+            }
+        }
+
+        private static MidiEvent TryParseRawMessage(IMidiMessage message)
+        {
+            byte[] raw = message.RawData.ToArray();
+            if (raw.Length == 0) return null;
+            int packed = raw[0];
+            if (raw.Length > 1) packed |= raw[1] << 8;
+            if (raw.Length > 2) packed |= raw[2] << 16;
+            try
+            {
+                return MidiEvent.FromRawMessage(packed);
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Converts a packed NAudio short message to a WinRT <see cref="IMidiMessage"/>.
+        /// </summary>
+        /// <param name="shortMessage">The packed MIDI message from <see cref="MidiEvent.GetAsShortMessage"/>.</param>
+        public static IMidiMessage ToWinRTMessage(int shortMessage)
+        {
+            byte status = (byte)(shortMessage & 0xFF);
+            byte data1 = (byte)((shortMessage >> 8) & 0xFF);
+            byte data2 = (byte)((shortMessage >> 16) & 0xFF);
+            byte channel = (byte)(status & 0x0F);
+            byte command = (byte)(status & 0xF0);
+
+            switch (command)
+            {
+                case 0x90:
+                    return new MidiNoteOnMessage(channel, data1, data2);
+                case 0x80:
+                    return new MidiNoteOffMessage(channel, data1, data2);
+                case 0xB0:
+                    return new MidiControlChangeMessage(channel, data1, data2);
+                case 0xC0:
+                    return new MidiProgramChangeMessage(channel, data1);
+                case 0xD0:
+                    return new MidiChannelPressureMessage(channel, data1);
+                case 0xE0:
+                    return new MidiPitchBendChangeMessage(channel, (ushort)(data1 | (data2 << 7)));
+                case 0xA0:
+                    return new MidiPolyphonicKeyPressureMessage(channel, data1, data2);
+                default:
+                    return SystemMessageFromStatus(status, data1, data2, shortMessage);
+            }
+        }
+
+        private static IMidiMessage SystemMessageFromStatus(byte status, byte data1, byte data2, int shortMessage)
+        {
+            switch (status)
+            {
+                // System common
+                case 0xF1:
+                    return new MidiTimeCodeMessage((byte)(data1 >> 4), (byte)(data1 & 0x0F));
+                case 0xF2:
+                    return new MidiSongPositionPointerMessage((ushort)(data1 | (data2 << 7)));
+                case 0xF3:
+                    return new MidiSongSelectMessage(data1);
+                case 0xF6:
+                    return new MidiTuneRequestMessage();
+                // System real-time
+                case 0xF8:
+                    return new MidiTimingClockMessage();
+                case 0xFA:
+                    return new MidiStartMessage();
+                case 0xFB:
+                    return new MidiContinueMessage();
+                case 0xFC:
+                    return new MidiStopMessage();
+                case 0xFE:
+                    return new MidiActiveSensingMessage();
+                case 0xFF:
+                    return new MidiSystemResetMessage();
+                default:
+                    throw new ArgumentException($"Unsupported MIDI message: 0x{status:X2}", nameof(shortMessage));
+            }
+        }
+
+        /// <summary>
+        /// Converts a sysex byte array to a WinRT <see cref="MidiSystemExclusiveMessage"/>.
+        /// </summary>
+        /// <param name="sysexData">The sysex bytes (including <c>0xF0</c> / <c>0xF7</c> framing).</param>
+        public static MidiSystemExclusiveMessage ToWinRTSysexMessage(byte[] sysexData)
+        {
+            return new MidiSystemExclusiveMessage(sysexData.AsBuffer());
+        }
+
+        /// <summary>
+        /// Packs a WinRT MIDI message back into NAudio's 32-bit short-message form.
+        /// </summary>
+        public static int ToRawMessage(IMidiMessage message)
+        {
+            byte[] raw = message.RawData.ToArray();
+            int packed = raw[0];
+            if (raw.Length > 1) packed |= raw[1] << 8;
+            if (raw.Length > 2) packed |= raw[2] << 16;
+            return packed;
+        }
+    }
+}

--- a/NAudio.Wasapi/Midi/WinRT/WinRTMidiIn.cs
+++ b/NAudio.Wasapi/Midi/WinRT/WinRTMidiIn.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Windows.Devices.Enumeration;
+using Windows.Devices.Midi;
+
+namespace NAudio.Midi
+{
+    /// <summary>
+    /// MIDI input backed by the WinRT <c>Windows.Devices.Midi</c> API.
+    /// </summary>
+    /// <remarks>
+    /// Construction is async — use <see cref="GetDevicesAsync"/> to enumerate devices and
+    /// <see cref="CreateAsync"/> to open one. Timestamps reach the event handler as <see cref="TimeSpan"/>
+    /// values relative to when the underlying port was opened, with full WinRT 100 ns resolution preserved.
+    /// </remarks>
+    public class WinRTMidiIn : IMidiInput
+    {
+        private MidiInPort port;
+        private bool listening;
+        private bool disposed;
+
+        /// <inheritdoc />
+        public event EventHandler<MidiInMessageEventArgs> MessageReceived;
+
+        /// <inheritdoc />
+        public event EventHandler<MidiInSysexMessageEventArgs> SysexMessageReceived;
+
+        private WinRTMidiIn(MidiInPort port)
+        {
+            this.port = port;
+        }
+
+        /// <summary>
+        /// Enumerates the available MIDI input devices.
+        /// </summary>
+        public static async Task<IReadOnlyList<DeviceInformation>> GetDevicesAsync()
+        {
+            var selector = MidiInPort.GetDeviceSelector();
+            return await DeviceInformation.FindAllAsync(selector);
+        }
+
+        /// <summary>
+        /// Opens the MIDI input device with the given identifier.
+        /// </summary>
+        /// <param name="deviceId">A device identifier from <see cref="GetDevicesAsync"/>.</param>
+        public static async Task<WinRTMidiIn> CreateAsync(string deviceId)
+        {
+            var port = await MidiInPort.FromIdAsync(deviceId);
+            if (port == null)
+            {
+                throw new InvalidOperationException($"Could not open MIDI input device: {deviceId}");
+            }
+            return new WinRTMidiIn(port);
+        }
+
+        /// <inheritdoc />
+        public void Start()
+        {
+            if (disposed) throw new ObjectDisposedException(nameof(WinRTMidiIn));
+            if (!listening)
+            {
+                port.MessageReceived += Port_MessageReceived;
+                listening = true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            if (listening)
+            {
+                port.MessageReceived -= Port_MessageReceived;
+                listening = false;
+            }
+        }
+
+        private void Port_MessageReceived(MidiInPort sender, MidiMessageReceivedEventArgs args)
+        {
+            var message = args.Message;
+
+            if (message.Type == MidiMessageType.SystemExclusive)
+            {
+                var sysex = (MidiSystemExclusiveMessage)message;
+                byte[] data = sysex.RawData.ToArray();
+                SysexMessageReceived?.Invoke(this, new MidiInSysexMessageEventArgs(data, message.Timestamp));
+                return;
+            }
+
+            int rawMessage = MidiMessageConverter.ToRawMessage(message);
+            MessageReceived?.Invoke(this, new MidiInMessageEventArgs(rawMessage, message.Timestamp));
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                Stop();
+                port?.Dispose();
+                port = null;
+                disposed = true;
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/NAudio.Wasapi/Midi/WinRT/WinRTMidiOut.cs
+++ b/NAudio.Wasapi/Midi/WinRT/WinRTMidiOut.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.Devices.Enumeration;
+using Windows.Devices.Midi;
+
+namespace NAudio.Midi
+{
+    /// <summary>
+    /// MIDI output backed by the WinRT <c>Windows.Devices.Midi</c> API.
+    /// </summary>
+    /// <remarks>
+    /// Construction is async — use <see cref="GetDevicesAsync"/> to enumerate devices and
+    /// <see cref="CreateAsync"/> to open one.
+    /// </remarks>
+    public class WinRTMidiOut : IMidiOutput
+    {
+        private IMidiOutPort port;
+        private bool disposed;
+
+        private WinRTMidiOut(IMidiOutPort port)
+        {
+            this.port = port;
+        }
+
+        /// <summary>
+        /// Enumerates the available MIDI output devices.
+        /// </summary>
+        public static async Task<IReadOnlyList<DeviceInformation>> GetDevicesAsync()
+        {
+            var selector = MidiOutPort.GetDeviceSelector();
+            return await DeviceInformation.FindAllAsync(selector);
+        }
+
+        /// <summary>
+        /// Opens the MIDI output device with the given identifier.
+        /// </summary>
+        /// <param name="deviceId">A device identifier from <see cref="GetDevicesAsync"/>.</param>
+        public static async Task<WinRTMidiOut> CreateAsync(string deviceId)
+        {
+            var port = await MidiOutPort.FromIdAsync(deviceId);
+            if (port == null)
+            {
+                throw new InvalidOperationException($"Could not open MIDI output device: {deviceId}");
+            }
+            return new WinRTMidiOut(port);
+        }
+
+        /// <inheritdoc />
+        public void Send(int message)
+        {
+            if (disposed) throw new ObjectDisposedException(nameof(WinRTMidiOut));
+            port.SendMessage(MidiMessageConverter.ToWinRTMessage(message));
+        }
+
+        /// <inheritdoc />
+        public void SendBuffer(byte[] byteBuffer)
+        {
+            if (disposed) throw new ObjectDisposedException(nameof(WinRTMidiOut));
+            port.SendMessage(MidiMessageConverter.ToWinRTSysexMessage(byteBuffer));
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                port?.Dispose();
+                port = null;
+                disposed = true;
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/NAudio.Wasapi/NAudio.Wasapi.csproj
+++ b/NAudio.Wasapi/NAudio.Wasapi.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NAudio.Core\NAudio.Core.csproj" />
+    <ProjectReference Include="..\NAudio.Midi\NAudio.Midi.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NAudio.WinMM/Midi/MidiIn.cs
+++ b/NAudio.WinMM/Midi/MidiIn.cs
@@ -4,10 +4,16 @@ using System.Runtime.InteropServices;
 namespace NAudio.Midi
 {
     /// <summary>
-    /// Represents a MIDI in device
+    /// Represents a MIDI in device backed by the legacy winmm <c>midiIn*</c> API.
     /// </summary>
-    public class MidiIn : IDisposable 
+    public class MidiIn : IMidiInput
     {
+        /// <summary>Default size of each sysex receive buffer (4 KB).</summary>
+        private const int DefaultSysexBufferSize = 4096;
+
+        /// <summary>Default number of sysex receive buffers allocated when sysex is first needed.</summary>
+        private const int DefaultSysexBufferCount = 4;
+
         private IntPtr hMidiIn = IntPtr.Zero;
         private bool disposeIsRunning = false; // true while the Dispose() method run.
         private bool disposed = false;
@@ -22,8 +28,12 @@ namespace NAudio.Midi
         public event EventHandler<MidiInMessageEventArgs> MessageReceived;
 
         /// <summary>
-        /// An invalid MIDI message
+        /// Raised when an invalid MIDI message is received.
         /// </summary>
+        /// <remarks>
+        /// This is winmm-specific and is not part of <see cref="IMidiInput"/>; the WinRT backend
+        /// does not surface invalid-message events.
+        /// </remarks>
         public event EventHandler<MidiInMessageEventArgs> ErrorReceived;
 
         /// <summary>
@@ -34,28 +44,28 @@ namespace NAudio.Midi
         /// <summary>
         /// Gets the number of MIDI input devices available in the system
         /// </summary>
-        public static int NumberOfDevices 
+        public static int NumberOfDevices
         {
-            get 
+            get
             {
                 return MidiInterop.midiInGetNumDevs();
             }
         }
-        
+
         /// <summary>
         /// Opens a specified MIDI in device
         /// </summary>
         /// <param name="deviceNo">The device number</param>
-        public MidiIn(int deviceNo) 
+        public MidiIn(int deviceNo)
         {
             this.callback = new MidiInterop.MidiInCallback(Callback);
-            MmException.Try(MidiInterop.midiInOpen(out hMidiIn, (IntPtr) deviceNo,this.callback,IntPtr.Zero,MidiInterop.CALLBACK_FUNCTION),"midiInOpen");
+            MmException.Try(MidiInterop.midiInOpen(out hMidiIn, (IntPtr)deviceNo, this.callback, IntPtr.Zero, MidiInterop.CALLBACK_FUNCTION), "midiInOpen");
         }
-        
+
         /// <summary>
         /// Closes this MIDI in device
         /// </summary>
-        public void Close() 
+        public void Close()
         {
             Dispose();
         }
@@ -63,7 +73,7 @@ namespace NAudio.Midi
         /// <summary>
         /// Closes this MIDI in device
         /// </summary>
-        public void Dispose() 
+        public void Dispose()
         {
             GC.KeepAlive(callback);
             Dispose(true);
@@ -75,6 +85,10 @@ namespace NAudio.Midi
         /// </summary>
         public void Start()
         {
+            // Allocate sysex receive buffers lazily so callers don't have to know about them.
+            // Without this, sysex messages would never fire on this backend even if the caller
+            // subscribed to SysexMessageReceived.
+            EnsureSysexBuffers();
             MmException.Try(MidiInterop.midiInStart(hMidiIn), "midiInStart");
         }
 
@@ -94,37 +108,33 @@ namespace NAudio.Midi
             MmException.Try(MidiInterop.midiInReset(hMidiIn), "midiInReset");
         }
 
-        /// <summary>
-        /// Create a number of buffers and make them available to receive incoming Sysex messages
-        /// </summary>
-        /// <param name="bufferSize">The size of each buffer, ideally large enough to hold a complete message from the device</param>
-        /// <param name="numberOfBuffers">The number of buffers needed to handle incoming Midi while busy</param>
-        public void CreateSysexBuffers(int bufferSize, int numberOfBuffers)
+        private void EnsureSysexBuffers()
         {
-            SysexBufferHeaders = new IntPtr[numberOfBuffers];
+            if (SysexBufferHeaders.Length > 0) return;
 
+            SysexBufferHeaders = new IntPtr[DefaultSysexBufferCount];
             var hdrSize = Marshal.SizeOf(typeof(MidiInterop.MIDIHDR));
-            for (var i = 0; i < numberOfBuffers; i++)
+            for (var i = 0; i < DefaultSysexBufferCount; i++)
             {
                 var hdr = new MidiInterop.MIDIHDR();
 
-                hdr.dwBufferLength = bufferSize;
+                hdr.dwBufferLength = DefaultSysexBufferSize;
                 hdr.dwBytesRecorded = 0;
-                hdr.lpData = Marshal.AllocHGlobal(bufferSize);
+                hdr.lpData = Marshal.AllocHGlobal(DefaultSysexBufferSize);
                 hdr.dwFlags = 0;
 
                 var lpHeader = Marshal.AllocHGlobal(hdrSize);
                 Marshal.StructureToPtr(hdr, lpHeader, false);
 
-                MmException.Try(MidiInterop.midiInPrepareHeader(hMidiIn, lpHeader, Marshal.SizeOf(typeof(MidiInterop.MIDIHDR))), "midiInPrepareHeader");
-                MmException.Try(MidiInterop.midiInAddBuffer(hMidiIn, lpHeader, Marshal.SizeOf(typeof(MidiInterop.MIDIHDR))), "midiInAddBuffer");
+                MmException.Try(MidiInterop.midiInPrepareHeader(hMidiIn, lpHeader, hdrSize), "midiInPrepareHeader");
+                MmException.Try(MidiInterop.midiInAddBuffer(hMidiIn, lpHeader, hdrSize), "midiInAddBuffer");
                 SysexBufferHeaders[i] = lpHeader;
             }
         }
 
         private void Callback(IntPtr midiInHandle, MidiInterop.MidiInMessage message, IntPtr userData, IntPtr messageParameter1, IntPtr messageParameter2)
         {
-            switch(message)
+            switch (message)
             {
                 case MidiInterop.MidiInMessage.Open:
                     // message Parameter 1 & 2 are not used
@@ -134,15 +144,15 @@ namespace NAudio.Midi
                     // parameter 2 is milliseconds since MidiInStart
                     if (MessageReceived != null)
                     {
-                        MessageReceived(this, new MidiInMessageEventArgs(messageParameter1.ToInt32(), messageParameter2.ToInt32()));
+                        MessageReceived(this, new MidiInMessageEventArgs(messageParameter1.ToInt32(), TimeSpan.FromMilliseconds(messageParameter2.ToInt32())));
                     }
                     break;
                 case MidiInterop.MidiInMessage.Error:
                     // parameter 1 is invalid MIDI message
                     if (ErrorReceived != null)
                     {
-                        ErrorReceived(this, new MidiInMessageEventArgs(messageParameter1.ToInt32(), messageParameter2.ToInt32()));
-                    } 
+                        ErrorReceived(this, new MidiInMessageEventArgs(messageParameter1.ToInt32(), TimeSpan.FromMilliseconds(messageParameter2.ToInt32())));
+                    }
                     break;
                 case MidiInterop.MidiInMessage.Close:
                     // message Parameter 1 & 2 are not used
@@ -158,9 +168,9 @@ namespace NAudio.Midi
                         var sysexBytes = new byte[hdr.dwBytesRecorded];
                         Marshal.Copy(hdr.lpData, sysexBytes, 0, hdr.dwBytesRecorded);
 
-                        if (sysexBytes.Length!=0) // do not trigger the sysex event if no data in SYSEX message
-                            SysexMessageReceived(this, new MidiInSysexMessageEventArgs(sysexBytes, messageParameter2.ToInt32()));
-                        
+                        if (sysexBytes.Length != 0) // do not trigger the sysex event if no data in SYSEX message
+                            SysexMessageReceived(this, new MidiInSysexMessageEventArgs(sysexBytes, TimeSpan.FromMilliseconds(messageParameter2.ToInt32())));
+
                         //  Re-use the buffer - but not if we have no event handler registered as we are closing
                         //  BUT When disposing the (resetting the MidiIn port), LONGDATA midi message are fired with a zero length.
                         //  In that case, buffer should no be ReAdd to avoid an inifinite loop of callback as buffer are reused forever.
@@ -186,7 +196,7 @@ namespace NAudio.Midi
         {
             MidiInCapabilities caps = new MidiInCapabilities();
             int structSize = Marshal.SizeOf(caps);
-            MmException.Try(MidiInterop.midiInGetDevCaps((IntPtr)midiInDeviceNumber,out caps,structSize),"midiInGetDevCaps");
+            MmException.Try(MidiInterop.midiInGetDevCaps((IntPtr)midiInDeviceNumber, out caps, structSize), "midiInGetDevCaps");
             return caps;
         }
 
@@ -194,16 +204,16 @@ namespace NAudio.Midi
         /// Closes the MIDI in device
         /// </summary>
         /// <param name="disposing">True if called from Dispose</param>
-        protected virtual void Dispose(bool disposing) 
+        protected virtual void Dispose(bool disposing)
         {
-            if(!this.disposed) 
+            if (!this.disposed)
             {
                 disposeIsRunning = true;
                 //if(disposing) Components.Dispose();
 
                 if (SysexBufferHeaders.Length > 0)
                 {
-                    //// When SysexMessageReceived contains event handlers (!=null) , the 'midiInReset' call generate a infinit loop of CallBack call with LONGDATA message having a zero length. 
+                    //// When SysexMessageReceived contains event handlers (!=null) , the 'midiInReset' call generate a infinit loop of CallBack call with LONGDATA message having a zero length.
                     //SysexMessageReceived = null; // removin all event handler to avoir the infinit loop.
 
                     //  Reset in order to release any Sysex buffers
@@ -233,7 +243,7 @@ namespace NAudio.Midi
         /// </summary>
         ~MidiIn()
         {
-            System.Diagnostics.Debug.Assert(false,"MIDI In was not finalised");
+            System.Diagnostics.Debug.Assert(false, "MIDI In was not finalised");
             Dispose(false);
         }
     }

--- a/NAudio.WinMM/Midi/MidiOut.cs
+++ b/NAudio.WinMM/Midi/MidiOut.cs
@@ -5,9 +5,9 @@ using NAudio.Wave;
 namespace NAudio.Midi 
 {
     /// <summary>
-    /// Represents a MIDI out device
+    /// Represents a MIDI out device backed by the legacy winmm <c>midiOut*</c> API.
     /// </summary>
-    public class MidiOut : IDisposable 
+    public class MidiOut : IMidiOutput
     {
         private IntPtr hMidiOut = IntPtr.Zero;
         private bool disposed = false;

--- a/NAudioDemo/MidiInDemo/MidiInPanel.Designer.cs
+++ b/NAudioDemo/MidiInDemo/MidiInPanel.Designer.cs
@@ -29,6 +29,8 @@ namespace NAudioDemo.MidiInDemo
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            this.comboBoxBackend = new System.Windows.Forms.ComboBox();
+            this.labelBackend = new System.Windows.Forms.Label();
             this.comboBoxMidiInDevices = new System.Windows.Forms.ComboBox();
             this.labelDevice = new System.Windows.Forms.Label();
             this.buttonMonitor = new System.Windows.Forms.Button();
@@ -42,9 +44,28 @@ namespace NAudioDemo.MidiInDemo
             this.timer1 = new System.Windows.Forms.Timer(this.components);
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
+            // labelBackend
+            //
+            this.labelBackend.AutoSize = true;
+            this.labelBackend.Location = new System.Drawing.Point(282, 16);
+            this.labelBackend.Name = "labelBackend";
+            this.labelBackend.Size = new System.Drawing.Size(53, 13);
+            this.labelBackend.TabIndex = 8;
+            this.labelBackend.Text = "Backend:";
+            //
+            // comboBoxBackend
+            //
+            this.comboBoxBackend.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxBackend.FormattingEnabled = true;
+            this.comboBoxBackend.Location = new System.Drawing.Point(338, 12);
+            this.comboBoxBackend.Name = "comboBoxBackend";
+            this.comboBoxBackend.Size = new System.Drawing.Size(160, 21);
+            this.comboBoxBackend.TabIndex = 9;
+            this.comboBoxBackend.SelectedIndexChanged += new System.EventHandler(this.OnComboBoxBackendSelectedIndexChanged);
+            //
             // comboBoxMidiInDevices
-            // 
+            //
             this.comboBoxMidiInDevices.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxMidiInDevices.FormattingEnabled = true;
             this.comboBoxMidiInDevices.Location = new System.Drawing.Point(94, 12);
@@ -69,7 +90,7 @@ namespace NAudioDemo.MidiInDemo
             this.buttonMonitor.TabIndex = 2;
             this.buttonMonitor.Text = "Monitor";
             this.buttonMonitor.UseVisualStyleBackColor = true;
-            this.buttonMonitor.Click += new System.EventHandler(this.buttonMonitor_Click);
+            this.buttonMonitor.Click += new System.EventHandler(this.OnButtonMonitorClick);
             // 
             // checkBoxFilterAutoSensing
             // 
@@ -103,7 +124,7 @@ namespace NAudioDemo.MidiInDemo
             this.buttonClearLog.TabIndex = 5;
             this.buttonClearLog.Text = "Clear Log";
             this.buttonClearLog.UseVisualStyleBackColor = true;
-            this.buttonClearLog.Click += new System.EventHandler(this.buttonClearLog_Click);
+            this.buttonClearLog.Click += new System.EventHandler(this.OnButtonClearLogClick);
             //
             // buttonRefreshDevices
             //
@@ -113,7 +134,7 @@ namespace NAudioDemo.MidiInDemo
             this.buttonRefreshDevices.TabIndex = 7;
             this.buttonRefreshDevices.Text = "Refresh";
             this.buttonRefreshDevices.UseVisualStyleBackColor = true;
-            this.buttonRefreshDevices.Click += new System.EventHandler(this.buttonRefreshDevices_Click);
+            this.buttonRefreshDevices.Click += new System.EventHandler(this.OnButtonRefreshDevicesClick);
             // 
             // groupBox1
             // 
@@ -137,7 +158,7 @@ namespace NAudioDemo.MidiInDemo
             this.checkBoxMidiOutMessages.TabIndex = 0;
             this.checkBoxMidiOutMessages.Text = "Send Test MIDI Out Messages";
             this.checkBoxMidiOutMessages.UseVisualStyleBackColor = true;
-            this.checkBoxMidiOutMessages.CheckedChanged += new System.EventHandler(this.checkBoxMidiOutMessages_CheckedChanged);
+            this.checkBoxMidiOutMessages.CheckedChanged += new System.EventHandler(this.OnCheckBoxMidiOutMessagesCheckedChanged);
             // 
             // comboBoxMidiOutDevices
             // 
@@ -152,7 +173,7 @@ namespace NAudioDemo.MidiInDemo
             // 
             this.timer1.Enabled = true;
             this.timer1.Interval = 1000;
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            this.timer1.Tick += new System.EventHandler(this.OnTimer1Tick);
             // 
             // MidiInForm
             // 
@@ -167,6 +188,8 @@ namespace NAudioDemo.MidiInDemo
             this.Controls.Add(this.buttonMonitor);
             this.Controls.Add(this.labelDevice);
             this.Controls.Add(this.comboBoxMidiInDevices);
+            this.Controls.Add(this.labelBackend);
+            this.Controls.Add(this.comboBoxBackend);
             this.Name = "MidiInForm";
             this.Text = "MIDI In Sample";
             this.Disposed += this.MidiInPanel_Disposed;
@@ -191,5 +214,7 @@ namespace NAudioDemo.MidiInDemo
         private System.Windows.Forms.CheckBox checkBoxMidiOutMessages;
         private System.Windows.Forms.ComboBox comboBoxMidiOutDevices;
         private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.ComboBox comboBoxBackend;
+        private System.Windows.Forms.Label labelBackend;
     }
 }

--- a/NAudioDemo/MidiInDemo/MidiInPanel.cs
+++ b/NAudioDemo/MidiInDemo/MidiInPanel.cs
@@ -1,28 +1,41 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using NAudio.Midi;
+using Windows.Devices.Enumeration;
 
 namespace NAudioDemo.MidiInDemo
 {
     public partial class MidiInPanel : UserControl
     {
-        MidiIn midiIn;
-        MidiOut midiOut;
-        bool monitoring;
-        bool sendingMidiOut;
-        List<MidiEvent> events;
-        int midiOutIndex;
+        private const string BackendWinRT = "WinRT (Windows.Devices.Midi)";
+        private const string BackendWinMM = "Legacy WinMM";
+
+        private IMidiInput midiIn;
+        private IMidiOutput midiOut;
+        private bool monitoring;
+        private bool sendingMidiOut;
+        private List<MidiEvent> events;
+        private int midiOutIndex;
+
+        // WinRT enumeration results, indexed alongside the corresponding combo box.
+        private IReadOnlyList<DeviceInformation> winRtInDevices;
+        private IReadOnlyList<DeviceInformation> winRtOutDevices;
 
         public MidiInPanel()
         {
             InitializeComponent();
         }
 
-        private void MidiInForm_Load(object sender, EventArgs e)
+        private async void MidiInForm_Load(object sender, EventArgs e)
         {
-            PopulateDeviceLists();
+            comboBoxBackend.Items.AddRange([BackendWinRT, BackendWinMM]);
+            comboBoxBackend.SelectedIndex = 0; // WinRT default
+
+            await PopulateDeviceListsAsync();
+
             events = new List<MidiEvent>();
             for (int note = 50; note < 62; note++)
             {
@@ -30,26 +43,48 @@ namespace NAudioDemo.MidiInDemo
             }
         }
 
-        private void PopulateDeviceLists()
+        private bool IsWinRT => comboBoxBackend.SelectedItem as string == BackendWinRT;
+
+        private async Task PopulateDeviceListsAsync()
         {
             string selectedIn = comboBoxMidiInDevices.SelectedItem as string;
             string selectedOut = comboBoxMidiOutDevices.SelectedItem as string;
 
             comboBoxMidiInDevices.Items.Clear();
-            for (int device = 0; device < MidiIn.NumberOfDevices; device++)
+            comboBoxMidiOutDevices.Items.Clear();
+            winRtInDevices = null;
+            winRtOutDevices = null;
+
+            if (IsWinRT)
             {
-                comboBoxMidiInDevices.Items.Add(MidiIn.DeviceInfo(device).ProductName);
+                winRtInDevices = await WinRTMidiIn.GetDevicesAsync();
+                foreach (var device in winRtInDevices)
+                {
+                    comboBoxMidiInDevices.Items.Add(device.Name);
+                }
+
+                winRtOutDevices = await WinRTMidiOut.GetDevicesAsync();
+                foreach (var device in winRtOutDevices)
+                {
+                    comboBoxMidiOutDevices.Items.Add(device.Name);
+                }
             }
+            else
+            {
+                for (int device = 0; device < MidiIn.NumberOfDevices; device++)
+                {
+                    comboBoxMidiInDevices.Items.Add(MidiIn.DeviceInfo(device).ProductName);
+                }
+                for (int device = 0; device < MidiOut.NumberOfDevices; device++)
+                {
+                    comboBoxMidiOutDevices.Items.Add(MidiOut.DeviceInfo(device).ProductName);
+                }
+            }
+
             if (comboBoxMidiInDevices.Items.Count > 0)
             {
                 int index = selectedIn != null ? comboBoxMidiInDevices.Items.IndexOf(selectedIn) : -1;
                 comboBoxMidiInDevices.SelectedIndex = index >= 0 ? index : 0;
-            }
-
-            comboBoxMidiOutDevices.Items.Clear();
-            for (int device = 0; device < MidiOut.NumberOfDevices; device++)
-            {
-                comboBoxMidiOutDevices.Items.Add(MidiOut.DeviceInfo(device).ProductName);
             }
             if (comboBoxMidiOutDevices.Items.Count > 0)
             {
@@ -61,16 +96,16 @@ namespace NAudioDemo.MidiInDemo
         private void AddNoteEvent(int noteNumber)
         {
             int channel = 1;
-            NoteOnEvent noteOnEvent = new NoteOnEvent(0, channel, noteNumber, 100, 50);
+            var noteOnEvent = new NoteOnEvent(0, channel, noteNumber, 100, 50);
             events.Add(noteOnEvent);
             events.Add(noteOnEvent.OffEvent);
         }
 
-        private void buttonMonitor_Click(object sender, EventArgs e)
+        private async void OnButtonMonitorClick(object sender, EventArgs e)
         {
             if (!monitoring)
             {
-                StartMonitoring();
+                await StartMonitoringAsync();
             }
             else
             {
@@ -78,58 +113,85 @@ namespace NAudioDemo.MidiInDemo
             }
         }
 
-        private void StartMonitoring()
+        private async Task StartMonitoringAsync()
         {
             if (comboBoxMidiInDevices.Items.Count == 0)
             {
                 MessageBox.Show("No MIDI input devices available");
                 return;
             }
-            if (midiIn != null)
+            DisposeMidiIn();
+            try
             {
-                midiIn.MessageReceived -= midiIn_MessageReceived;
-                midiIn.ErrorReceived -= midiIn_ErrorReceived;
-                midiIn.Dispose();
-                midiIn = null;
+                int index = comboBoxMidiInDevices.SelectedIndex;
+                if (IsWinRT)
+                {
+                    midiIn = await WinRTMidiIn.CreateAsync(winRtInDevices[index].Id);
+                }
+                else
+                {
+                    var legacyIn = new MidiIn(index);
+                    legacyIn.ErrorReceived += OnMidiInErrorReceived;
+                    midiIn = legacyIn;
+                }
+                midiIn.MessageReceived += OnMidiInMessageReceived;
+                midiIn.SysexMessageReceived += OnMidiInSysexMessageReceived;
+                midiIn.Start();
+                monitoring = true;
+                buttonMonitor.Text = "Stop";
+                UpdateDeviceListEnabledState();
             }
-            midiIn = new MidiIn(comboBoxMidiInDevices.SelectedIndex);
-            midiIn.MessageReceived += midiIn_MessageReceived;
-            midiIn.ErrorReceived += midiIn_ErrorReceived;
-            midiIn.Start();
-            monitoring = true;
-            buttonMonitor.Text = "Stop";
-            UpdateDeviceListEnabledState();
+            catch (Exception ex)
+            {
+                progressLog1.LogMessage(Color.Red, "Failed to open MIDI input: " + ex.Message);
+                DisposeMidiIn();
+            }
         }
 
-        void midiIn_ErrorReceived(object sender, MidiInMessageEventArgs e)
+        void OnMidiInErrorReceived(object sender, MidiInMessageEventArgs e)
         {
-            progressLog1.LogMessage(Color.Red, String.Format("Time {0} Message 0x{1:X8} Event {2}",
-                e.Timestamp, e.RawMessage, e.MidiEvent));
+            progressLog1.LogMessage(Color.Red, $"Time {e.Timestamp} Message 0x{e.RawMessage:X8} Event {e.MidiEvent}");
         }
 
         private void StopMonitoring()
         {
-            if (monitoring && midiIn != null)
+            if (monitoring)
             {
-                midiIn.Stop();
-                midiIn.MessageReceived -= midiIn_MessageReceived;
-                midiIn.ErrorReceived -= midiIn_ErrorReceived;
-                midiIn.Dispose();
-                midiIn = null;
+                try { midiIn?.Stop(); } catch { /* swallow — already disposing */ }
             }
+            DisposeMidiIn();
             monitoring = false;
             buttonMonitor.Text = "Monitor";
             UpdateDeviceListEnabledState();
         }
 
-        void midiIn_MessageReceived(object sender, MidiInMessageEventArgs e)
+        private void DisposeMidiIn()
+        {
+            if (midiIn != null)
+            {
+                midiIn.MessageReceived -= OnMidiInMessageReceived;
+                midiIn.SysexMessageReceived -= OnMidiInSysexMessageReceived;
+                if (midiIn is MidiIn legacyIn)
+                {
+                    legacyIn.ErrorReceived -= OnMidiInErrorReceived;
+                }
+                midiIn.Dispose();
+                midiIn = null;
+            }
+        }
+
+        void OnMidiInMessageReceived(object sender, MidiInMessageEventArgs e)
         {
             if (checkBoxFilterAutoSensing.Checked && e.MidiEvent != null && e.MidiEvent.CommandCode == MidiCommandCode.AutoSensing)
             {
                 return;
             }
-            progressLog1.LogMessage(Color.Blue, String.Format("Time {0} Message 0x{1:X8} Event {2}",
-                e.Timestamp, e.RawMessage, e.MidiEvent));
+            progressLog1.LogMessage(Color.Blue, $"Time {e.Timestamp} Message 0x{e.RawMessage:X8} Event {e.MidiEvent}");
+        }
+
+        void OnMidiInSysexMessageReceived(object sender, MidiInSysexMessageEventArgs e)
+        {
+            progressLog1.LogMessage(Color.DarkBlue, $"Time {e.Timestamp} Sysex {e.SysexBytes.Length} bytes");
         }
 
         private void MidiInPanel_Disposed(object sender, EventArgs e)
@@ -139,21 +201,29 @@ namespace NAudioDemo.MidiInDemo
             StopSendingMidiOut();
         }
 
-        private void buttonClearLog_Click(object sender, EventArgs e)
+        private void OnButtonClearLogClick(object sender, EventArgs e)
         {
             progressLog1.ClearLog();
         }
 
-        private void buttonRefreshDevices_Click(object sender, EventArgs e)
+        private async void OnButtonRefreshDevicesClick(object sender, EventArgs e)
         {
-            PopulateDeviceLists();
+            await PopulateDeviceListsAsync();
         }
 
-        private void checkBoxMidiOutMessages_CheckedChanged(object sender, EventArgs e)
+        private async void OnComboBoxBackendSelectedIndexChanged(object sender, EventArgs e)
+        {
+            // Stop anything in-flight before switching APIs.
+            StopMonitoring();
+            StopSendingMidiOut();
+            await PopulateDeviceListsAsync();
+        }
+
+        private async void OnCheckBoxMidiOutMessagesCheckedChanged(object sender, EventArgs e)
         {
             if (checkBoxMidiOutMessages.Checked)
             {
-                StartSendingMidiOut();
+                await StartSendingMidiOutAsync();
             }
             else
             {
@@ -161,7 +231,7 @@ namespace NAudioDemo.MidiInDemo
             }
         }
 
-        private void StartSendingMidiOut()
+        private async Task StartSendingMidiOutAsync()
         {
             if (comboBoxMidiOutDevices.Items.Count == 0)
             {
@@ -171,7 +241,19 @@ namespace NAudioDemo.MidiInDemo
             }
             if (midiOut == null)
             {
-                midiOut = new MidiOut(comboBoxMidiOutDevices.SelectedIndex);
+                try
+                {
+                    int index = comboBoxMidiOutDevices.SelectedIndex;
+                    midiOut = IsWinRT
+                        ? await WinRTMidiOut.CreateAsync(winRtOutDevices[index].Id)
+                        : new MidiOut(index);
+                }
+                catch (Exception ex)
+                {
+                    progressLog1.LogMessage(Color.Red, "Failed to open MIDI output: " + ex.Message);
+                    checkBoxMidiOutMessages.Checked = false;
+                    return;
+                }
             }
             midiOutIndex = 0;
             sendingMidiOut = true;
@@ -183,8 +265,13 @@ namespace NAudioDemo.MidiInDemo
             sendingMidiOut = false;
             if (midiOut != null)
             {
-                // Make sure any currently playing note is silenced.
-                midiOut.Reset();
+                // send NoteOff for any notes that might still be on, to avoid hanging notes in the synth
+                var nextEvent = events[midiOutIndex] as NoteEvent;
+                if (nextEvent != null && !MidiEvent.IsNoteOn(nextEvent))
+                {
+                    midiOut.Send(nextEvent); 
+                }
+            
                 midiOut.Dispose();
                 midiOut = null;
             }
@@ -194,12 +281,13 @@ namespace NAudioDemo.MidiInDemo
 
         private void UpdateDeviceListEnabledState()
         {
+            comboBoxBackend.Enabled = !monitoring && !sendingMidiOut;
             comboBoxMidiInDevices.Enabled = !monitoring;
             comboBoxMidiOutDevices.Enabled = !sendingMidiOut;
             buttonRefreshDevices.Enabled = !monitoring && !sendingMidiOut;
         }
 
-        private void timer1_Tick(object sender, EventArgs e)
+        private void OnTimer1Tick(object sender, EventArgs e)
         {
             if (sendingMidiOut)
             {
@@ -211,8 +299,8 @@ namespace NAudioDemo.MidiInDemo
         {
             if (midiOut == null) return;
             MidiEvent eventToSend = events[midiOutIndex++];
-            midiOut.Send(eventToSend.GetAsShortMessage());
-            progressLog1.LogMessage(Color.Green, String.Format("Sent {0}", eventToSend));
+            midiOut.Send(eventToSend); // extension method — works for both backends
+            progressLog1.LogMessage(Color.Green, $"Sent {eventToSend}");
             if (midiOutIndex >= events.Count)
             {
                 midiOutIndex = 0;

--- a/NAudioTests/Wasapi/Midi/MidiMessageConverterTests.cs
+++ b/NAudioTests/Wasapi/Midi/MidiMessageConverterTests.cs
@@ -1,0 +1,530 @@
+using System;
+using System.Runtime.InteropServices.WindowsRuntime;
+using NAudio.Midi;
+using NUnit.Framework;
+using Windows.Devices.Midi;
+
+namespace NAudioTests.Wasapi.Midi
+{
+    [TestFixture]
+    [Category("UnitTest")]
+    public class MidiMessageConverterTests
+    {
+        // --- ToMidiEvent tests (WinRT → NAudio) ---
+
+        [TestCase(0, 60, 100)]
+        [TestCase(9, 36, 127)]
+        [TestCase(15, 0, 1)]
+        public void ToMidiEvent_NoteOn(byte channel, byte note, byte velocity)
+        {
+            var winRtMessage = new MidiNoteOnMessage(channel, note, velocity);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<NoteOnEvent>());
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.NoteOn));
+            var noteEvent = (NoteEvent)midiEvent;
+            Assert.That(noteEvent.NoteNumber, Is.EqualTo(note));
+            Assert.That(noteEvent.Velocity, Is.EqualTo(velocity));
+        }
+
+        [TestCase(0, 60, 64)]
+        [TestCase(5, 127, 0)]
+        public void ToMidiEvent_NoteOff(byte channel, byte note, byte velocity)
+        {
+            var winRtMessage = new MidiNoteOffMessage(channel, note, velocity);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<NoteEvent>());
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.NoteOff));
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            var noteEvent = (NoteEvent)midiEvent;
+            Assert.That(noteEvent.NoteNumber, Is.EqualTo(note));
+            Assert.That(noteEvent.Velocity, Is.EqualTo(velocity));
+        }
+
+        [TestCase(0, 7, 100)]   // Volume
+        [TestCase(0, 1, 64)]    // Modulation
+        [TestCase(15, 64, 127)] // Sustain
+        public void ToMidiEvent_ControlChange(byte channel, byte controller, byte value)
+        {
+            var winRtMessage = new MidiControlChangeMessage(channel, controller, value);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<ControlChangeEvent>());
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            var cc = (ControlChangeEvent)midiEvent;
+            Assert.That((int)cc.Controller, Is.EqualTo(controller));
+            Assert.That(cc.ControllerValue, Is.EqualTo(value));
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(9, 42)]
+        [TestCase(15, 127)]
+        public void ToMidiEvent_ProgramChange(byte channel, byte program)
+        {
+            var winRtMessage = new MidiProgramChangeMessage(channel, program);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<PatchChangeEvent>());
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            var pc = (PatchChangeEvent)midiEvent;
+            Assert.That(pc.Patch, Is.EqualTo(program));
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(3, 64)]
+        [TestCase(15, 127)]
+        public void ToMidiEvent_ChannelPressure(byte channel, byte pressure)
+        {
+            var winRtMessage = new MidiChannelPressureMessage(channel, pressure);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<ChannelAfterTouchEvent>());
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            var afterTouch = (ChannelAfterTouchEvent)midiEvent;
+            Assert.That(afterTouch.AfterTouchPressure, Is.EqualTo(pressure));
+        }
+
+        [TestCase(0, 8192)]   // Center
+        [TestCase(0, 0)]      // Min
+        [TestCase(0, 16383)]  // Max
+        [TestCase(7, 4096)]
+        public void ToMidiEvent_PitchBend(byte channel, int bend)
+        {
+            var winRtMessage = new MidiPitchBendChangeMessage(channel, (ushort)bend);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<PitchWheelChangeEvent>());
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            var pb = (PitchWheelChangeEvent)midiEvent;
+            Assert.That(pb.Pitch, Is.EqualTo(bend));
+        }
+
+        [TestCase(0, 60, 80)]
+        [TestCase(5, 48, 127)]
+        public void ToMidiEvent_PolyphonicKeyPressure(byte channel, byte note, byte pressure)
+        {
+            var winRtMessage = new MidiPolyphonicKeyPressureMessage(channel, note, pressure);
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.TypeOf<NoteEvent>());
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.KeyAfterTouch));
+            Assert.That(midiEvent.Channel, Is.EqualTo(channel + 1));
+            var noteEvent = (NoteEvent)midiEvent;
+            Assert.That(noteEvent.NoteNumber, Is.EqualTo(note));
+            Assert.That(noteEvent.Velocity, Is.EqualTo(pressure));
+        }
+
+        [Test]
+        public void ToMidiEvent_SystemExclusive_ReturnsNull()
+        {
+            var sysexData = new byte[] { 0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7 };
+            var winRtMessage = new MidiSystemExclusiveMessage(sysexData.AsBuffer());
+            var midiEvent = MidiMessageConverter.ToMidiEvent(winRtMessage);
+
+            Assert.That(midiEvent, Is.Null);
+        }
+
+        [Test]
+        public void ToMidiEvent_TimingClock()
+        {
+            var midiEvent = MidiMessageConverter.ToMidiEvent(new MidiTimingClockMessage());
+            Assert.That(midiEvent, Is.Not.Null);
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.TimingClock));
+        }
+
+        [Test]
+        public void ToMidiEvent_ActiveSensing()
+        {
+            var midiEvent = MidiMessageConverter.ToMidiEvent(new MidiActiveSensingMessage());
+            Assert.That(midiEvent, Is.Not.Null);
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.AutoSensing));
+        }
+
+        [Test]
+        public void ToMidiEvent_StartMessage()
+        {
+            var midiEvent = MidiMessageConverter.ToMidiEvent(new MidiStartMessage());
+            Assert.That(midiEvent, Is.Not.Null);
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.StartSequence));
+        }
+
+        [Test]
+        public void ToMidiEvent_ContinueMessage()
+        {
+            var midiEvent = MidiMessageConverter.ToMidiEvent(new MidiContinueMessage());
+            Assert.That(midiEvent, Is.Not.Null);
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.ContinueSequence));
+        }
+
+        [Test]
+        public void ToMidiEvent_StopMessage()
+        {
+            var midiEvent = MidiMessageConverter.ToMidiEvent(new MidiStopMessage());
+            Assert.That(midiEvent, Is.Not.Null);
+            Assert.That(midiEvent.CommandCode, Is.EqualTo(MidiCommandCode.StopSequence));
+        }
+
+        [Test]
+        public void ToMidiEvent_SystemReset()
+        {
+            var midiEvent = MidiMessageConverter.ToMidiEvent(new MidiSystemResetMessage());
+            // NAudio's FromRawMessage doesn't have a dedicated SystemReset event, but should not throw
+            // and either returns null or a MidiEvent — the contract is just "don't blow up".
+            Assert.That(() => MidiMessageConverter.ToMidiEvent(new MidiSystemResetMessage()), Throws.Nothing);
+        }
+
+        [Test]
+        public void ToMidiEvent_SongPositionPointer_DoesNotThrow()
+        {
+            var msg = new MidiSongPositionPointerMessage(1234);
+            Assert.That(() => MidiMessageConverter.ToMidiEvent(msg), Throws.Nothing);
+        }
+
+        [Test]
+        public void ToMidiEvent_SongSelect_DoesNotThrow()
+        {
+            var msg = new MidiSongSelectMessage(5);
+            Assert.That(() => MidiMessageConverter.ToMidiEvent(msg), Throws.Nothing);
+        }
+
+        [Test]
+        public void ToMidiEvent_TimeCode_DoesNotThrow()
+        {
+            var msg = new MidiTimeCodeMessage(0, 12);
+            Assert.That(() => MidiMessageConverter.ToMidiEvent(msg), Throws.Nothing);
+        }
+
+        [Test]
+        public void ToMidiEvent_TuneRequest_DoesNotThrow()
+        {
+            var msg = new MidiTuneRequestMessage();
+            Assert.That(() => MidiMessageConverter.ToMidiEvent(msg), Throws.Nothing);
+        }
+
+        // --- ToWinRTMessage tests (NAudio → WinRT) ---
+
+        [TestCase(1, 60, 100)]
+        [TestCase(10, 36, 127)]
+        [TestCase(16, 0, 1)]
+        public void ToWinRTMessage_NoteOn(int channel, int note, int velocity)
+        {
+            var noteOn = new NoteOnEvent(0, channel, note, velocity, 0);
+            var result = MidiMessageConverter.ToWinRTMessage(noteOn.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiNoteOnMessage>());
+            var msg = (MidiNoteOnMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Note, Is.EqualTo(note));
+            Assert.That(msg.Velocity, Is.EqualTo(velocity));
+        }
+
+        [TestCase(1, 60, 64)]
+        [TestCase(16, 127, 0)]
+        public void ToWinRTMessage_NoteOff(int channel, int note, int velocity)
+        {
+            var noteOff = new NoteEvent(0, channel, MidiCommandCode.NoteOff, note, velocity);
+            var result = MidiMessageConverter.ToWinRTMessage(noteOff.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiNoteOffMessage>());
+            var msg = (MidiNoteOffMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Note, Is.EqualTo(note));
+            Assert.That(msg.Velocity, Is.EqualTo(velocity));
+        }
+
+        [TestCase(1, MidiController.MainVolume, 100)]
+        [TestCase(1, MidiController.Modulation, 64)]
+        [TestCase(16, MidiController.Sustain, 127)]
+        public void ToWinRTMessage_ControlChange(int channel, MidiController controller, int value)
+        {
+            var cc = new ControlChangeEvent(0, channel, controller, value);
+            var result = MidiMessageConverter.ToWinRTMessage(cc.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiControlChangeMessage>());
+            var msg = (MidiControlChangeMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Controller, Is.EqualTo((byte)controller));
+            Assert.That(msg.ControlValue, Is.EqualTo(value));
+        }
+
+        [TestCase(1, 0)]
+        [TestCase(10, 42)]
+        [TestCase(16, 127)]
+        public void ToWinRTMessage_ProgramChange(int channel, int program)
+        {
+            var pc = new PatchChangeEvent(0, channel, program);
+            var result = MidiMessageConverter.ToWinRTMessage(pc.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiProgramChangeMessage>());
+            var msg = (MidiProgramChangeMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Program, Is.EqualTo(program));
+        }
+
+        [TestCase(1, 0)]
+        [TestCase(4, 64)]
+        [TestCase(16, 127)]
+        public void ToWinRTMessage_ChannelPressure(int channel, int pressure)
+        {
+            var cp = new ChannelAfterTouchEvent(0, channel, pressure);
+            var result = MidiMessageConverter.ToWinRTMessage(cp.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiChannelPressureMessage>());
+            var msg = (MidiChannelPressureMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Pressure, Is.EqualTo(pressure));
+        }
+
+        [TestCase(1, 8192)]   // Center
+        [TestCase(1, 0)]      // Min
+        [TestCase(1, 16383)]  // Max
+        [TestCase(8, 4096)]
+        public void ToWinRTMessage_PitchBend(int channel, int pitch)
+        {
+            var pb = new PitchWheelChangeEvent(0, channel, pitch);
+            var result = MidiMessageConverter.ToWinRTMessage(pb.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiPitchBendChangeMessage>());
+            var msg = (MidiPitchBendChangeMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Bend, Is.EqualTo(pitch));
+        }
+
+        [TestCase(1, 60, 80)]
+        [TestCase(6, 48, 127)]
+        public void ToWinRTMessage_PolyphonicKeyPressure(int channel, int note, int pressure)
+        {
+            var poly = new NoteEvent(0, channel, MidiCommandCode.KeyAfterTouch, note, pressure);
+            var result = MidiMessageConverter.ToWinRTMessage(poly.GetAsShortMessage());
+
+            Assert.That(result, Is.TypeOf<MidiPolyphonicKeyPressureMessage>());
+            var msg = (MidiPolyphonicKeyPressureMessage)result;
+            Assert.That(msg.Channel, Is.EqualTo(channel - 1));
+            Assert.That(msg.Note, Is.EqualTo(note));
+            Assert.That(msg.Pressure, Is.EqualTo(pressure));
+        }
+
+        [Test]
+        public void ToWinRTMessage_TimingClock()
+        {
+            var midiEvent = new MidiEvent(0, 1, MidiCommandCode.TimingClock);
+            var result = MidiMessageConverter.ToWinRTMessage(midiEvent.GetAsShortMessage());
+            Assert.That(result, Is.TypeOf<MidiTimingClockMessage>());
+        }
+
+        [Test]
+        public void ToWinRTMessage_StartSequence()
+        {
+            var midiEvent = new MidiEvent(0, 1, MidiCommandCode.StartSequence);
+            var result = MidiMessageConverter.ToWinRTMessage(midiEvent.GetAsShortMessage());
+            Assert.That(result, Is.TypeOf<MidiStartMessage>());
+        }
+
+        [Test]
+        public void ToWinRTMessage_ContinueSequence()
+        {
+            var midiEvent = new MidiEvent(0, 1, MidiCommandCode.ContinueSequence);
+            var result = MidiMessageConverter.ToWinRTMessage(midiEvent.GetAsShortMessage());
+            Assert.That(result, Is.TypeOf<MidiContinueMessage>());
+        }
+
+        [Test]
+        public void ToWinRTMessage_StopSequence()
+        {
+            var midiEvent = new MidiEvent(0, 1, MidiCommandCode.StopSequence);
+            var result = MidiMessageConverter.ToWinRTMessage(midiEvent.GetAsShortMessage());
+            Assert.That(result, Is.TypeOf<MidiStopMessage>());
+        }
+
+        [Test]
+        public void ToWinRTMessage_ActiveSensing()
+        {
+            var midiEvent = new MidiEvent(0, 1, MidiCommandCode.AutoSensing);
+            var result = MidiMessageConverter.ToWinRTMessage(midiEvent.GetAsShortMessage());
+            Assert.That(result, Is.TypeOf<MidiActiveSensingMessage>());
+        }
+
+        [Test]
+        public void ToWinRTMessage_TimeCode()
+        {
+            // MTC quarter-frame: 0xF1, single data byte holding (messageType << 4) | values
+            int packed = 0xF1 | (0x2C << 8); // type=2, values=0xC
+            var result = MidiMessageConverter.ToWinRTMessage(packed);
+            Assert.That(result, Is.TypeOf<MidiTimeCodeMessage>());
+            var msg = (MidiTimeCodeMessage)result;
+            Assert.That(msg.FrameType, Is.EqualTo(2));
+            Assert.That(msg.Values, Is.EqualTo(0xC));
+        }
+
+        [Test]
+        public void ToWinRTMessage_SongPositionPointer()
+        {
+            int beats = 1234;
+            int packed = 0xF2 | ((beats & 0x7F) << 8) | (((beats >> 7) & 0x7F) << 16);
+            var result = MidiMessageConverter.ToWinRTMessage(packed);
+            Assert.That(result, Is.TypeOf<MidiSongPositionPointerMessage>());
+            Assert.That(((MidiSongPositionPointerMessage)result).Beats, Is.EqualTo(beats));
+        }
+
+        [Test]
+        public void ToWinRTMessage_SongSelect()
+        {
+            int packed = 0xF3 | (5 << 8);
+            var result = MidiMessageConverter.ToWinRTMessage(packed);
+            Assert.That(result, Is.TypeOf<MidiSongSelectMessage>());
+            Assert.That(((MidiSongSelectMessage)result).Song, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void ToWinRTMessage_TuneRequest()
+        {
+            var result = MidiMessageConverter.ToWinRTMessage(0xF6);
+            Assert.That(result, Is.TypeOf<MidiTuneRequestMessage>());
+        }
+
+        [Test]
+        public void ToWinRTMessage_UnsupportedThrows()
+        {
+            // 0xF4 is undefined in the MIDI spec — should throw.
+            int unsupportedMessage = 0xF4;
+            Assert.Throws<ArgumentException>(() => MidiMessageConverter.ToWinRTMessage(unsupportedMessage));
+        }
+
+        // --- ToWinRTSysexMessage tests ---
+
+        [Test]
+        public void ToWinRTSysexMessage_CreatesValidMessage()
+        {
+            var sysexData = new byte[] { 0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7 };
+            var result = MidiMessageConverter.ToWinRTSysexMessage(sysexData);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Type, Is.EqualTo(MidiMessageType.SystemExclusive));
+            var raw = result.RawData.ToArray();
+            Assert.That(raw, Is.EqualTo(sysexData));
+        }
+
+        // --- ToRawMessage tests ---
+
+        [Test]
+        public void ToRawMessage_NoteOn_PacksCorrectly()
+        {
+            var msg = new MidiNoteOnMessage(0, 60, 100);
+            int raw = MidiMessageConverter.ToRawMessage(msg);
+
+            Assert.That(raw & 0xFF, Is.EqualTo(0x90));       // status: note on, channel 0
+            Assert.That((raw >> 8) & 0xFF, Is.EqualTo(60));   // note
+            Assert.That((raw >> 16) & 0xFF, Is.EqualTo(100)); // velocity
+        }
+
+        [Test]
+        public void ToRawMessage_ProgramChange_PacksCorrectly()
+        {
+            var msg = new MidiProgramChangeMessage(3, 42);
+            int raw = MidiMessageConverter.ToRawMessage(msg);
+
+            Assert.That(raw & 0xFF, Is.EqualTo(0xC3));       // status: program change, channel 3
+            Assert.That((raw >> 8) & 0xFF, Is.EqualTo(42));  // program
+        }
+
+        // --- Round-trip tests (NAudio → WinRT → NAudio) ---
+
+        [TestCase(1, 60, 100)]
+        [TestCase(10, 36, 127)]
+        [TestCase(16, 127, 1)]
+        public void RoundTrip_NoteOn(int channel, int note, int velocity)
+        {
+            var original = new NoteOnEvent(0, channel, note, velocity, 0);
+            int shortMsg = original.GetAsShortMessage();
+
+            var winRtMsg = MidiMessageConverter.ToWinRTMessage(shortMsg);
+            var roundTripped = MidiMessageConverter.ToMidiEvent(winRtMsg);
+
+            Assert.That(roundTripped, Is.TypeOf<NoteOnEvent>());
+            Assert.That(roundTripped.Channel, Is.EqualTo(channel));
+            var noteEvent = (NoteEvent)roundTripped;
+            Assert.That(noteEvent.NoteNumber, Is.EqualTo(note));
+            Assert.That(noteEvent.Velocity, Is.EqualTo(velocity));
+        }
+
+        [TestCase(1, MidiController.MainVolume, 100)]
+        [TestCase(16, MidiController.Pan, 64)]
+        public void RoundTrip_ControlChange(int channel, MidiController controller, int value)
+        {
+            var original = new ControlChangeEvent(0, channel, controller, value);
+            int shortMsg = original.GetAsShortMessage();
+
+            var winRtMsg = MidiMessageConverter.ToWinRTMessage(shortMsg);
+            var roundTripped = MidiMessageConverter.ToMidiEvent(winRtMsg);
+
+            Assert.That(roundTripped, Is.TypeOf<ControlChangeEvent>());
+            Assert.That(roundTripped.Channel, Is.EqualTo(channel));
+            var cc = (ControlChangeEvent)roundTripped;
+            Assert.That(cc.Controller, Is.EqualTo(controller));
+            Assert.That(cc.ControllerValue, Is.EqualTo(value));
+        }
+
+        [TestCase(1, 0)]
+        [TestCase(1, 8192)]
+        [TestCase(1, 16383)]
+        [TestCase(8, 4096)]
+        public void RoundTrip_PitchBend(int channel, int pitch)
+        {
+            var original = new PitchWheelChangeEvent(0, channel, pitch);
+            int shortMsg = original.GetAsShortMessage();
+
+            var winRtMsg = MidiMessageConverter.ToWinRTMessage(shortMsg);
+            var roundTripped = MidiMessageConverter.ToMidiEvent(winRtMsg);
+
+            Assert.That(roundTripped, Is.TypeOf<PitchWheelChangeEvent>());
+            Assert.That(roundTripped.Channel, Is.EqualTo(channel));
+            var pb = (PitchWheelChangeEvent)roundTripped;
+            Assert.That(pb.Pitch, Is.EqualTo(pitch));
+        }
+
+        [TestCase(1, 42)]
+        [TestCase(10, 0)]
+        [TestCase(16, 127)]
+        public void RoundTrip_ProgramChange(int channel, int program)
+        {
+            var original = new PatchChangeEvent(0, channel, program);
+            int shortMsg = original.GetAsShortMessage();
+
+            var winRtMsg = MidiMessageConverter.ToWinRTMessage(shortMsg);
+            var roundTripped = MidiMessageConverter.ToMidiEvent(winRtMsg);
+
+            Assert.That(roundTripped, Is.TypeOf<PatchChangeEvent>());
+            Assert.That(roundTripped.Channel, Is.EqualTo(channel));
+            var pc = (PatchChangeEvent)roundTripped;
+            Assert.That(pc.Patch, Is.EqualTo(program));
+        }
+
+        [TestCase(1, 64)]
+        [TestCase(16, 0)]
+        [TestCase(4, 127)]
+        public void RoundTrip_ChannelPressure(int channel, int pressure)
+        {
+            var original = new ChannelAfterTouchEvent(0, channel, pressure);
+            int shortMsg = original.GetAsShortMessage();
+
+            var winRtMsg = MidiMessageConverter.ToWinRTMessage(shortMsg);
+            var roundTripped = MidiMessageConverter.ToMidiEvent(winRtMsg);
+
+            Assert.That(roundTripped, Is.TypeOf<ChannelAfterTouchEvent>());
+            Assert.That(roundTripped.Channel, Is.EqualTo(channel));
+            var cp = (ChannelAfterTouchEvent)roundTripped;
+            Assert.That(cp.AfterTouchPressure, Is.EqualTo(pressure));
+        }
+
+        [Test]
+        public void RoundTrip_Sysex()
+        {
+            var sysexData = new byte[] { 0xF0, 0x00, 0x21, 0x1D, 0x01, 0x01, 0xF7 };
+            var winRtMsg = MidiMessageConverter.ToWinRTSysexMessage(sysexData);
+            var raw = winRtMsg.RawData.ToArray();
+            Assert.That(raw, Is.EqualTo(sysexData));
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,8 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `MmResult`, `MmException`, and `Manufacturers` moved from `NAudio.Core` to `NAudio.WinMM`
  * `DirectSoundOut` moved from `NAudio.Core` to `NAudio.Wasapi` (DirectSound has always been Windows-only)
  * `NAudio.Midi` is now cross-platform — its `net9.0` target no longer P/Invokes `winmm.dll`
+ * `MidiInMessageEventArgs.Timestamp` and `MidiInSysexMessageEventArgs.Timestamp` are now `TimeSpan` (previously `int` milliseconds) — preserves full WinRT 100 ns resolution on the WinRT backend
+ * `MidiIn.CreateSysexBuffers` removed — `MidiIn` now allocates sysex receive buffers automatically inside `Start()`
  * `WasapiOut`, `WasapiCapture`, and `WasapiLoopbackCapture` are now `[Obsolete]` in favour of the new `WasapiPlayer` / `WasapiRecorder` APIs (the legacy types still ship and continue to work)
  * `WaveOut` and `WaveIn` now default to event-driven callbacks; the legacy window-based variants are renamed `WaveOutWindow` / `WaveInWindow` and live in `NAudio.WinForms`
  * `WaveInEventArgs` now fires one event per WASAPI packet (previously batched). A new `BufferSpan` property exposes the data without copying through the existing `Buffer` byte array
@@ -35,6 +37,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * **DSP:** new `FftProcessor` with real-input specialisation and precomputed windowing
  * **WAV chunks:** new `IWaveChunkInterpreter<T>` extension point, with built-in interpreters for cue lists, BWF `bext` (v1 and v2), and LIST/INFO metadata. RF64 promotion is now an explicit `WaveFileWriterOption`
  * **`Span<T>` overloads:** added on `BiQuadFilter.Transform`, `ALawDecoder.Decode`, `MuLawDecoder.Decode`, and `IMp3FrameDecompressor.DecompressFrame` (default interface method preserves backward compatibility with `NLayer` and other third-party decoders)
+ * **MIDI:** new `WinRTMidiIn` / `WinRTMidiOut` classes in `NAudio.Wasapi` backed by `Windows.Devices.Midi`, with `MidiMessageConverter` for interop with the WinRT MIDI types. New `IMidiInput` / `IMidiOutput` interfaces (with a `Send(MidiEvent)` extension) let callers write backend-agnostic code; legacy `MidiIn` / `MidiOut` also implement them
 
 #### Demo apps and Test Harnesses
 


### PR DESCRIPTION
## Summary
- Adds `WinRTMidiIn` / `WinRTMidiOut` in `NAudio.Wasapi`, backed by `Windows.Devices.Midi`, plus a `MidiMessageConverter` for interop between `MidiEvent` and the WinRT `IMidiMessage` types.
- Introduces `IMidiInput` / `IMidiOutput` interfaces in `NAudio.Midi` so callers can target either backend interchangeably; legacy WinMM `MidiIn` / `MidiOut` now implement them, and a `Send(MidiEvent)` extension lives in `MidiOutputExtensions`.
- Refreshes the `MidiInDemo` panel to exercise both backends and updates `Docs/MidiInAndOut.md`.

## Breaking changes
- `MidiInMessageEventArgs.Timestamp` and `MidiInSysexMessageEventArgs.Timestamp` are now `TimeSpan` (previously `int` milliseconds) — preserves WinRT's 100 ns resolution.
- `MidiIn.CreateSysexBuffers` removed — sysex receive buffers are now allocated automatically inside `Start()`.

## Test plan
- [x] `MidiMessageConverterTests` cover MIDI ↔ WinRT round-tripping (channel voice, system common, real-time, sysex)
- [x] Full solution build + headless test run on Windows
- [x] Manual smoke test of `MidiInDemo` against a real device on both WinMM and WinRT backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)