### PR TITLE
Fix Id3v2Tag.ReadTag using exceptions for control flow (#265)

### DIFF
--- a/NAudio.Core.Tests/Mp3/Id3v2TagTests.cs
+++ b/NAudio.Core.Tests/Mp3/Id3v2TagTests.cs
@@ -69,6 +69,16 @@ namespace NAudio.Core.Tests.Mp3
         }
 
         [Test]
+        public void ReadTagDoesNotThrowForNonId3Data()
+        {
+            var bytes = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xA0, 0xB0 };
+            using (var stream = new MemoryStream(bytes))
+            {
+                Assert.That(() => Id3v2Tag.ReadTag(stream), Throws.Nothing);
+            }
+        }
+
+        [Test]
         public void ReadTagParsesHeaderOnlyTag()
         {
             var data = BuildTag(new byte[0]);

--- a/NAudio.Core/FileFormats/Mp3/Id3v2Tag.cs
+++ b/NAudio.Core/FileFormats/Mp3/Id3v2Tag.cs
@@ -20,14 +20,17 @@ namespace NAudio.Wave
         /// </summary>
         public static Id3v2Tag ReadTag(Stream input)
         {
-            try
+            long tagStartPosition = input.Position;
+            var reader = new BinaryReader(input);
+            int dataLength;
+            int footerLength;
+            if (!TryReadTagHeader(reader, out dataLength, out footerLength))
             {
-                return new Id3v2Tag(input);
-            }
-            catch (FormatException)
-            {
+                input.Position = tagStartPosition;
                 return null;
             }
+
+            return new Id3v2Tag(input, reader, tagStartPosition, dataLength, footerLength);
         }
 
         #region Id3v2 Creation from key-value pairs
@@ -267,26 +270,14 @@ namespace NAudio.Wave
             }
         }
 
-        private Id3v2Tag(Stream input)
+        private Id3v2Tag(Stream input, BinaryReader reader, long startPosition, int dataLength, int footerLength)
         {
-            tagStartPosition = input.Position;
-            var reader = new BinaryReader(input);
-            int dataLength;
-            int footerLength;
-            if (TryReadTagHeader(reader, out dataLength, out footerLength))
-            {
-                SkipBytes(reader, dataLength);
-                SkipBytes(reader, footerLength);
-            }
-            else
-            {
-                input.Position = tagStartPosition;
-                throw new FormatException("Not an ID3v2 tag");
-            }
+            tagStartPosition = startPosition;
+            SkipBytes(reader, dataLength);
+            SkipBytes(reader, footerLength);
             tagEndPosition = input.Position;
             input.Position = tagStartPosition;
             rawData = reader.ReadBytes((int)(tagEndPosition - tagStartPosition));
-
         }
 
         /// <summary>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -88,6 +88,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `AudioClient.Dispose`: made idempotent and safe against concurrent/re-entrant disposal — fixes an intermittent `NullReferenceException` from the COM interop layer when a WASAPI capture or playback wrapper is disposed more than once (#1183)
  * `WaveFileReader` / `AiffFileReader`: malformed headers that declared `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` from the `Position` setter (#1254)
  * `AiffFileReader.Read`: truncated `SSND` chunks no longer trigger `IndexOutOfRangeException` in the byte-swap loop — the read count is rounded down to a whole block (#1254)
+ * `Id3v2Tag.ReadTag`: no longer throws and catches a `FormatException` for MP3 streams without an ID3v2 tag — the header check now returns `null` directly (#265)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

`Id3v2Tag.ReadTag` previously used a `throw new FormatException(...)` / `catch (FormatException)` pair purely as control flow for the common case of an MP3 stream with no ID3v2 tag. This refactor eliminates that pattern (#265).

- `ReadTag` now captures the start position, calls the existing non-throwing `TryReadTagHeader`, and returns `null` directly (restoring the stream position) when no tag is present — no exception thrown.
- The private constructor now accepts the already-parsed `reader`, `startPosition`, `dataLength`, and `footerLength`, leaving it to just skip the body/footer and capture `RawData`.
- Public contract is preserved exactly: `ReadTag` returns `null` for tag-less streams, still propagates `NotSupportedException` for non-seekable streams (read of `input.Position` happens up front, outside any catch), and restores stream position when no tag is found.

## Test plan

- [x] Added `ReadTagDoesNotThrowForNonId3Data` asserting `Throws.Nothing` for a tag-less stream.
- [x] `Id3v2TagTests`: 19/19 pass.
- [x] Full `NAudio.Core.Tests` suite (excluding integration tests): 970 passed, 3 skipped, 0 failed — no regressions.

https://claude.ai/code/session_01Ux6LvFqYd8Y4UVLvrg6KKH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ux6LvFqYd8Y4UVLvrg6KKH)_