### PR TITLE
Revert ALSA package id to NAudio.Alsa

### DIFF
--- a/Docs/PlayAudioFileLinuxAlsa.md
+++ b/Docs/PlayAudioFileLinuxAlsa.md
@@ -6,14 +6,8 @@ explicitly (it is not part of the `NAudio` meta-package, and the runtime
 needs `libasound` — `sudo apt install libasound2`):
 
 ```sh
-dotnet add package NAudio.Linux.Alsa
+dotnet add package NAudio.Alsa
 ```
-
-> The package id is currently `NAudio.Linux.Alsa` because the `NAudio.Alsa`
-> name on nuget.org is held by a third party. We intend (but cannot
-> guarantee) to move to `NAudio.Alsa` once that name is reclaimed. The
-> assembly name and namespaces are `NAudio.Alsa` either way, so your code
-> does not change.
 
 `AlsaOut` plays any `IWaveProvider`, so the format you can play depends
 on the **reader** you give it. `AudioFileReader`, `Mp3FileReader` and

--- a/Docs/RecordAudioFileLinuxAlsa.md
+++ b/Docs/RecordAudioFileLinuxAlsa.md
@@ -5,14 +5,8 @@ from an ALSA capture device. Add the package (the runtime needs
 `libasound` — `sudo apt install libasound2`):
 
 ```sh
-dotnet add package NAudio.Linux.Alsa
+dotnet add package NAudio.Alsa
 ```
-
-> The package id is currently `NAudio.Linux.Alsa` because the `NAudio.Alsa`
-> name on nuget.org is held by a third party. We intend (but cannot
-> guarantee) to move to `NAudio.Alsa` once that name is reclaimed. The
-> assembly name and namespaces are `NAudio.Alsa` either way, so your code
-> does not change.
 
 Recording follows the standard NAudio pattern: set the `WaveFormat`,
 subscribe to `DataAvailable` and write the captured bytes to a

--- a/NAudio.Alsa/NAudio.Alsa.csproj
+++ b/NAudio.Alsa/NAudio.Alsa.csproj
@@ -6,10 +6,6 @@
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>ALSA playback and capture for Linux via libasound for the NAudio audio library.</Description>
-    <!-- Temporary package id: the "NAudio.Alsa" name on nuget.org is held by
-         a third party. Published as NAudio.Linux.Alsa until that name is
-         reclaimed. AssemblyName and namespaces stay NAudio.Alsa. -->
-    <PackageId>NAudio.Linux.Alsa</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NAudio.Alsa/README.md
+++ b/NAudio.Alsa/README.md
@@ -27,14 +27,8 @@ This package is **not** pulled in by the `NAudio` meta-package (there is
 no `net9.0-linux` TFM). Reference it explicitly:
 
 ```sh
-dotnet add package NAudio.Linux.Alsa
+dotnet add package NAudio.Alsa
 ```
-
-> **Package id note:** this ships as `NAudio.Linux.Alsa` because the
-> `NAudio.Alsa` name on nuget.org is held by a third party. We intend (but
-> cannot guarantee) to move to `NAudio.Alsa` once that name is reclaimed.
-> The assembly name and namespaces are `NAudio.Alsa` regardless, so your
-> code does not change.
 
 ## Supported input formats
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -106,7 +106,6 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * Migrated to the modern `.slnx` solution format
  * Renamed `license.txt` to `LICENSE` for GitHub license detection; refreshed copyright year to 2008–2026
  * Added per-package `<Description>` metadata to every shipping NAudio NuGet package so each clearly identifies itself as part of the NAudio family
- * ALSA backend ships as `NAudio.Linux.Alsa` on NuGet (temporary id while the `NAudio.Alsa` name is reclaimed); assembly name and namespaces are unchanged
 
 ### 2.3.0 (12 Mar 2026)
 


### PR DESCRIPTION
## Summary

The `NAudio.Alsa` name on nuget.org has been reclaimed, so the temporary `NAudio.Linux.Alsa` id introduced in #1297 is no longer needed. This removes it entirely:

- Removed the `<PackageId>NAudio.Linux.Alsa</PackageId>` override (and its comment) from `NAudio.Alsa.csproj` — the package packs as `NAudio.Alsa` again. Assembly name and namespaces were always `NAudio.Alsa`, so nothing else changes.
- Reverted the `dotnet add package` lines in the two Linux ALSA tutorials and `NAudio.Alsa/README.md` back to `NAudio.Alsa`, removing the temporary-id notes.
- Dropped the `NAudio.Linux.Alsa` line from the release notes (it never shipped under that id).

No `NAudio.Linux.Alsa` references remain anywhere in the repo.

## Test plan

- [ ] CI build + test passes on `windows-latest`
- [ ] Confirm the ALSA package packs as `NAudio.Alsa`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETfeEQtUr5fUaMQJnnY2gy)_