### PR TITLE
Append MmResult error text to MmException message (#1192)

### DIFF
--- a/NAudio.WinMM/MmException.cs
+++ b/NAudio.WinMM/MmException.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text;
+using NAudio.Wave;
 
 namespace NAudio
 {
@@ -20,9 +22,26 @@ namespace NAudio
         }
 
 
+        // MAXERRORLENGTH from mmsystem.h
+        private const int ErrorTextMaxLength = 256;
+
+        private static string GetErrorText(MmResult result)
+        {
+            var buffer = new StringBuilder(ErrorTextMaxLength);
+            if (WaveInterop.waveOutGetErrorText(result, buffer, (uint)buffer.Capacity) == MmResult.NoError)
+            {
+                return buffer.ToString();
+            }
+
+            return string.Empty;
+        }
+
         private static string ErrorMessage(MmResult result, string function)
         {
-            return $"{result} calling {function}";
+            var errorText = GetErrorText(result);
+            return errorText.Length > 0
+                ? $"{result} calling {function}: {errorText}"
+                : $"{result} calling {function}";
         }
 
         /// <summary>

--- a/NAudio.WinMM/MmeInterop/WaveInterop.cs
+++ b/NAudio.WinMM/MmeInterop/WaveInterop.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace NAudio.Wave
 {
@@ -180,6 +181,14 @@ namespace NAudio.Wave
         /// </summary>
         [DllImport("winmm.dll", CharSet = CharSet.Auto)]
         public static extern MmResult waveOutGetDevCaps(IntPtr deviceID, out WaveOutCapabilities waveOutCaps, int waveOutCapsSize);
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/mmeapi/nf-mmeapi-waveoutgeterrortext
+        /// <summary>
+        /// Retrieves a textual description of an MME error. The MMSYSERR error codes are
+        /// shared across the MME APIs, so this also resolves waveIn and (standard) midi errors.
+        /// </summary>
+        [DllImport("winmm.dll", CharSet = CharSet.Auto)]
+        public static extern MmResult waveOutGetErrorText(MmResult mmrError, StringBuilder pszText, uint cchText);
 
         /// <summary>
         /// Get number of WaveIn devices

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -89,6 +89,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `WaveFileReader` / `AiffFileReader`: malformed headers that declared `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` from the `Position` setter (#1254)
  * `AiffFileReader.Read`: truncated `SSND` chunks no longer trigger `IndexOutOfRangeException` in the byte-swap loop — the read count is rounded down to a whole block (#1254)
  * `AudioEndpointVolume.OnVolumeNotification`: fixed per-channel volume notification returning channel 0's volume for every channel — the read pointer was not advanced per channel (#351)
+ * `MmException`: error messages now append a human-readable description of the `MmResult` via `waveOutGetErrorText`, e.g. `NoDriver calling waveOutSetVolume: No device driver is present` (#1192)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

`MmException` messages currently produce only `{result} calling {function}` (e.g. `NoDriver calling waveOutSetVolume`), which is vague for non-experienced users. This appends a human-readable description via winmm.dll's `waveOutGetErrorText`, so the message becomes e.g. `NoDriver calling waveOutSetVolume: No device driver is present`.

This ports the approach from #1192 (which targeted `release/2.x` and the old `NAudio.Core/MmException.cs` location) to `main`, where `MmException` now lives in `NAudio.WinMM` — an assembly that targets `net9.0-windows` and already P/Invokes winmm.dll, so the `DllImport` is a natural fit. Supersedes the now-closed #1113.

`waveOutGetErrorText` is used as a general lookup: the `MMSYSERR_*` codes are shared across the MME APIs, so it resolves waveIn/midi errors too.

## Changes vs. the original #1192

- Declared the `waveOutGetErrorText` P/Invoke in `WaveInterop.cs` alongside the other `waveOut*` interop, rather than inlining it in the exception type — matches the codebase's interop convention.
- Fixed the fallback: on lookup failure the message reverts cleanly to `{result} calling {function}` instead of appending the lookup's own error code.
- Added a release-notes bullet.

## Test plan

- [ ] CI build + test on `windows-latest`
- [ ] Manually confirm an `MmException` from a failing winmm call carries the appended description

Credit to @worstenbrood for the original PR #1192.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV6tfzvCJFFvVLurtU2DkK)_