### PR TITLE
Remove dead naudio.codeplex.com links

### DIFF
--- a/MixDiff/MixDiffForm.cs
+++ b/MixDiff/MixDiffForm.cs
@@ -451,7 +451,7 @@ namespace MarkHeath.AudioUtils
         {
             try
             {
-                System.Diagnostics.Process.Start("http://www.codeplex.com/naudio/Wiki/View.aspx?title=MixDiff");
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://github.com/naudio/NAudio") { UseShellExecute = true });
             }
             catch (Exception)
             {

--- a/NAudio.Wasapi/WasapiLoopbackCapture.cs
+++ b/NAudio.Wasapi/WasapiLoopbackCapture.cs
@@ -6,7 +6,7 @@ namespace NAudio.Wave
 {
     /// <summary>
     /// WASAPI Loopback Capture
-    /// based on a contribution from "Pygmy" - http://naudio.codeplex.com/discussions/203605
+    /// based on a contribution from "Pygmy"
     /// </summary>
     [Obsolete("Use WasapiRecorderBuilder.WithProcessLoopback() for process-specific loopback, or configure a WasapiRecorder with a render device for system-wide loopback.")]
     public class WasapiLoopbackCapture : WasapiCapture

--- a/NAudio.Wasapi/WasapiOut.cs
+++ b/NAudio.Wasapi/WasapiOut.cs
@@ -165,7 +165,7 @@ namespace NAudio.Wave
                             numFramesPadding = audioClient.CurrentPadding;
                         }
                         int numFramesAvailable = bufferFrameCount - numFramesPadding;
-                        if (numFramesAvailable > 10) // see https://naudio.codeplex.com/workitem/16363
+                        if (numFramesAvailable > 10)
                         {
                             if (FillBuffer(playbackProvider, numFramesAvailable))
                             {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ NAudio comes with several demo applications which are the quickest way to see ho
 * [Merge MP3 Files](http://markheath.net/post/merging-mp3-files-with-naudio-in-c-and)
 * [Convert an AIFF file to WAV](http://markheath.net/post/how-to-convert-aiff-files-to-wav-using)
 * [Use the WavFileWriter class](http://markheath.net/post/how-to-use-wavefilewriter)
-* [Create an ID3v2 tag](http://naudio.codeplex.com/wikipage?title=Create%20an%20ID3v2%20Tag)
 
 ### Manipulating audio
 
@@ -149,7 +148,6 @@ NAudio comes with several demo applications which are the quickest way to see ho
 
 Additional sources of documentation for NAudio are:
 
-* [Original Documentation on CodePlex](http://naudio.codeplex.com/documentation)
 * [NAudio articles on Mark Heath's blog](http://markheath.net/category/naudio)
 
 ## NAudio Training Courses

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -76,6 +76,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `MediaBufferLease`: hardened against out-of-order disposal
  * Added finalizers to DMO `MediaBuffer` and the `Mf*` wrappers that hold (RCW, IntPtr) pairs to prevent COM ref leaks
  * Clarified `BiQuadFilter` `q` parameter docs (#1264)
+ * Removed dead `naudio.codeplex.com` links from README, MixDiff Help menu, and source comments (CodePlex was shut down by Microsoft in 2017) (#985)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

CodePlex was shut down by Microsoft in late 2017, so every link to `naudio.codeplex.com` is unreachable. This sweep removes the live ones (README links, the MixDiff Help menu, and inline source-comment URLs) and leaves archival mentions in release-notes / changelog files alone.

Fixes #985.

## Changes

- **`README.md`** — removed the *"Original Documentation on CodePlex"* and *"Create an ID3v2 tag"* bullets.
- **`MixDiff/MixDiffForm.cs`** — Help → Contents menu now opens `https://github.com/naudio/NAudio` instead of the dead CodePlex wiki page. Also switched to `ProcessStartInfo { UseShellExecute = true }` so the browser actually launches on .NET 5+ (the bare-string `Process.Start` overload stopped opening URLs after .NET Core 3).
- **`NAudio.Wasapi/WasapiOut.cs`** — removed dead workitem URL from inline comment.
- **`NAudio.Wasapi/WasapiLoopbackCapture.cs`** — removed dead discussion URL from the XML doc; kept the "based on a contribution from Pygmy" attribution.
- **`RELEASE_NOTES.md`** — added a bullet under *Reliability and bug fixes* referencing #985.

## Deliberately left alone

Archival historical records, none clickable from current docs/UI:

- `RELEASE_NOTES.md` historic entries (lines 362, 363, 421)
- `AudioFileInspector/ReleaseNotes.md`, `MidiFileConverter/ReleaseNotes.md`, `MixDiff/ReleaseNotes.md`
- `NAudio.Asio/AsioDriver.cs` attribution comment (no URL, just textual mention of "codeplex issue tracker")
- `NAudio/Changes.xml` legacy changelog

## Test plan

- [ ] CI build passes on `windows-latest`
- [ ] Spot-check README renders correctly on GitHub
- [ ] (Manual, optional) Run MixDiff and confirm Help → Contents now opens the NAudio GitHub repo in the default browser

---
_Generated by [Claude Code](https://claude.ai/code/session_018CkscxQXvWajxeUpsttNmA)_