### PR TITLE
Fix CueListInterpreter returning null for cues without labels (#549)

### DIFF
--- a/NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs
+++ b/NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs
@@ -47,9 +47,10 @@ namespace NAudio.Core.Tests.WaveStreams
         }
 
         [Test]
-        public void ReturnsNullWhenCuePresentButNoLabels()
+        public void ReadsLabellessCueListWhenCuePresentButNoLabels()
         {
-            // Orphan "cue " chunk (no companion LIST/adtl) — use AddChunk at the byte level.
+            // Orphan "cue " chunk (no companion LIST/adtl), e.g. unnamed markers from Wavosaur (#549).
+            // The cue must still be returned, with an empty label.
             var cueBytes = BuildOrphanCueChunkBody(cueId: 1, samplePosition: 100);
             var ms = new MemoryStream();
             using (var w = new WaveFileWriter(new IgnoreDisposeStream(ms), Format))
@@ -59,13 +60,18 @@ namespace NAudio.Core.Tests.WaveStreams
             }
             ms.Position = 0;
             using var reader = new WaveFileReader(ms);
-            Assert.That(reader.Chunks.Read(CueListInterpreter.Instance), Is.Null);
+            var cues = reader.Chunks.Read(CueListInterpreter.Instance);
+            Assert.That(cues, Is.Not.Null);
+            Assert.That(cues.Count, Is.EqualTo(1));
+            Assert.That(cues[0].Position, Is.EqualTo(100));
+            Assert.That(cues[0].Label, Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void ReturnsNullWhenOnlyInfoListIsPresent()
+        public void ReadsLabellessCueListWhenOnlyInfoListIsPresent()
         {
-            // cue chunk + LIST/INFO (no adtl) — the interpreter must not mistake INFO for adtl.
+            // cue chunk + LIST/INFO (no adtl) — the interpreter must not mistake INFO for adtl,
+            // but should still return the cue with an empty label rather than null (#549).
             var cueBytes = BuildOrphanCueChunkBody(cueId: 1, samplePosition: 100);
             var info = new InfoMetadata();
             info.Set("INAM", "Title");
@@ -79,7 +85,11 @@ namespace NAudio.Core.Tests.WaveStreams
             }
             ms.Position = 0;
             using var reader = new WaveFileReader(ms);
-            Assert.That(reader.Chunks.Read(CueListInterpreter.Instance), Is.Null);
+            var cues = reader.Chunks.Read(CueListInterpreter.Instance);
+            Assert.That(cues, Is.Not.Null);
+            Assert.That(cues.Count, Is.EqualTo(1));
+            Assert.That(cues[0].Position, Is.EqualTo(100));
+            Assert.That(cues[0].Label, Is.EqualTo(string.Empty));
         }
 
         [Test]

--- a/NAudio.Core/Wave/WaveStreams/CueList.cs
+++ b/NAudio.Core/Wave/WaveStreams/CueList.cs
@@ -152,8 +152,10 @@ namespace NAudio.Wave
             string[] labels = new string[cueCount];
             var labelChunkId = ChunkIdentifier.ChunkIdentifierToInt32("labl");
 
-            // Parse list chunk - properly handle all chunk types
-            for (int p = 4; listChunkData.Length - p >= 8; )
+            // Parse list chunk - properly handle all chunk types.
+            // listChunkData may be null when the file has cue points but no adtl labels
+            // (e.g. unnamed markers written by Wavosaur); in that case the cues keep empty labels.
+            for (int p = 4; listChunkData != null && listChunkData.Length - p >= 8; )
             {
                 int chunkId = BitConverter.ToInt32(listChunkData, p);
                 int chunkSize = BitConverter.ToInt32(listChunkData, p + 4);
@@ -256,7 +258,8 @@ namespace NAudio.Wave
     /// <summary>
     /// <see cref="IWaveChunkInterpreter{T}"/> that reads the <c>cue</c> and companion <c>LIST/adtl</c>
     /// chunks from a WAV file and returns a <see cref="CueList"/>.
-    /// Returns <c>null</c> if either chunk is absent.
+    /// Returns <c>null</c> only when no <c>cue </c> chunk is present. When a <c>cue </c> chunk
+    /// exists without a companion <c>LIST/adtl</c> label chunk, the cues are returned with empty labels.
     /// </summary>
     public sealed class CueListInterpreter : IWaveChunkInterpreter<CueList>
     {
@@ -285,8 +288,9 @@ namespace NAudio.Wave
                     break;
                 }
             }
-            if (listChunkData == null) return null;
 
+            // listChunkData may be null here: the file has cue points but no adtl labels
+            // (e.g. unnamed markers). The cues are still returned, with empty labels.
             var cueChunkData = chunks.GetData(cueChunk);
             return new CueList(cueChunkData, listChunkData);
         }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,6 +65,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 
 #### Reliability and bug fixes
 
+ * `CueListInterpreter`: fixed returning null for WAV files with cue points but no labels (e.g. unnamed Wavosaur markers); cues are now returned with empty labels (#549)
  * `WaveViewer`: fixed waveform rendering upside-down (#801, #818)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide via a reentrant lock — fixes process-killing access violations under concurrent ACM access
  * `AcmStream`: fixed double-close in finalizer by zeroing the handle field before close


### PR DESCRIPTION
## Summary

Fixes #549. WAV files that contain cue points (a `cue ` chunk) but no cue labels (no companion `LIST`/`adtl` chunk) — e.g. unnamed markers written by Wavosaur — caused `CueListInterpreter` to return `null`, silently dropping the cue points. The cues are now returned with empty-string labels instead.

## Changes

- **`NAudio.Core/Wave/WaveStreams/CueList.cs`**
  - Removed the `if (listChunkData == null) return null;` early return in `CueListInterpreter.Interpret`; the `CueList` is now built whenever a `cue ` chunk is present, regardless of whether an `adtl` label chunk exists.
  - Guarded the label-parsing loop in the `CueList(byte[], byte[])` constructor against a null `listChunkData` (the `Cue` constructor already coalesces a null label to `string.Empty`).
  - Updated the now-stale XML doc that claimed it returns null "if either chunk is absent".
- **`NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs`** — repurposed the two tests that asserted the buggy null behaviour:
  - `ReturnsNullWhenCuePresentButNoLabels` → `ReadsLabellessCueListWhenCuePresentButNoLabels`
  - `ReturnsNullWhenOnlyInfoListIsPresent` → `ReadsLabellessCueListWhenOnlyInfoListIsPresent` (a `cue ` chunk is present, so it now yields a labelless `CueList` rather than null)
- **`RELEASE_NOTES.md`** — added a bullet under *Reliability and bug fixes*.

## Test plan

- [x] Full `NAudio.Core.Tests` suite passes headless on Linux (.NET 10): 971 passed, 0 failed, 7 skipped (the skips are hardware/local-file integration tests, unrelated to this change).
- [x] No external test asset needed — the no-label file is built in memory via the existing `BuildOrphanCueChunkBody` helper.

https://claude.ai/code/session_01Bxv9TgSa7pA8oFFPGnyQEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bxv9TgSa7pA8oFFPGnyQEP)_