### PR TITLE
Clarify UI thread marshalling in RecordingLevelMeter docs

### DIFF
--- a/Docs/RecordingLevelMeter.md
+++ b/Docs/RecordingLevelMeter.md
@@ -111,6 +111,6 @@ In both our examples, we calulated `max` as a floating point value between 0.0f 
 progressBar.Value = 100 * max;
 ```
 
-Note that you are updating the UI in the `OnDataAvailable` callback. NAudio will attempt to call this on the UI context if there is one. 
+Note that you are updating the UI in the `OnDataAvailable` callback. `WaveIn` marshals this event back onto the synchronization context that was active when `StartRecording` was called, so if you start recording from the UI thread you can update controls directly. Other capture classes such as `WasapiCapture` and `WasapiLoopbackCapture` raise `DataAvailable` on a background thread, so you'll need to marshal to the UI thread yourself (e.g. `Control.Invoke` in WinForms or `Dispatcher.Invoke` in WPF) before updating a control. 
 
 Also, this approach means that the frequency of meter updates will match the size of recording buffers. This is the simplest approach, and normally works just fine as there will usually be at least 10 buffers per second which is usually adequate for a volume meter.


### PR DESCRIPTION
## Summary

Addresses [#447](https://github.com/naudio/NAudio/issues/447). The "Updating the Volume Meter" section previously said NAudio "will attempt to call this on the UI context if there is one", which is accurate for `WaveIn` but misleading for the WASAPI capture classes the same doc presents as alternatives.

- Clarified that `WaveIn` marshals `DataAvailable` back onto the synchronization context captured at `StartRecording` time, so UI controls can be updated directly when recording is started from the UI thread.
- Noted that `WasapiCapture`/`WasapiLoopbackCapture` raise `DataAvailable` on a background thread, so callers must marshal to the UI thread themselves (`Control.Invoke` in WinForms, `Dispatcher.Invoke` in WPF) before touching a control.

## Test plan

- [ ] Docs-only change — review rendered markdown for `Docs/RecordingLevelMeter.md`.

https://claude.ai/code/session_01HQu3kuRkmBHeM9sv3Ui2mG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQu3kuRkmBHeM9sv3Ui2mG)_