### PR TITLE
Fix BlockAlignReductionStream.Position validating the wrong variable (#368)

### DIFF
--- a/NAudio.Core/Wave/WaveStreams/BlockAlignReductionStream.cs
+++ b/NAudio.Core/Wave/WaveStreams/BlockAlignReductionStream.cs
@@ -80,7 +80,7 @@ namespace NAudio.Wave
                 {
                     if (position != value)
                     {
-                        if (position % BlockAlign != 0)
+                        if (value % BlockAlign != 0)
                             throw new ArgumentException("Position must be block aligned");
                         long sourcePosition = value - (value % sourceStream.BlockAlign);
                         if (sourceStream.Position != sourcePosition)

--- a/NAudioTests/WaveStreams/BlockAlignmentReductionStreamTests.cs
+++ b/NAudioTests/WaveStreams/BlockAlignmentReductionStreamTests.cs
@@ -63,6 +63,46 @@ namespace NAudioTests.WaveStreams
             CheckReadBuffer(inputBuffer, 1024, 1000);
         }
 
+        [Test]
+        public void CanRepositionAfterNonBlockAlignedRead()
+        {
+            // Reproduces #368: an arbitrary-length read (the whole point of
+            // this helper) leaves the internal position non-block-aligned.
+            // A subsequent valid, block-aligned reposition must not throw
+            // "Position must be block aligned" - the setter must validate
+            // the incoming value, not the stale current position.
+            BlockAlignedWaveStream inputStream = new BlockAlignedWaveStream(726, 80000);
+            BlockAlignReductionStream blockStream = new BlockAlignReductionStream(inputStream);
+
+            byte[] inputBuffer = new byte[1023]; // odd -> position becomes non-block-aligned
+            int read = blockStream.Read(inputBuffer, 0, 1023);
+            Assert.That(read, Is.EqualTo(1023), "bytes read 1");
+            Assert.That(blockStream.Position, Is.EqualTo(1023), "position 1");
+            CheckReadBuffer(inputBuffer, 1023, 0);
+
+            // 2048 is a multiple of BlockAlign (2) so this must succeed even
+            // though the current position (1023) is not block aligned.
+            Assert.DoesNotThrow(() => blockStream.Position = 2048);
+            Assert.That(blockStream.Position, Is.EqualTo(2048), "position 2");
+
+            byte[] readBuffer = new byte[1024];
+            read = blockStream.Read(readBuffer, 0, 1024);
+            Assert.That(read, Is.EqualTo(1024), "bytes read 2");
+            Assert.That(blockStream.Position, Is.EqualTo(3072), "position 3");
+            CheckReadBuffer(readBuffer, 1024, 2048);
+        }
+
+        [Test]
+        public void RepositionToNonBlockAlignedPositionThrows()
+        {
+            // The setter must reject a non-block-aligned target value.
+            // BlockAlign is 2 (16-bit mono) so an odd position is invalid.
+            BlockAlignedWaveStream inputStream = new BlockAlignedWaveStream(726, 80000);
+            BlockAlignReductionStream blockStream = new BlockAlignReductionStream(inputStream);
+
+            Assert.Throws<ArgumentException>(() => blockStream.Position = 1001);
+        }
+
         private void CheckReadBuffer(byte[] readBuffer, int count, int startPosition)
         {
             for (int n = 0; n < count; n++)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -69,6 +69,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * MP3 frame parsing: more robust against false frame detections from album art and trailing metadata
  * `MidiFile`: preserved running-status across meta events (fixes "Read too far" errors when meta events interrupt running-status sequences)
  * `WaveStream.CurrentTime` setter: now lands on a block boundary, preventing garbage audio on seek in custom readers
+ * `BlockAlignReductionStream.Position` setter: now validates the incoming value instead of the stale current position, so a block-aligned seek after an arbitrary-length read no longer wrongly throws "Position must be block aligned" (#368)
  * `IconExtractor.Extract`: now guards against null icon handles from `ExtractIconEx`
  * `DirectSoundOut.InitializeDirectSound`: wrapped notification setup in try/finally to prevent COM ref leak on `SetNotificationPositions` failure
  * ASIO: implemented missing `Asio64Bit` conversions (Int24LSB and Float32LSB output sample types)


### PR DESCRIPTION
## Summary

Fixes #368.

`BlockAlignReductionStream.Position`'s setter validated `position % BlockAlign` (the **stale current position**) instead of `value % BlockAlign` (the **requested target**). Since this helper exists precisely to allow arbitrary-length reads, the internal position is routinely left non-block-aligned — so a subsequent, perfectly valid block-aligned seek would wrongly throw `ArgumentException("Position must be block aligned")`.

This was the root cause. The second concern raised in #368 (a non-block-aligned read leaving the position "invalid") is a *symptom* of the same defect and is fully resolved by validating the incoming `value` — no separate guard is needed, since reading arbitrary lengths is the documented purpose of this class.

* One-line fix in `BlockAlignReductionStream.cs`: validate `value` instead of `position`. Genuinely unaligned target values are still rejected.
* Added two regression tests in `BlockAlignmentReductionStreamTests.cs`:
  * `CanRepositionAfterNonBlockAlignedRead` — the exact #368 repro: arbitrary-length read then a valid aligned seek must not throw, and data after the seek is correct.
  * `RepositionToNonBlockAlignedPositionThrows` — confirms the setter still rejects genuinely unaligned targets.
* Added a `RELEASE_NOTES.md` entry under "Reliability and bug fixes".

Note: the maintainer flagged this class as effectively semi-deprecated in the issue thread, but the fix is still worthwhile as it ships in the public API.

## Test plan

- [x] Both new regression tests verified to **fail** with the fix reverted and **pass** with it applied
- [x] Full headless suite green on the cross-platform `net10.0` TFM: 940 tests, 937 passed, 3 skipped, 0 failed
- [ ] CI build + test on `windows-latest` (full suite incl. Windows-only TFM)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQpp7SnXNtVND8kZg916YZ)_