### PR TITLE
Fix WaveViewer rendering waveform upside-down (#801)

### DIFF
--- a/NAudio.WinForms/Gui/WaveViewer.cs
+++ b/NAudio.WinForms/Gui/WaveViewer.cs
@@ -125,7 +125,7 @@ namespace NAudio.Gui
                     }
                     float lowPercent = ((((float) low) - short.MinValue) / ushort.MaxValue);
                     float highPercent = ((((float) high) - short.MinValue) / ushort.MaxValue);
-                    e.Graphics.DrawLine(Pens.Black,x,this.Height * lowPercent,x,this.Height * highPercent);					
+                    e.Graphics.DrawLine(Pens.Black,x,this.Height * (1 - lowPercent),x,this.Height * (1 - highPercent));
                 } 
             }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,6 +65,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 
 #### Reliability and bug fixes
 
+ * `WaveViewer`: fixed waveform rendering upside-down (#801, #818)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide via a reentrant lock — fixes process-killing access violations under concurrent ACM access
  * `AcmStream`: fixed double-close in finalizer by zeroing the handle field before close
  * `MediaFoundationReader`: informational source-reader flags (`STREAMTICK`, `NEWSTREAM`, `NativeMediaTypeChanged`, `AllEffectsRemoved`) are now non-fatal instead of aborting reads


### PR DESCRIPTION
## Summary

- Fixes the `WaveViewer` WinForms control rendering waveforms vertically flipped (#801).
- WinForms screen-Y grows downward, so the existing percent mapping plotted positive amplitudes at the bottom and negatives at the top. Inverting the mapping (`1 - percent`) restores the conventional orientation.
- One-line change to `NAudio.WinForms/Gui/WaveViewer.cs` — a lighter alternative to the `Matrix`/`RectangleF` transform rewrite in #818, with no extra imports and without mutating `Graphics.Transform` for the rest of the paint.

## Test plan

- [ ] Verify on Windows: host a `WaveViewer` on a form, load a known WAV, confirm positive amplitudes render toward the top.

Note: NAudioDemo does not host `WaveViewer` and this is WinForms/GDI+, so it could not be visually verified in CI. The change is low-risk arithmetic.

Closes #801.

https://claude.ai/code/session_01CeFjhyear9NkNWxSfFHZj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeFjhyear9NkNWxSfFHZj2)_