### PR TITLE
Make AudioClient.Dispose idempotent and concurrency-safe (#1183)

### DIFF
--- a/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
@@ -4,6 +4,7 @@ using NAudio.Wave;
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NAudio.CoreAudioApi
@@ -28,6 +29,7 @@ namespace NAudio.CoreAudioApi
         private AudioClockClient audioClockClient;
         private AudioStreamVolume audioStreamVolume;
         private AudioClientShareMode shareMode;
+        private int disposed;
 
         /// <summary>
         /// Activate Async
@@ -434,6 +436,14 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public void Dispose()
         {
+            // Idempotent and safe against concurrent/re-entrant disposal: WASAPI capture
+            // and playback wrappers can race a teardown thread against their worker
+            // thread's stop path, and a second COM release here previously surfaced as a
+            // NullReferenceException out of the interop layer (issue #1183).
+            if (Interlocked.Exchange(ref disposed, 1) != 0)
+            {
+                return;
+            }
             if (audioClientInterface != null)
             {
                 if (audioClockClient != null)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,6 +80,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `WaveFileChunkReader`: fixed `ArgumentException` parsing WAV files whose odd-length chunks are followed by non-UTF-8 bytes — the word-alignment pad-byte check no longer decodes via `BinaryReader.PeekChar()`, and is now guarded against end-of-stream (#959)
  * Clarified `BiQuadFilter` `q` parameter docs (#1264)
  * Removed dead `naudio.codeplex.com` links from README, MixDiff Help menu, and source comments (CodePlex was shut down by Microsoft in 2017) (#985)
+ * `AudioClient.Dispose`: made idempotent and safe against concurrent/re-entrant disposal — fixes an intermittent `NullReferenceException` from the COM interop layer when a WASAPI capture or playback wrapper is disposed more than once (#1183)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

Fixes the intermittent `NullReferenceException` reported in #1183, thrown out of the COM interop layer when disposing a WASAPI capture/playback wrapper.

**Cause:** `AudioClient.Dispose()` used a check-then-act (`if (audioClientInterface != null)`) null guard that is neither idempotent nor thread-safe. WASAPI wrappers race a teardown thread against their worker thread's stop path (e.g. a mixer disposing a loopback source from more than one path, or from inside `RecordingStopped`), so two callers could both pass the guard and double-release the COM client. On NAudio 2 this surfaced as `NullReferenceException` from `Marshal.ReleaseComObject`; on `main` the source-generated COM rewrite removed that exact API, but the underlying check-then-act race was still latent.

**Fix:** Guard the body with an `Interlocked.Exchange(ref disposed, 1)` claim so it runs exactly once under re-entrant or concurrent calls. `AudioClient.Dispose()` is the single point every WASAPI wrapper delegates teardown to, so this one change covers:

- capture — `WasapiCapture` / `WasapiLoopbackCapture` (obsolete) and `WasapiRecorder`
- playback — `WasapiOut` and `WasapiPlayer`

No per-class locking is needed. This makes Dispose-vs-Dispose safe; the worker-thread-vs-Dispose ordering is already handled by the existing `StopRecording()`/`Stop()` + thread `Join()` in the wrappers.

## Changes

- `NAudio.Wasapi/CoreAudioApi/AudioClient.cs` — added `using System.Threading;`, a `private int disposed;` field, and the `Interlocked` guard at the top of `Dispose()`. Existing body unchanged.
- `RELEASE_NOTES.md` — bullet under "Reliability and bug fixes".

## Test plan

- [ ] CI build + test on `windows-latest` (cannot build locally — `NAudio.Wasapi` targets `net9.0-windows` and this environment is Linux with no `dotnet` SDK)
- [ ] Verify no regression in existing WASAPI capture/playback tests

https://claude.ai/code/session_01FrbQnig93vrdbgMaJdsjpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrbQnig93vrdbgMaJdsjpj)_