### PR TITLE
Fix WaveFileChunkReader crash on odd-length chunks with non-UTF-8 bytes (#959)

### DIFF
--- a/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
+++ b/NAudio.Core/FileFormats/Wav/WaveFileChunkReader.cs
@@ -108,9 +108,16 @@ namespace NAudio.FileFormats.Wav
                 // "If the chunk size is an odd number of bytes, a pad byte with value zero is
                 //  written after ckData. Word aligning improves access speed (for chunks resident in memory)
                 //  and maintains compatibility with EA IFF. The ckSize value does not include the pad byte."
-                if (((chunkLength % 2) != 0) && (br.PeekChar() == 0))
+                if (((chunkLength % 2) != 0) && stream.Position < stream.Length)
                 {
-                    stream.Position++;
+                    // Read the pad byte directly. BinaryReader.PeekChar() decodes bytes as
+                    // UTF-8 and throws on non-text data (see issue #959); ReadByte() does not.
+                    if (br.ReadByte() != 0)
+                    {
+                        // Not a pad byte: this file isn't word-aligned. Put the byte back so
+                        // it's read as the start of the next chunk.
+                        stream.Position--;
+                    }
                 }
             }
 

--- a/NAudioTests/WaveStreams/WaveFileChunkReaderPeekCharTests.cs
+++ b/NAudioTests/WaveStreams/WaveFileChunkReaderPeekCharTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using System.Text;
+using NAudio.Wave;
+using NAudioTests.Utils;
+using NUnit.Framework;
+
+namespace NAudioTests.WaveStreams
+{
+    /// <summary>
+    /// Regression coverage for issue #959: the word-alignment pad-byte check used
+    /// <c>BinaryReader.PeekChar()</c>, which decodes bytes as UTF-8 and threw
+    /// <see cref="ArgumentException"/> on non-text data after an odd-length chunk.
+    /// Also covers the end-of-stream gap that the originally proposed fix in PR #828
+    /// would have introduced (<c>BinaryReader.ReadByte()</c> throws at EOF).
+    /// </summary>
+    [TestFixture]
+    [Category("UnitTest")]
+    public class WaveFileChunkReaderPeekCharTests
+    {
+        private static WaveFormat DefaultFormat => new WaveFormat(8000, 16, 1);
+
+        [Test]
+        public void OddLengthChunkFollowedByNonUtf8ByteDoesNotThrow()
+        {
+            // An odd-length, non-word-aligned chunk whose following bytes begin a UTF-8
+            // supplementary character (U+1F600, "F0 9F 98 80"). PeekChar() decodes this to
+            // a surrogate pair and throws "The output char buffer is too small..." — the
+            // exact failure reported in issue #959. The byte-wise read must not.
+            var bytes = BuildMalformedWav(
+                audioData: new byte[] { 0, 0, 10, 0, 20, 0, 30, 0 },
+                oddChunkId: "Tst1",
+                oddChunkData: new byte[] { 1, 2, 3 },
+                writePadByte: false,
+                trailingChunkId: new byte[] { 0xF0, 0x9F, 0x98, 0x80 });
+
+            WaveFileReader reader = null;
+            Assert.That(() => reader = new WaveFileReader(new MemoryStream(bytes)), Throws.Nothing);
+            using (reader)
+            {
+                Assert.That(reader.WaveFormat.SampleRate, Is.EqualTo(8000));
+                Assert.That(reader.Length, Is.EqualTo(8));
+            }
+        }
+
+        [Test]
+        public void OddLengthFinalChunkAtEndOfStreamDoesNotThrow()
+        {
+            // The data chunk is odd-length with no trailing pad byte and ends exactly at
+            // end of stream. PeekChar() returned -1 here; a naive ReadByte() (PR #828)
+            // would throw EndOfStreamException. The EOF guard must keep this working.
+            var bytes = BuildMalformedWav(
+                audioData: new byte[] { 11, 22, 33 },
+                oddChunkId: null,
+                oddChunkData: null,
+                writePadByte: false,
+                trailingChunkId: null);
+
+            WaveFileReader reader = null;
+            Assert.That(() => reader = new WaveFileReader(new MemoryStream(bytes)), Throws.Nothing);
+            using (reader)
+            {
+                Assert.That(reader.Length, Is.EqualTo(3));
+            }
+        }
+
+        [Test]
+        public void WellFormedOddLengthChunkStillSkipsPadByte()
+        {
+            // Behaviour preservation: a word-aligned odd-length chunk (proper 0 pad byte)
+            // must still have its pad byte consumed so the following chunk parses cleanly.
+            var bytes = WaveFileBuilder.Build(
+                DefaultFormat,
+                new byte[] { 0, 0, 10, 0 },
+                new WaveFileBuilder.Chunk("odd ", new byte[] { 1, 2, 3 }, beforeData: true),
+                new WaveFileBuilder.Chunk("aftr", new byte[] { 9, 9, 9, 9 }));
+
+            using var reader = new WaveFileReader(new MemoryStream(bytes));
+            Assert.That(reader.Chunks.Contains("odd "), Is.True);
+            Assert.That(reader.Chunks.Contains("aftr"), Is.True);
+            Assert.That(reader.Chunks.GetData(reader.Chunks.Find("odd ")), Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(reader.Chunks.GetData(reader.Chunks.Find("aftr")), Is.EqualTo(new byte[] { 9, 9, 9, 9 }));
+        }
+
+        /// <summary>
+        /// Hand-rolls a RIFF/WAVE stream that NAudio's own writer won't produce: an
+        /// optionally non-word-aligned odd-length chunk followed by arbitrary bytes.
+        /// </summary>
+        private static byte[] BuildMalformedWav(
+            byte[] audioData,
+            string oddChunkId,
+            byte[] oddChunkData,
+            bool writePadByte,
+            byte[] trailingChunkId)
+        {
+            using var ms = new MemoryStream();
+            using (var w = new BinaryWriter(ms, Encoding.ASCII, leaveOpen: true))
+            {
+                w.Write(Encoding.ASCII.GetBytes("RIFF"));
+                w.Write(0); // RIFF size placeholder
+                w.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+                w.Write(Encoding.ASCII.GetBytes("fmt "));
+                DefaultFormat.Serialize(w);
+
+                w.Write(Encoding.ASCII.GetBytes("data"));
+                w.Write(audioData.Length);
+                w.Write(audioData);
+                if ((audioData.Length & 1) == 1 && writePadByte) w.Write((byte)0);
+
+                if (oddChunkId != null)
+                {
+                    w.Write(Encoding.ASCII.GetBytes(oddChunkId));
+                    w.Write(oddChunkData.Length);
+                    w.Write(oddChunkData);
+                    if ((oddChunkData.Length & 1) == 1 && writePadByte) w.Write((byte)0);
+                }
+
+                if (trailingChunkId != null)
+                {
+                    w.Write(trailingChunkId); // 4-byte chunk id
+                    w.Write(0);               // zero-length chunk
+                }
+
+                long fileLength = ms.Length;
+                ms.Position = 4;
+                w.Write((uint)(fileLength - 8));
+            }
+
+            return ms.ToArray();
+        }
+    }
+}

--- a/NAudioTests/WaveStreams/WaveFileChunkReaderTests.cs
+++ b/NAudioTests/WaveStreams/WaveFileChunkReaderTests.cs
@@ -8,15 +8,12 @@ using NUnit.Framework;
 namespace NAudioTests.WaveStreams
 {
     /// <summary>
-    /// Regression coverage for issue #959: the word-alignment pad-byte check used
-    /// <c>BinaryReader.PeekChar()</c>, which decodes bytes as UTF-8 and threw
-    /// <see cref="ArgumentException"/> on non-text data after an odd-length chunk.
-    /// Also covers the end-of-stream gap that the originally proposed fix in PR #828
-    /// would have introduced (<c>BinaryReader.ReadByte()</c> throws at EOF).
+    /// Tests for <see cref="NAudio.FileFormats.Wav.WaveFileChunkReader"/>, exercised
+    /// through <see cref="WaveFileReader"/> against hand-built RIFF streams.
     /// </summary>
     [TestFixture]
     [Category("UnitTest")]
-    public class WaveFileChunkReaderPeekCharTests
+    public class WaveFileChunkReaderTests
     {
         private static WaveFormat DefaultFormat => new WaveFormat(8000, 16, 1);
 

--- a/NAudioTests/WaveStreams/WaveFileChunkReaderTests.cs
+++ b/NAudioTests/WaveStreams/WaveFileChunkReaderTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
+using NAudio.FileFormats.Wav;
 using NAudio.Wave;
 using NAudioTests.Utils;
 using NUnit.Framework;
@@ -125,6 +127,216 @@ namespace NAudioTests.WaveStreams
             }
 
             return ms.ToArray();
+        }
+
+        // --- Header / structural validation ---------------------------------
+
+        [Test]
+        public void NotARiffOrRf64FileThrowsFormatException()
+        {
+            var bytes = Riff("JUNK", w => { Fourcc(w, "WAVE"); WriteFmt(w); WriteChunk(w, "data", new byte[] { 0, 0 }); });
+            Assert.That(() => Read(bytes), Throws.TypeOf<FormatException>().With.Message.Contain("RIFF"));
+        }
+
+        [Test]
+        public void RiffWithoutWaveHeaderThrowsFormatException()
+        {
+            var bytes = Riff("RIFF", w => { Fourcc(w, "XXXX"); WriteFmt(w); WriteChunk(w, "data", new byte[] { 0, 0 }); });
+            Assert.That(() => Read(bytes), Throws.TypeOf<FormatException>().With.Message.Contain("WAVE"));
+        }
+
+        [Test]
+        public void MissingFmtChunkThrowsFormatException()
+        {
+            var bytes = Riff("RIFF", w => { Fourcc(w, "WAVE"); WriteChunk(w, "data", new byte[] { 0, 0, 0, 0 }); });
+            Assert.That(() => Read(bytes), Throws.TypeOf<FormatException>().With.Message.Contain("fmt"));
+        }
+
+        [Test]
+        public void MissingDataChunkThrowsFormatException()
+        {
+            var bytes = Riff("RIFF", w => { Fourcc(w, "WAVE"); WriteFmt(w); });
+            Assert.That(() => Read(bytes), Throws.TypeOf<FormatException>().With.Message.Contain("data"));
+        }
+
+        [Test]
+        public void FmtChunkLengthExceedingInt32ThrowsInvalidDataException()
+        {
+            var bytes = Riff("RIFF", w =>
+            {
+                Fourcc(w, "WAVE");
+                Fourcc(w, "fmt ");
+                w.Write(0xFFFFFFFFu); // declared fmt length > Int32.MaxValue
+                Fourcc(w, "data");
+                w.Write(0u);
+            });
+            Assert.That(() => Read(bytes), Throws.TypeOf<InvalidDataException>());
+        }
+
+        // --- RF64 ----------------------------------------------------------
+
+        [Test]
+        public void Rf64WithoutDs64ChunkThrowsFormatException()
+        {
+            var bytes = Riff("RF64", w => { Fourcc(w, "WAVE"); WriteChunk(w, "junk", new byte[] { 0, 0, 0, 0 }); },
+                riffSizeOverride: 0xFFFFFFFF);
+            Assert.That(() => Read(bytes), Throws.TypeOf<FormatException>().With.Message.Contain("ds64"));
+        }
+
+        [Test]
+        public void Rf64TakesDataChunkLengthFromDs64NotDataHeader()
+        {
+            // The data chunk's own size field is the RF64 0xFFFFFFFF sentinel; the real
+            // length must come from the ds64 chunk (exercises the `if (!isRf64)` branch).
+            var audio = new byte[] { 1, 2, 3, 4, 5, 6 };
+            var bytes = Riff("RF64", w =>
+            {
+                Fourcc(w, "WAVE");
+                Fourcc(w, "ds64");
+                w.Write(28);                 // ds64 chunk size
+                w.Write(1_000_000L);         // riffSize (clamped against stream length)
+                w.Write((long)audio.Length); // dataChunkLength
+                w.Write(3L);                 // sampleCount
+                w.Write(0);                  // table length (chunkSize - 24 == 4 bytes)
+                WriteFmt(w);
+                Fourcc(w, "data");
+                w.Write(0xFFFFFFFFu);        // RF64 sentinel in the data header
+                w.Write(audio);
+            }, riffSizeOverride: 0xFFFFFFFF);
+
+            var r = Read(bytes);
+            Assert.That(r.DataChunkLength, Is.EqualTo(audio.Length));
+            Assert.That(r.WaveFormat, Is.Not.Null);
+        }
+
+        // --- Corrupt / oversized trailing chunk ----------------------------
+
+        [Test]
+        public void OversizedTrailingChunkIsToleratedWhenFmtAndDataAlreadyFound()
+        {
+            var bytes = Riff("RIFF", w =>
+            {
+                Fourcc(w, "WAVE");
+                WriteFmt(w);
+                WriteChunk(w, "data", new byte[] { 1, 2, 3, 4 });
+                Fourcc(w, "junk");
+                w.Write(0x7FFFFFFEu);          // declared length far beyond what remains
+                w.Write(new byte[] { 9, 9 });
+            });
+
+            var r = Read(bytes);
+            Assert.That(r.WaveFormat, Is.Not.Null);
+            Assert.That(r.DataChunkLength, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void OversizedChunkBeforeFmtAndDataStillThrows()
+        {
+            var bytes = Riff("RIFF", w =>
+            {
+                Fourcc(w, "WAVE");
+                Fourcc(w, "junk");
+                w.Write(0x7FFFFFFEu);          // breaks the loop before fmt/data are seen
+                w.Write(new byte[] { 0, 0 });
+            });
+            Assert.That(() => Read(bytes), Throws.TypeOf<FormatException>());
+        }
+
+        // --- riffSize boundary handling ------------------------------------
+
+        [Test]
+        public void ExtraBytesBeyondRiffSizeAreIgnored()
+        {
+            using var ms = new MemoryStream();
+            using (var w = new BinaryWriter(ms, Encoding.ASCII, leaveOpen: true))
+            {
+                Fourcc(w, "RIFF");
+                w.Write(0u);
+                Fourcc(w, "WAVE");
+                WriteFmt(w);
+                WriteChunk(w, "data", new byte[] { 1, 2, 3, 4 });
+                long covered = ms.Length;                       // RIFF region ends here
+                WriteChunk(w, "extr", new byte[] { 7, 7, 7, 7 }); // physically present, but beyond riffSize
+                ms.Position = 4;
+                w.Write((uint)(covered - 8));
+            }
+
+            var r = Read(ms.ToArray());
+            Assert.That(r.WaveFormat, Is.Not.Null);
+            Assert.That(r.RiffChunks.Any(c => c.IdentifierAsString == "extr"), Is.False);
+        }
+
+        [Test]
+        public void RiffSizeLargerThanStreamDoesNotReadPastEnd()
+        {
+            var bytes = Riff("RIFF", w =>
+            {
+                Fourcc(w, "WAVE");
+                WriteFmt(w);
+                WriteChunk(w, "data", new byte[] { 1, 2, 3, 4 });
+            }, riffSizeOverride: 0xFFFFFF00u);
+
+            var r = Read(bytes);
+            Assert.That(r.WaveFormat, Is.Not.Null);
+            Assert.That(r.DataChunkLength, Is.EqualTo(4));
+        }
+
+        // --- Chunk ordering ------------------------------------------------
+
+        [Test]
+        public void FmtChunkAfterDataChunkStillParses()
+        {
+            var bytes = Riff("RIFF", w =>
+            {
+                Fourcc(w, "WAVE");
+                WriteChunk(w, "data", new byte[] { 1, 2, 3, 4 });
+                WriteFmt(w);
+            });
+
+            var r = Read(bytes);
+            Assert.That(r.WaveFormat, Is.Not.Null);
+            Assert.That(r.WaveFormat.SampleRate, Is.EqualTo(8000));
+            Assert.That(r.DataChunkLength, Is.EqualTo(4));
+            Assert.That(r.DataChunkPosition, Is.GreaterThan(0));
+        }
+
+        // --- Builders ------------------------------------------------------
+
+        private static byte[] Riff(string headerFourCc, Action<BinaryWriter> body, uint? riffSizeOverride = null)
+        {
+            using var ms = new MemoryStream();
+            using (var w = new BinaryWriter(ms, Encoding.ASCII, leaveOpen: true))
+            {
+                Fourcc(w, headerFourCc);
+                w.Write(0u); // riff size placeholder at offset 4
+                body(w);
+                long len = ms.Length;
+                ms.Position = 4;
+                w.Write(riffSizeOverride ?? (uint)(len - 8));
+            }
+            return ms.ToArray();
+        }
+
+        private static void Fourcc(BinaryWriter w, string id) => w.Write(Encoding.ASCII.GetBytes(id));
+
+        private static void WriteChunk(BinaryWriter w, string id, byte[] data)
+        {
+            Fourcc(w, id);
+            w.Write(data.Length);
+            w.Write(data);
+        }
+
+        private static void WriteFmt(BinaryWriter w)
+        {
+            Fourcc(w, "fmt ");
+            DefaultFormat.Serialize(w);
+        }
+
+        private static WaveFileChunkReader Read(byte[] bytes)
+        {
+            var reader = new WaveFileChunkReader();
+            reader.ReadWaveHeader(new MemoryStream(bytes));
+            return reader;
         }
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -76,6 +76,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `WdlResampler`: backported three upstream Cockos WDL bug fixes (latency calculation, `ResampleOut` clamping, Blackman-Harris window correction)
  * `MediaBufferLease`: hardened against out-of-order disposal
  * Added finalizers to DMO `MediaBuffer` and the `Mf*` wrappers that hold (RCW, IntPtr) pairs to prevent COM ref leaks
+ * `WaveFileChunkReader`: fixed `ArgumentException` parsing WAV files whose odd-length chunks are followed by non-UTF-8 bytes — the word-alignment pad-byte check no longer decodes via `BinaryReader.PeekChar()`, and is now guarded against end-of-stream (#959)
  * Clarified `BiQuadFilter` `q` parameter docs (#1264)
  * Removed dead `naudio.codeplex.com` links from README, MixDiff Help menu, and source comments (CodePlex was shut down by Microsoft in 2017) (#985)
 


### PR DESCRIPTION
## Summary

Fixes #959. The word-alignment pad-byte check in `WaveFileChunkReader` used `BinaryReader.PeekChar()`, which decodes bytes as UTF-8 and throws `ArgumentException` ("The output char buffer is too small...") when an odd-length chunk is followed by non-text data.

- Replaced `PeekChar()` with a direct `ReadByte()` + `Position--` rewind (same approach as the stalled #828), **plus** a `stream.Position < stream.Length` end-of-stream guard — the gap that the original #828 proposal would have introduced (`BinaryReader.ReadByte()` throws `EndOfStreamException` at EOF rather than returning -1 like `PeekChar()` did).
- Behaviour is unchanged for well-formed, word-aligned files.

While here, `WaveFileChunkReader` had no dedicated test file (only indirect coverage via `WaveFileReader`). Added `WaveFileChunkReaderTests` covering the previously-untested paths:

- The #959 crash, the EOF edge case, and well-formed pad-byte preservation
- RIFF/WAVE header validation, missing `fmt `/`data` chunks
- RF64: missing `ds64`, and data length sourced from `ds64` (not the `0xFFFFFFFF` data header)
- Oversized `fmt ` chunk, oversized trailing chunk (tolerated vs. fatal)
- `riffSize` boundary clamping (extra bytes ignored; oversized riffSize doesn't read past end)
- Chunk-order independence (`fmt ` after `data`)

### Note for maintainer (not addressed here)

Two unreachable code paths surfaced while writing coverage — left as-is, flagging for a separate decision:
- The `strictMode` `Debug.Assert` branch is dead (the only constructor hardcodes `strictMode = false`).
- The `storeAllChunks` `chunkLength > Int32.MaxValue` → `InvalidDataException` is unreachable: the preceding `chunkLength > stream.Length - stream.Position` check always breaks first unless the stream itself is >2 GB.

## Test plan

- [x] New `WaveFileChunkReaderTests` (15 tests) pass on `net10.0`
- [x] #959 regression test verified to fail against the old `PeekChar()` code with the exact `ArgumentException`
- [x] Full cross-platform suite green: 957 total, 950 passed, 0 failed, 7 environment-skips
- [ ] CI build + test on `windows-latest`

https://claude.ai/code/session_01NCm7T7Kyu3QKQ7mwi9ohfj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCm7T7Kyu3QKQ7mwi9ohfj)_