### PR TITLE
Discard oversized fmt extra data instead of throwing (#482)

### DIFF
--- a/NAudio.Core.Tests/WaveStreams/WaveFileReaderTests.cs
+++ b/NAudio.Core.Tests/WaveStreams/WaveFileReaderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using NAudio.Utils;
 using NAudio.Wave;
 using NUnit.Framework;
@@ -289,6 +290,55 @@ namespace NAudio.Core.Tests.WaveStreams
 
             Assert.Throws<InvalidDataException>(
                 () => { using var _ = new WaveFileReader(new MemoryStream(payload)); });
+        }
+
+        // Regression: a fmt chunk can declare more extra (cbSize) bytes than NAudio's fixed
+        // 100-byte buffer. The reader used to throw ArgumentException; it must now discard the
+        // surplus and carry on reading the rest of the file. See issue #482.
+        [Test]
+        [Category("UnitTest")]
+        public void OversizedFmtExtraDataIsDiscardedNotThrown()
+        {
+            const int extraSize = 200; // larger than WaveFormatExtraData's 100-byte buffer
+            var audio = new byte[] { 1, 0, 2, 0, 3, 0, 4, 0 };
+
+            using var ms = new MemoryStream();
+            using (var w = new BinaryWriter(ms, Encoding.ASCII, leaveOpen: true))
+            {
+                w.Write(Encoding.ASCII.GetBytes("RIFF"));
+                w.Write(0); // RIFF size placeholder, patched below
+                w.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+                w.Write(Encoding.ASCII.GetBytes("fmt "));
+                w.Write(18 + extraSize);      // fmt chunk length
+                w.Write((short)1);            // PCM
+                w.Write((short)2);            // channels
+                w.Write(16000);               // sample rate
+                w.Write(64000);               // average bytes per second
+                w.Write((short)4);            // block align
+                w.Write((short)16);           // bits per sample
+                w.Write((short)extraSize);    // cbSize
+                w.Write(new byte[extraSize]); // oversized extra data
+
+                w.Write(Encoding.ASCII.GetBytes("data"));
+                w.Write(audio.Length);
+                w.Write(audio);
+
+                long fileLength = ms.Length;
+                ms.Position = 4;
+                w.Write((uint)(fileLength - 8));
+            }
+            ms.Position = 0;
+
+            var chunkReader = new WaveFileChunkReader();
+            chunkReader.ReadWaveHeader(ms);
+
+            Assert.That(chunkReader.WaveFormat.Channels, Is.EqualTo(2));
+            Assert.That(chunkReader.WaveFormat.SampleRate, Is.EqualTo(16000));
+            Assert.That(chunkReader.WaveFormat.BitsPerSample, Is.EqualTo(16));
+            Assert.That(chunkReader.WaveFormat.AverageBytesPerSecond, Is.EqualTo(64000));
+            Assert.That(chunkReader.WaveFormat.ExtraSize, Is.EqualTo(0)); // surplus discarded
+            Assert.That(chunkReader.DataChunkLength, Is.EqualTo(audio.Length));
         }
 
         [Test]

--- a/NAudio.Core/Wave/WaveFormats/WaveFormatExtraData.cs
+++ b/NAudio.Core/Wave/WaveFormats/WaveFormatExtraData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.IO;
+using System.Diagnostics;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave
@@ -38,7 +39,15 @@ namespace NAudio.Wave
 
         internal void ReadExtraData(BinaryReader reader)
         {
-            if (this.extraSize > 0)
+            if (extraSize > extraData.Length)
+            {
+                // The fmt chunk declares more extra bytes than our fixed buffer can hold.
+                // Consume them so the stream stays aligned for the next chunk, then discard.
+                Debug.WriteLine($"Discarding {extraSize} bytes of fmt extra data exceeding the {extraData.Length}-byte buffer");
+                reader.ReadBytes(extraSize);
+                extraSize = 0;
+            }
+            if (extraSize > 0)
             {
                 reader.Read(extraData, 0, extraSize);
             }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -89,6 +89,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `WaveFileReader` / `AiffFileReader`: malformed headers that declared `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` from the `Position` setter (#1254)
  * `AiffFileReader.Read`: truncated `SSND` chunks no longer trigger `IndexOutOfRangeException` in the byte-swap loop — the read count is rounded down to a whole block (#1254)
  * `AudioEndpointVolume.OnVolumeNotification`: fixed per-channel volume notification returning channel 0's volume for every channel — the read pointer was not advanced per channel (#351)
+ * `WaveFileReader`: fixed `ArgumentException` reading WAV files whose `fmt` chunk declares more extra (`cbSize`) bytes than the fixed 100-byte buffer holds — the surplus is now discarded instead of throwing (#482)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

Fixes #482. A WAV `fmt ` chunk can declare more extra (`cbSize`) bytes than `WaveFormatExtraData`'s fixed 100-byte buffer holds. `ReadExtraData` then called `reader.Read(extraData, 0, extraSize)` with `extraSize > 100`, throwing `ArgumentException` ("Offset and length were out of bounds...") while reading otherwise-valid files.

The guard now consumes the surplus bytes from the stream (keeping chunk alignment for the next chunk) and discards them, setting `extraSize = 0`, instead of crashing.

This is the NAudio 3 (`main`) counterpart to the long-standing community PR #1044, which targeted `release/2.x`.

## Notes / design

- The fixed `byte[100]` buffer is deliberately left unchanged. It exists for `[MarshalAs(ByValArray, SizeConst=100)]` round-tripping to native `WAVEFORMATEX` in ACM/WinMM interop; `ByValArray` requires a compile-time constant, so it can't be made dynamic, and enlarging it would bloat every marshalled format for no benefit. Hardening the file-read path is the correct, low-risk fix.
- Discarding *all* the extra data (rather than keeping the first 100 bytes) is intentional — truncated codec extra-data is unusable, and full discard keeps the stream cursor exactly at the next chunk.
- `Debug.WriteLine` is `[Conditional("DEBUG")]`, so the message (and its string interpolation) is fully elided in Release builds of the assembly.

## Test plan

- [x] Added `OversizedFmtExtraDataIsDiscardedNotThrown` — builds a WAV with a 200-byte `cbSize` and asserts the reader parses the format, reports `ExtraSize == 0`, and still locates the data chunk. This throws without the fix.
- [x] `dotnet test NAudio.Core.Tests` validated by CI

https://claude.ai/code/session_01RbKfE1NbTxQytT8AsAm7X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbKfE1NbTxQytT8AsAm7X6)_
Thanks to @rjschnorenberg for original implementation