### PR TITLE
Support multiple event clients on AudioSessionControl (#1263)

### DIFF
--- a/NAudio.Wasapi/CoreAudioApi/AudioSessionControl.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioSessionControl.cs
@@ -4,6 +4,7 @@
 // -----------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
@@ -22,7 +23,8 @@ namespace NAudio.CoreAudioApi
         private IAudioSessionControl audioSessionControlInterface;
         private IAudioSessionControl2 audioSessionControlInterface2;
         private readonly bool ownsInterface;
-        private AudioSessionEventsCallback audioSessionEventCallback;
+        private readonly Dictionary<IAudioSessionEventsHandler, AudioSessionEventsCallback> audioSessionEventCallbacks = new();
+        private readonly object eventCallbackLock = new();
 
         // ComWrappers CCWs return a distinct IntPtr per interface (and a separate vtable
         // for IUnknown). Registration APIs that expect IAudioSessionEvents* must receive
@@ -88,18 +90,21 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public void Dispose()
         {
-            if (audioSessionEventCallback != null)
+            lock (eventCallbackLock)
             {
-                var ptr = QueryEventsInterface(audioSessionEventCallback);
-                try
+                foreach (var callback in audioSessionEventCallbacks.Values)
                 {
-                    audioSessionControlInterface.UnregisterAudioSessionNotification(ptr);
+                    var ptr = QueryEventsInterface(callback);
+                    try
+                    {
+                        audioSessionControlInterface.UnregisterAudioSessionNotification(ptr);
+                    }
+                    finally
+                    {
+                        Marshal.Release(ptr);
+                    }
                 }
-                finally
-                {
-                    Marshal.Release(ptr);
-                }
-                audioSessionEventCallback = null;
+                audioSessionEventCallbacks.Clear();
             }
             if (audioSessionControlInterface != null)
             {
@@ -249,34 +254,46 @@ namespace NAudio.CoreAudioApi
         }
 
         /// <summary>
-        /// Registers an even client for callbacks
+        /// Registers an event client for callbacks. Multiple clients can be registered;
+        /// registering a client that is already registered has no effect.
         /// </summary>
-        /// <param name="eventClient"></param>
+        /// <param name="eventClient">The handler to register.</param>
         public void RegisterEventClient(IAudioSessionEventsHandler eventClient)
         {
-            // we could have an array or list of listeners if we like
-            audioSessionEventCallback = new AudioSessionEventsCallback(eventClient);
-            var ptr = QueryEventsInterface(audioSessionEventCallback);
-            try
+            lock (eventCallbackLock)
             {
-                CoreAudioException.ThrowIfFailed(audioSessionControlInterface.RegisterAudioSessionNotification(ptr));
-            }
-            finally
-            {
-                Marshal.Release(ptr);
+                if (audioSessionEventCallbacks.ContainsKey(eventClient))
+                {
+                    return;
+                }
+                var callback = new AudioSessionEventsCallback(eventClient);
+                var ptr = QueryEventsInterface(callback);
+                try
+                {
+                    CoreAudioException.ThrowIfFailed(audioSessionControlInterface.RegisterAudioSessionNotification(ptr));
+                }
+                finally
+                {
+                    Marshal.Release(ptr);
+                }
+                audioSessionEventCallbacks.Add(eventClient, callback);
             }
         }
 
         /// <summary>
-        /// Unregisters an event client from receiving callbacks
+        /// Unregisters an event client from receiving callbacks. Unregistering a client that
+        /// is not registered has no effect.
         /// </summary>
-        /// <param name="eventClient"></param>
+        /// <param name="eventClient">The handler to unregister.</param>
         public void UnRegisterEventClient(IAudioSessionEventsHandler eventClient)
         {
-            // if one is registered, let it go
-            if (audioSessionEventCallback != null)
+            lock (eventCallbackLock)
             {
-                var ptr = QueryEventsInterface(audioSessionEventCallback);
+                if (!audioSessionEventCallbacks.TryGetValue(eventClient, out var callback))
+                {
+                    return;
+                }
+                var ptr = QueryEventsInterface(callback);
                 try
                 {
                     CoreAudioException.ThrowIfFailed(audioSessionControlInterface.UnregisterAudioSessionNotification(ptr));
@@ -285,7 +302,7 @@ namespace NAudio.CoreAudioApi
                 {
                     Marshal.Release(ptr);
                 }
-                audioSessionEventCallback = null;
+                audioSessionEventCallbacks.Remove(eventClient);
             }
         }
     }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,6 +65,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 
 #### Reliability and bug fixes
 
+ * `AudioSessionControl`: now supports multiple registered event clients. `RegisterEventClient` no longer leaks a prior registration, and `UnRegisterEventClient` now honours its `eventClient` argument instead of unregistering whichever handler happened to be stored (#1263)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide via a reentrant lock — fixes process-killing access violations under concurrent ACM access
  * `AcmStream`: fixed double-close in finalizer by zeroing the handle field before close
  * `MediaFoundationReader`: informational source-reader flags (`STREAMTICK`, `NEWSTREAM`, `NativeMediaTypeChanged`, `AllEffectsRemoved`) are now non-fatal instead of aborting reads


### PR DESCRIPTION
## Summary

Fixes #1263. `AudioSessionControl` stored a single `AudioSessionEventsCallback` field, which caused two related lifetime bugs:

1. **`RegisterEventClient` leaked a prior registration** — registering a second handler overwrote the field, so the first callback could never be unregistered (Windows kept dispatching to it).
2. **`UnRegisterEventClient` ignored its `eventClient` argument** — it unregistered whatever happened to be stored, so `UnRegisterEventClient(A)` after registering A then B would silently unregister B.

This replaces the single field with a `Dictionary<IAudioSessionEventsHandler, AudioSessionEventsCallback>` (guarded by a lock, since registration happens on the caller thread while WASAPI dispatches on a worker thread), implementing the issue's Option 2 / multiple-listener support:

- `RegisterEventClient` — registers and tracks each handler. **Idempotent**: registering an already-registered handler is a no-op.
- `UnRegisterEventClient` — now honours its argument: looks up that specific handler, unregisters its callback, removes it. Unknown handler is a silent no-op (matches `event -=` semantics).
- `Dispose` — unregisters every tracked callback and clears the map.

No public signatures change, so this is fully backward-compatible. The existing `QueryEventsInterface` helper is reused unchanged.

## Test plan

- [ ] CI build + test on `windows-latest`
- [ ] Smoke test via the **Volume Mixer** demo in `NAudioDemo`: open the panel with apps playing audio (exercises `RegisterEventClient`), change volume/mute externally (confirms callbacks dispatch without access violation), then close/switch plugin (exercises the `Dispose` unregister loop)

Note: I could not compile locally — no .NET SDK in the environment — so CI is the first real build verification.

🤖 This PR was generated with assistance from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_0193X3ipwpRNvJcw1piJr44L)_