### PR TITLE
Cache output-buffer array in DMO Read hot paths (#971)

### DIFF
--- a/NAudio.Wasapi/DmoMp3FrameDecompressor.cs
+++ b/NAudio.Wasapi/DmoMp3FrameDecompressor.cs
@@ -16,6 +16,7 @@ namespace NAudio.FileFormats.Mp3
         private WaveFormat pcmFormat;
         private MediaBuffer inputMediaBuffer;
         private DmoOutputDataBuffer outputBuffer;
+        private DmoOutputDataBuffer[] outputBufferArray;
         private bool reposition;
 
         /// <summary>
@@ -40,6 +41,7 @@ namespace NAudio.FileFormats.Mp3
             // a second is more than enough to decompress a frame at a time
             inputMediaBuffer = new MediaBuffer(sourceFormat.AverageBytesPerSecond);
             outputBuffer = new DmoOutputDataBuffer(pcmFormat.AverageBytesPerSecond);
+            outputBufferArray = new[] { outputBuffer };
         }
 
         /// <summary>
@@ -67,8 +69,11 @@ namespace NAudio.FileFormats.Mp3
             outputBuffer.MediaBuffer.SetLength(0);
             outputBuffer.StatusFlags = DmoOutputDataBufferFlags.None;
 
-            // 3. Now ask the DMO for some output data
-            mp3Decoder.MediaObject.ProcessOutput(DmoProcessOutputFlags.None, 1, new[] { outputBuffer });
+            // 3. Now ask the DMO for some output data.
+            // DmoOutputDataBuffer is a struct; refresh the cached single-element
+            // array slot so ProcessOutput sees the freshly reset flags.
+            outputBufferArray[0] = outputBuffer;
+            mp3Decoder.MediaObject.ProcessOutput(DmoProcessOutputFlags.None, 1, outputBufferArray);
 
             if (outputBuffer.Length == 0)
             {

--- a/NAudio.Wasapi/ResamplerDmoStream.cs
+++ b/NAudio.Wasapi/ResamplerDmoStream.cs
@@ -15,6 +15,7 @@ namespace NAudio.Wave
         private readonly WaveStream inputStream;
         private readonly WaveFormat outputFormat;
         private DmoOutputDataBuffer outputBuffer;
+        private DmoOutputDataBuffer[] outputBufferArray;
         private DmoResampler dmoResampler;
         private MediaBuffer inputMediaBuffer;
         private byte[] inputBuffer;
@@ -49,6 +50,7 @@ namespace NAudio.Wave
             }
             inputMediaBuffer = new MediaBuffer(inputProvider.WaveFormat.AverageBytesPerSecond);
             outputBuffer = new DmoOutputDataBuffer(outputFormat.AverageBytesPerSecond);
+            outputBufferArray = new[] { outputBuffer };
         }
 
         /// <summary>
@@ -153,7 +155,10 @@ namespace NAudio.Wave
                     outputBuffer.MediaBuffer.SetLength(0);
                     outputBuffer.StatusFlags = DmoOutputDataBufferFlags.None;
 
-                    dmoResampler.MediaObject.ProcessOutput(DmoProcessOutputFlags.None, 1, new[] { outputBuffer });
+                    // DmoOutputDataBuffer is a struct; copy current state into the cached
+                    // single-element array so ProcessOutput sees the freshly reset flags.
+                    outputBufferArray[0] = outputBuffer;
+                    dmoResampler.MediaObject.ProcessOutput(DmoProcessOutputFlags.None, 1, outputBufferArray);
 
                     if (outputBuffer.Length == 0)
                     {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `WasapiCapture` capture path is now zero-copy via the native WASAPI buffer span
  * `BiQuadFilter` state and coefficient fields hoisted to locals in batch loops for register retention
  * `Mp3FileReader` now builds its table-of-contents lazily on first seek instead of eagerly during construction; the `Position` setter no longer blocks; rapid scrub seeks debounce and silence output
+ * Eliminated per-`Read` allocations in `ResamplerDmoStream` (cached input buffer and output-buffer array) (#971)
 
 #### Reliability and bug fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,7 +56,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `WasapiCapture` capture path is now zero-copy via the native WASAPI buffer span
  * `BiQuadFilter` state and coefficient fields hoisted to locals in batch loops for register retention
  * `Mp3FileReader` now builds its table-of-contents lazily on first seek instead of eagerly during construction; the `Position` setter no longer blocks; rapid scrub seeks debounce and silence output
- * Eliminated per-`Read` allocations in `ResamplerDmoStream` (cached input buffer and output-buffer array) (#971)
+ * Eliminated per-`Read` allocations in `ResamplerDmoStream` and `DmoMp3FrameDecompressor` (cached input buffer and output-buffer array) (#971)
 
 #### Reliability and bug fixes
 


### PR DESCRIPTION
## Summary

Eliminates the per-iteration single-element `DmoOutputDataBuffer[]` allocation that was passed to `IMediaObject.ProcessOutput` in two DMO hot paths:

- `ResamplerDmoStream.Read` — the remaining half of the patch in #971 (the variable-sized input buffer was already addressed via `BufferHelpers.Ensure`)
- `DmoMp3FrameDecompressor.DecompressFrame` — same pattern, same fix

A `DmoOutputDataBuffer[]` field is cached and reused across calls. Because `DmoOutputDataBuffer` is a struct, the array slot is refreshed from the field (`outputBufferArray[0] = outputBuffer;`) immediately before each `ProcessOutput` call so the freshly-reset `StatusFlags = None` is what the DMO sees. A short comment notes the struct-copy rationale.

Closes #971.

## Test plan

- [x] CI build + tests pass on `windows-latest`
- [x] Manual sanity check: resample a file via `ResamplerDmoStream` and decode an MP3 via `DmoMp3FrameDecompressor` — output identical to pre-change

### A/B compare results (via `NAudioConsoleTest`, `pr-1283` vs `main`)

| Test | Input | Output | SHA-256 |
|---|---|---|---|
| `Dmo.ResampleFile` | `crash-trimmed.wav` (2s mono 44.1 kHz) → 22.05 kHz | 87,920 B | `530573ba7eb7ef1062997ad09e91d31aa0dcf48465f73ec5adb0dc7a33a2937d` |
| `Dmo.DecodeMp3` | 5:03 stereo MP3, 304 `ProcessOutput` calls | 58,233,838 B | `686427a3a5f84595ab9ee51cb232309e65cd7b89588c537d042681f7043ae83d` |

Both outputs byte-identical between `main` (`fdb1823`) and `pr-1283` (`ee60a54`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK9X5z2apSEZJr4xvJKZhW)_