### PR TITLE
Add NuGet package descriptions; ship ALSA as NAudio.Linux.Alsa temporarily

### DIFF
--- a/Docs/PlayAudioFileLinuxAlsa.md
+++ b/Docs/PlayAudioFileLinuxAlsa.md
@@ -6,8 +6,14 @@ explicitly (it is not part of the `NAudio` meta-package, and the runtime
 needs `libasound` — `sudo apt install libasound2`):
 
 ```sh
-dotnet add package NAudio.Alsa
+dotnet add package NAudio.Linux.Alsa
 ```
+
+> The package id is currently `NAudio.Linux.Alsa` because the `NAudio.Alsa`
+> name on nuget.org is held by a third party. We intend (but cannot
+> guarantee) to move to `NAudio.Alsa` once that name is reclaimed. The
+> assembly name and namespaces are `NAudio.Alsa` either way, so your code
+> does not change.
 
 `AlsaOut` plays any `IWaveProvider`, so the format you can play depends
 on the **reader** you give it. `AudioFileReader`, `Mp3FileReader` and

--- a/Docs/RecordAudioFileLinuxAlsa.md
+++ b/Docs/RecordAudioFileLinuxAlsa.md
@@ -5,8 +5,14 @@ from an ALSA capture device. Add the package (the runtime needs
 `libasound` — `sudo apt install libasound2`):
 
 ```sh
-dotnet add package NAudio.Alsa
+dotnet add package NAudio.Linux.Alsa
 ```
+
+> The package id is currently `NAudio.Linux.Alsa` because the `NAudio.Alsa`
+> name on nuget.org is held by a third party. We intend (but cannot
+> guarantee) to move to `NAudio.Alsa` once that name is reclaimed. The
+> assembly name and namespaces are `NAudio.Alsa` either way, so your code
+> does not change.
 
 Recording follows the standard NAudio pattern: set the `WaveFormat`,
 subscribe to `DataAvailable` and write the captured bytes to a

--- a/NAudio.Alsa/NAudio.Alsa.csproj
+++ b/NAudio.Alsa/NAudio.Alsa.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>ALSA playback and capture for Linux via libasound for the NAudio audio library.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NAudio.Alsa/NAudio.Alsa.csproj
+++ b/NAudio.Alsa/NAudio.Alsa.csproj
@@ -6,6 +6,10 @@
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>ALSA playback and capture for Linux via libasound for the NAudio audio library.</Description>
+    <!-- Temporary package id: the "NAudio.Alsa" name on nuget.org is held by
+         a third party. Published as NAudio.Linux.Alsa until that name is
+         reclaimed. AssemblyName and namespaces stay NAudio.Alsa. -->
+    <PackageId>NAudio.Linux.Alsa</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NAudio.Alsa/README.md
+++ b/NAudio.Alsa/README.md
@@ -27,8 +27,14 @@ This package is **not** pulled in by the `NAudio` meta-package (there is
 no `net9.0-linux` TFM). Reference it explicitly:
 
 ```sh
-dotnet add package NAudio.Alsa
+dotnet add package NAudio.Linux.Alsa
 ```
+
+> **Package id note:** this ships as `NAudio.Linux.Alsa` because the
+> `NAudio.Alsa` name on nuget.org is held by a third party. We intend (but
+> cannot guarantee) to move to `NAudio.Alsa` once that name is reclaimed.
+> The assembly name and namespaces are `NAudio.Alsa` regardless, so your
+> code does not change.
 
 ## Supported input formats
 

--- a/NAudio.Asio/NAudio.Asio.csproj
+++ b/NAudio.Asio/NAudio.Asio.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>ASIO driver support for the NAudio audio library — low-latency multichannel playback and capture via ASIO SDK.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NAudio.Core/NAudio.Core.csproj
+++ b/NAudio.Core/NAudio.Core.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>Core audio types, wave format and provider interfaces, sample providers, file readers/writers, DSP, and resampling for the NAudio audio library.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NAudio.Dmo/NAudio.Dmo.csproj
+++ b/NAudio.Dmo/NAudio.Dmo.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>DirectX Media Objects (echo, chorus, reverb, MP3 decoder, resampler) and DirectSound output for the NAudio audio library.</Description>
   </PropertyGroup>
 
   <!-- needed for perfomance profiling unit tests -->

--- a/NAudio.Extras/NAudio.Extras.csproj
+++ b/NAudio.Extras/NAudio.Extras.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>Optional extras (extra demo/sample providers and helpers) for the NAudio audio library.</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">

--- a/NAudio.Midi/NAudio.Midi.csproj
+++ b/NAudio.Midi/NAudio.Midi.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>Cross-platform MIDI file reading and writing, MIDI message types, and SMPTE timing for the NAudio audio library.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NAudio.Wasapi/NAudio.Wasapi.csproj
+++ b/NAudio.Wasapi/NAudio.Wasapi.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>WASAPI playback and capture (including loopback and process loopback) and WinRT MIDI for the NAudio audio library.</Description>
   </PropertyGroup>
 
   <!-- needed for perfomance profiling unit tests -->

--- a/NAudio.WinForms/NAudio.WinForms.csproj
+++ b/NAudio.WinForms/NAudio.WinForms.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>Windows Forms audio controls and window-callback variants of WaveOut/WaveIn for the NAudio audio library.</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/NAudio.WinMM/NAudio.WinMM.csproj
+++ b/NAudio.WinMM/NAudio.WinMM.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>winmm.dll-based Windows audio APIs (WaveOut, WaveIn, MidiIn, MidiOut, ACM) for the NAudio audio library.</Description>
   </PropertyGroup>
 
 	<!-- needed for perfomance profiling unit tests -->

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Description>NAudio, an audio library for .NET</Description>
+    <Description>NAudio is an open source .NET audio library — playback and recording, file readers and writers, MIDI, DSP and effects, with platform-specific backends auto-selected by target framework.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -106,6 +106,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * Migrated to the modern `.slnx` solution format
  * Renamed `license.txt` to `LICENSE` for GitHub license detection; refreshed copyright year to 2008–2026
  * Added per-package `<Description>` metadata to every shipping NAudio NuGet package so each clearly identifies itself as part of the NAudio family
+ * ALSA backend ships as `NAudio.Linux.Alsa` on NuGet (temporary id while the `NAudio.Alsa` name is reclaimed); assembly name and namespaces are unchanged
 
 ### 2.3.0 (12 Mar 2026)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -105,6 +105,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `NAudio.Alsa.Tests` and `NAudio.SoundFile.Tests` now ignore MTP exit codes 8/9 so `dotnet test` succeeds on machines where the suite legitimately runs zero tests (ALSA off-Linux) or self-skips (libsndfile absent)
  * Migrated to the modern `.slnx` solution format
  * Renamed `license.txt` to `LICENSE` for GitHub license detection; refreshed copyright year to 2008–2026
+ * Added per-package `<Description>` metadata to every shipping NAudio NuGet package so each clearly identifies itself as part of the NAudio family
 
 ### 2.3.0 (12 Mar 2026)
 


### PR DESCRIPTION
## Summary

- Added a `<Description>` to every shipping NAudio package that was missing one (Core, Asio, WinForms, Midi, WinMM, Wasapi, Dmo, Alsa, Extras) and slightly expanded the `NAudio` meta-package description. This is groundwork for applying for the `NAudio.*` reserved NuGet prefix — every description references "NAudio" so the family is obvious in search results. (`NAudio.SoundFile` already had one.)
- The `NAudio.Alsa` id on nuget.org is held by a third party, so the ALSA backend now publishes under the temporary id `NAudio.Linux.Alsa` via `<PackageId>`. The assembly name, namespaces, and `InternalsVisibleTo` are unchanged, so consumer code is identical regardless of which package id they restore from.
- Updated the `dotnet add package` lines in the two Linux ALSA tutorials and the package README to `NAudio.Linux.Alsa`, with a note that the move back to `NAudio.Alsa` is intended but not guaranteed.
- Release notes updated for both the description metadata and the ALSA package id.

## Test plan

- [ ] CI build + test passes on `windows-latest`
- [ ] Confirm the generated `.nupkg` files carry the new descriptions
- [ ] Confirm the ALSA package builds/packs as `NAudio.Linux.Alsa` while the assembly remains `NAudio.Alsa.dll`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETfeEQtUr5fUaMQJnnY2gy)_