### PR TITLE
Docs: WasapiPlayer/WasapiRecorder tutorials + point WASAPI/ASIO docs at NAudio 3 APIs

### DIFF
--- a/Docs/CrossPlatformAudioFilesWithSoundFile.md
+++ b/Docs/CrossPlatformAudioFilesWithSoundFile.md
@@ -33,7 +33,7 @@ using NAudio.Wave;
 using var reader = new SoundFileReader("song.flac");
 Console.WriteLine($"{reader.WaveFormat} {reader.TotalTime}");
 
-using var output = new WasapiOut();   // or AlsaOut on Linux
+using var output = new WasapiPlayerBuilder().Build();   // or AlsaOut on Linux
 output.Init(reader);
 output.Play();
 while (output.PlaybackState == PlaybackState.Playing)

--- a/Docs/EnumerateOutputDevices.md
+++ b/Docs/EnumerateOutputDevices.md
@@ -75,12 +75,12 @@ foreach (var wasapi in enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceSt
 }
 ```
 
-To open the device you want, simply pass the device in to the appropriate WASAPI class depending on if you are playing back or recording...
+To open the device you want, pass the device in to the appropriate WASAPI builder depending on whether you are playing back or recording...
 
 ```c#
-var outputDevice = new WasapiOut(mmDevice, ...);
-var recordingDevice = new WasapiCapture(captureDevice, ...);
-var loopbackCapture = new WasapiLoopbackCapture(loopbackDevice);
+var outputDevice = new WasapiPlayerBuilder().WithDevice(mmDevice).Build();
+var recordingDevice = new WasapiRecorderBuilder().WithDevice(captureDevice).Build();
+var loopbackCapture = new WasapiRecorderBuilder().WithDevice(loopbackDevice).WithLoopbackCapture().Build();
 ```
 
 You can also use the MMEnumerator to request what the default device is for a number of different scenarios (playback or record, and voice, multimedia or 'console'):

--- a/Docs/EnumerateOutputDevices.md
+++ b/Docs/EnumerateOutputDevices.md
@@ -91,10 +91,10 @@ enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
 
 # ASIO
 
-You can discover the registered ASIO drivers on your system with `AsioOut.GetDriverNames`. There is no guarantee that the associated soundcard is currently connected to the system.
+You can discover the registered ASIO drivers on your system with `AsioDevice.GetDriverNames`. There is no guarantee that the associated soundcard is currently connected to the system.
 
 ```c#
-foreach (var asio in AsioOut.GetDriverNames())
+foreach (var asio in AsioDevice.GetDriverNames())
 {
     Console.WriteLine(asio);
 }
@@ -103,8 +103,10 @@ foreach (var asio in AsioOut.GetDriverNames())
 You can then use the driver name to open the device:
 
 ```c#
-new AsioOut(driverName);
+using var device = AsioDevice.Open(driverName);
 ```
+
+(`AsioDevice` is the NAudio 3 ASIO API. The legacy `AsioOut` class still works — see [Migrating from AsioOut to AsioDevice](AsioMigration.md).)
 
 # Management Objects
 

--- a/Docs/OutputDeviceTypes.md
+++ b/Docs/OutputDeviceTypes.md
@@ -46,12 +46,14 @@ To select a specific device with `DirectSoundOut`, you can call the static `Dire
 
 `DirectSoundOut` uses a background thread waiting to fill buffers (same as `WaveOut`). This is a reliable and uncomplicated mechanism, but as with any callback mechanism that uses a background thread, you must take responsibility yourself for ensuring that repositions do not happen at the same time as reads (although some of NAudio's built-in WaveStreams can protect you from getting this wrong).
 
-## AsioOut
+## ASIO
 
 ASIO is the de-facto standard for audio interface drivers for recording studios. All professional audio interfaces for Windows will come with ASIO drivers that are designed to operate at the lowest latencies possible. ASIO is a good choice for professional audio applications requiring very low latency and direct hardware access.
 
-ASIO Out devices are selected by name. Use the `AsioOut.GetDriverNames()` to see what devices are available on your system. Note that this will return all installed ASIO drivers. It does not necessarily mean that the soundcard is currently connected in the case of an external audio interface, so `Init` can fail for that reason.
+In NAudio 3 the ASIO device is [`AsioDevice`](AsioPlayback.md), which adds explicit playback/recording/duplex modes, non-contiguous channel selection, and per-channel `Span<float>` callbacks. (The older `AsioOut` class still works as a thin facade over `AsioDevice` — see [Migrating from AsioOut to AsioDevice](AsioMigration.md).)
+
+ASIO devices are selected by name. Use `AsioDevice.GetDriverNames()` to see what devices are available on your system. Note that this will return all installed ASIO drivers. It does not necessarily mean that the soundcard is currently connected in the case of an external audio interface, so initialization can fail for that reason.
 
 ASIO drivers support their own customised settings GUI. You can access this by calling `ShowControlPanel()`. Latencies are usually set within the control panel and are typically specified in samples. Remember that if you try to work at a really low latency, your input IWaveProvider's `Init` function needs to be really fast.
 
-ASIO drivers can process data in a whole host of native WAV formats (e.g. big endian vs little endian, 16, 24, 32 bit ints, IEEE floats etc), not all of which are currently supported by NAudio. If ASIO Out doesn't work with your soundcard, create an issue on the NAudio GitHub page, as it is fairly easy to add support for another format.
+ASIO drivers can process data in a whole host of native WAV formats (e.g. big endian vs little endian, 16, 24, 32 bit ints, IEEE floats etc), not all of which are currently supported by NAudio. If ASIO doesn't work with your soundcard, create an issue on the NAudio GitHub page, as it is fairly easy to add support for another format.

--- a/Docs/OutputDeviceTypes.md
+++ b/Docs/OutputDeviceTypes.md
@@ -14,9 +14,11 @@ You may notice a `Volume` property on the interface that is marked as `[Obsolete
 
 Finally there is a `PlaybackState` property that can report `Stopped`, `Playing` or `Paused`. Be careful with Stopped though, since if you call the `Stop` method, the `PlaybackState` will immediately go to `Stopped` but it may be a few milliseconds before any background playback threads have actually exited.
 
-## WasapiOut
+## WASAPI
 
 WASAPI is the recommended audio output API on modern Windows. It is the native audio API from Windows Vista onwards and offers the best combination of features, performance and audio quality.
+
+In NAudio 3 the WASAPI playback device is [`WasapiPlayer`](WasapiPlayer.md), created via `WasapiPlayerBuilder`. (The older `WasapiOut` class is still available but is now considered legacy — see [its article](WasapiOut.md).)
 
 In shared mode (the default), WASAPI handles sample rate conversion automatically — you can pass in audio at any sample rate and it will be resampled to match the device's configured format. This makes it just as easy to use as `WaveOut`, while offering lower latency and better audio quality.
 
@@ -38,7 +40,7 @@ You can also set `BufferMilliseconds`, which specifies the duration of each buff
 
 ## DirectSoundOut
 
-DirectSound is another legacy API that can be used as an alternative to `WaveOut`. It is simple and widely supported, but offers no particular advantage over `WaveOut` or `WasapiOut` on modern systems.
+DirectSound is another legacy API that can be used as an alternative to `WaveOut`. It is simple and widely supported, but offers no particular advantage over `WaveOut` or WASAPI (`WasapiPlayer`) on modern systems.
 
 To select a specific device with `DirectSoundOut`, you can call the static `DirectSoundOut.Devices` property which will let you get at the GUID for each device, which you can pass into the `DirectSoundOut` constructor. Like `WaveOut`, you can adjust the latency (overall buffer size).
 

--- a/Docs/PlayAudioFromUrl.md
+++ b/Docs/PlayAudioFromUrl.md
@@ -7,7 +7,7 @@ In this example designed to be run from a console app, we use `MediaFoundationRe
 ```c#
 var url = "http://media.ch9.ms/ch9/2876/fd36ef30-cfd2-4558-8412-3cf7a0852876/AzureWebJobs103.mp3";
 using(var mf = new MediaFoundationReader(url))
-using(var wo = new WasapiOut())
+using(var wo = new WasapiPlayerBuilder().Build())
 {
     wo.Init(mf);
     wo.Play();

--- a/Docs/PlaybackStopped.md
+++ b/Docs/PlaybackStopped.md
@@ -1,6 +1,6 @@
 # Handling Playback Stopped
 
-In NAudio, you use an implementation of the `IWavePlayer` class to play audio. Examples include `WaveOut`, `WasapiOut`, `AsioOut` etc. To specify the audio to be played, you call the `Init` method passing in an `IWaveProvider`. And to start playing you call `Play`.
+In NAudio, you use an implementation of the `IWavePlayer` class to play audio. Examples include `WaveOut`, `WasapiPlayer`, `AsioDevice` etc. To specify the audio to be played, you call the `Init` method passing in an `IWaveProvider`. And to start playing you call `Play`.
 
 ## Manually Stopping Playback
 

--- a/Docs/RecordWavFileWinFormsWaveIn.md
+++ b/Docs/RecordWavFileWinFormsWaveIn.md
@@ -10,7 +10,7 @@ Directory.CreateDirectory(outputFolder);
 var outputFilePath = Path.Combine(outputFolder,"recorded.wav");
 ```
 
-Next, let's create the recording device. I'm going to use `WaveIn` in this case. We could also use `WasapiCapture`.
+Next, let's create the recording device. I'm going to use `WaveIn` in this case. We could also use [`WasapiRecorder`](WasapiRecorder.md) for WASAPI capture.
 
 ```c#
 var waveIn = new WaveIn();

--- a/Docs/WasapiLoopbackCapture.md
+++ b/Docs/WasapiLoopbackCapture.md
@@ -1,5 +1,7 @@
 # Record Soundcard Output with WasapiLoopbackCapture
 
+> **Legacy:** `WasapiCapture` and `WasapiLoopbackCapture` are retained for backwards compatibility. For new code, prefer [`WasapiRecorder`](WasapiRecorder.md), the modern WASAPI capture device introduced in NAudio 3. It offers zero-copy capture, MMCSS thread priority, `IAsyncEnumerable` support, async disposal, and a fluent builder — including loopback capture via `WithLoopbackCapture()`.
+
 Lots of people ask how they can use NAudio to record the audio being played by another program. The answer is that unfortunately Windows does not provide an API that lets you target the output of one specific program to record. However, with WASAPI loopback capture, you can record all the audio that is being played out of a specific output device.
 
 Since NAudio 2.1.0, the audio can be captured at a sample rate of your choosing, although it will make sense to match the sound card's format.

--- a/Docs/WasapiOut.md
+++ b/Docs/WasapiOut.md
@@ -1,5 +1,7 @@
 # Working with WasapiOut
 
+> **Legacy:** `WasapiOut` is retained for backwards compatibility. For new code, prefer [`WasapiPlayer`](WasapiPlayer.md), the modern WASAPI playback device introduced in NAudio 3. It offers zero-copy buffering, MMCSS thread priority, `IAudioClient3` low-latency shared mode, async disposal, and a fluent builder.
+
 `WasapiOut` is an implementation of `IWavePlayer` that uses the WASAPI audio API under the hood. WASAPI was introduced with Windows Vista, meaning it will be supported on most versions of Windows, but not XP.
 
 ## Configuring WasapiOut

--- a/Docs/WasapiPlayer.md
+++ b/Docs/WasapiPlayer.md
@@ -1,0 +1,98 @@
+# Playing Audio with WasapiPlayer
+
+`WasapiPlayer` is NAudio 3's modern WASAPI playback device. It is the recommended way to play audio through WASAPI, superseding the older [`WasapiOut`](WasapiOut.md). It still implements `IWavePlayer`, so it works with the rest of the NAudio playback pipeline, but adds:
+
+- **Zero-copy buffering** — audio is read directly into the WASAPI render buffer via `Span<byte>`, avoiding an intermediate copy.
+- **MMCSS thread priority** — the playback thread can be registered with the Multimedia Class Scheduler Service for glitch-resistant low-latency playback.
+- **`IAudioClient3` low-latency shared mode** — when the OS and driver support it, shared-mode playback can run at the engine's minimum period.
+- **A fluent builder** (`WasapiPlayerBuilder`) instead of a long constructor.
+- **`IAsyncDisposable`** for non-blocking teardown in async/UI code.
+
+## Creating a WasapiPlayer
+
+You create a `WasapiPlayer` through `WasapiPlayerBuilder`. With no configuration, it uses the default render device in shared mode with event synchronization:
+
+```c#
+using NAudio.Wave;
+
+var player = new WasapiPlayerBuilder().Build();
+```
+
+The builder methods are chainable, so you can configure exactly what you need:
+
+```c#
+var player = new WasapiPlayerBuilder()
+    .WithDevice(someMMDevice)        // default: system default render device
+    .WithExclusiveMode()             // default: shared mode
+    .WithEventSync()                 // default: event sync (vs WithPollingSync)
+    .WithLatency(50)                 // default: 200ms
+    .WithLowLatency()                // try IAudioClient3 shared-mode low latency
+    .WithMmcssThreadPriority("Pro Audio")
+    .WithCategory(AudioStreamCategory.Media)
+    .Build();
+```
+
+To select a specific device, enumerate render endpoints with `MMDeviceEnumerator` (see [enumerating output devices](EnumerateOutputDevices.md)) and pass the `MMDevice` to `WithDevice`.
+
+### Share modes
+
+`WithSharedMode()` (the default) mixes your audio with other applications. In shared mode the engine resamples/converts your audio to the device mix format automatically, so any reasonable `WaveFormat` will play.
+
+`WithExclusiveMode()` takes sole ownership of the device, allowing the exact sample rate and lower latency, but no other application can play through it while you hold it. In exclusive mode the format must be natively supported by the device — check first with `IsFormatSupported` or discover one with `GetSupportedExclusiveFormat`:
+
+```c#
+var preferred = new WaveFormat(48000, 24, 2);
+var format = player.GetSupportedExclusiveFormat(preferred);
+if (format == null)
+{
+    // no supported exclusive format found for this device
+}
+```
+
+## Playing audio
+
+Usage mirrors any other `IWavePlayer`: call `Init` with your source, `Play` to start, `Stop` to stop, and subscribe to `PlaybackStopped` to know when playback ends. If a `SynchronizationContext` is present when the player is constructed (e.g. on a UI thread), `PlaybackStopped` is raised on that context.
+
+```c#
+using NAudio.Wave;
+
+using var audioFile = new AudioFileReader("example.mp3");
+using var player = new WasapiPlayerBuilder().Build();
+
+player.Init(audioFile);
+player.Play();
+while (player.PlaybackState == PlaybackState.Playing)
+{
+    Thread.Sleep(500);
+}
+```
+
+## Volume control
+
+`WasapiPlayer` exposes several levels of volume control:
+
+- `Volume` / `IsMuted` — your application's slider in the Windows volume mixer (delegates to `SessionVolume`). This is the one most apps want.
+- `SessionVolume` — the full `SimpleAudioVolume` for the session.
+- `StreamVolume` — per-channel volume for this stream (shared mode only; throws in exclusive mode).
+- `DeviceVolume` — the device endpoint master volume, affecting **all** applications on that device. Use with care.
+
+```c#
+player.Volume = 0.5f;   // 50% for this application only
+player.IsMuted = true;  // mute just this application
+```
+
+## Async disposal
+
+In async or UI code, prefer `DisposeAsync` over `Dispose` so the calling thread isn't blocked while the playback thread is joined:
+
+```c#
+await using var player = new WasapiPlayerBuilder().Build();
+player.Init(reader);
+player.Play();
+// ...
+// disposal happens asynchronously at end of scope
+```
+
+## Getting playback position
+
+`WasapiPlayer` implements `IWavePosition`. `GetPosition()` returns the number of bytes the device has actually rendered (driven by the audio clock), which is not the same as the read position of your source stream.

--- a/Docs/WasapiRecorder.md
+++ b/Docs/WasapiRecorder.md
@@ -1,0 +1,103 @@
+# Recording Audio with WasapiRecorder
+
+`WasapiRecorder` is NAudio 3's modern WASAPI capture device. It is the recommended way to capture audio through WASAPI, superseding the older [`WasapiCapture` and `WasapiLoopbackCapture`](WasapiLoopbackCapture.md). It adds:
+
+- **Zero-copy capture** — the `DataAvailable` event hands you a `ReadOnlySpan<byte>` directly over the WASAPI buffer.
+- **MMCSS thread priority** — register the capture thread with the Multimedia Class Scheduler Service.
+- **`IAsyncEnumerable` support** — consume captured audio with `await foreach` via `CaptureAsync`.
+- **A fluent builder** (`WasapiRecorderBuilder`) covering microphone capture and loopback capture.
+- **`IAsyncDisposable`** for non-blocking teardown.
+
+## Creating a WasapiRecorder
+
+You create a `WasapiRecorder` through `WasapiRecorderBuilder`. With no configuration, it captures from the default capture device (microphone) in shared mode with event synchronization:
+
+```c#
+using NAudio.Wasapi;
+
+var recorder = new WasapiRecorderBuilder().Build();
+```
+
+The builder methods are chainable:
+
+```c#
+var recorder = new WasapiRecorderBuilder()
+    .WithDevice(someMMDevice)        // default: system default capture device
+    .WithExclusiveMode()             // default: shared mode
+    .WithEventSync()                 // default: event sync (vs WithPollingSync)
+    .WithBufferLength(50)            // default: 100ms
+    .WithFormat(new WaveFormat(44100, 16, 2))  // default: device mix format
+    .WithMmcssThreadPriority("Pro Audio")
+    .Build();
+```
+
+In shared mode the engine converts to the format you request via `WithFormat`. If you don't request one, the device's mix format is used and exposed on the `WaveFormat` property after building.
+
+## Recording with the DataAvailable event
+
+The zero-copy path uses the `DataAvailable` event. The span is **only valid for the duration of the callback** — if you need to keep the data (e.g. to write to a file), copy it out. Here we record to a WAV file:
+
+```c#
+using NAudio.Wasapi;
+using NAudio.Wave;
+
+var recorder = new WasapiRecorderBuilder().Build();
+var writer = new WaveFileWriter("recorded.wav", recorder.WaveFormat);
+
+recorder.DataAvailable += (buffer, flags) =>
+{
+    writer.Write(buffer);   // WaveFileWriter has a ReadOnlySpan<byte> overload
+};
+
+recorder.RecordingStopped += (s, a) =>
+{
+    writer.Dispose();
+    writer = null;
+    recorder.Dispose();
+};
+
+recorder.StartRecording();
+// ... record for a while ...
+recorder.StopRecording();
+```
+
+As with the playback device, if a `SynchronizationContext` was present when the recorder was constructed, `RecordingStopped` is raised on that context.
+
+## Loopback capture
+
+To record what an output device is *playing* (rather than a microphone), call `WithLoopbackCapture()`. This replaces the older `WasapiLoopbackCapture` class. Pass a render endpoint via `WithDevice`, or omit it to use the default render device:
+
+```c#
+var recorder = new WasapiRecorderBuilder()
+    .WithLoopbackCapture()
+    .Build();
+```
+
+As with the legacy loopback class, the `DataAvailable` event only fires while audio is actually playing through the device. If you need to capture continuous silence, play silence through the device for the duration.
+
+## Async capture with CaptureAsync
+
+For async pipelines you can consume audio as an `IAsyncEnumerable<AudioBuffer>`. Unlike the `DataAvailable` span, each `AudioBuffer` contains a heap-allocated **copy** of the data, so it is safe to store or process asynchronously. It also carries the device and QPC positions for the captured packet.
+
+```c#
+await using var recorder = new WasapiRecorderBuilder().Build();
+
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+await foreach (var buffer in recorder.CaptureAsync(cts.Token))
+{
+    // buffer.Data is a ReadOnlyMemory<byte>
+    ProcessAudio(buffer.Data.Span);
+}
+```
+
+Cancelling the token (or letting it time out) stops capture and ends the enumeration.
+
+## Async disposal
+
+In async or UI code, prefer `DisposeAsync` so the calling thread isn't blocked while the capture thread is joined:
+
+```c#
+await using var recorder = new WasapiRecorderBuilder().Build();
+```
+
+> **Note:** per-process loopback capture (`WithProcessLoopback`) is not yet implemented and currently throws `NotImplementedException`. Use `WithLoopbackCapture()` for system-wide loopback for now.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ NAudio comes with several demo applications which are the quickest way to see ho
 * [Playing Audio from a URL](Docs/PlayAudioFromUrl.md)
 * [Choose an audio output device type](Docs/OutputDeviceTypes.md)
 * [Enumerate and select Output Devices](Docs/EnumerateOutputDevices.md)
-* [Creating and configuring a WasapiOut device](Docs/WasapiOut.md)
+* [Playing audio with WasapiPlayer (recommended for WASAPI)](Docs/WasapiPlayer.md)
+* [Creating and configuring a WasapiOut device (legacy)](Docs/WasapiOut.md)
 * [Implement "Fire and Forget" Playback (e.g. game sound effects)](http://markheath.net/post/fire-and-forget-audio-playback-with)
 * [Play streaming MP3](http://markheath.net/post/how-to-play-back-streaming-mp3-using)
 * [Handling playback stopped](Docs/PlaybackStopped.md)
@@ -126,7 +127,8 @@ NAudio comes with several demo applications which are the quickest way to see ho
 ### Recording
 
 * [Recording a WAV file from a WinForms application](Docs/RecordWavFileWinFormsWaveIn.md)
-* [Capturing system audio with WasapiLoopbackCapture](Docs/WasapiLoopbackCapture.md)
+* [Recording audio with WasapiRecorder (recommended for WASAPI)](Docs/WasapiRecorder.md)
+* [Capturing system audio with WasapiLoopbackCapture (legacy)](Docs/WasapiLoopbackCapture.md)
 * [Play and Record audio at the same time](http://markheath.net/post/how-to-record-and-play-audio-at-same)
 * [Record Audio with ASIO](Docs/AsioRecording.md)
 * [Duplex Processing with ASIO](Docs/AsioDuplex.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * **MIDI:** new `WinRTMidiIn` / `WinRTMidiOut` classes in `NAudio.Wasapi` backed by `Windows.Devices.Midi`, with `MidiMessageConverter` for interop with the WinRT MIDI types. New `IMidiInput` / `IMidiOutput` interfaces (with a `Send(MidiEvent)` extension) let callers write backend-agnostic code; legacy `MidiIn` / `MidiOut` also implement them
  * **MIDI:** `MidiFile` now reads RIFF-RMID (`.rmi`) files by unwrapping the RIFF container and parsing the embedded standard MIDI file (#1236)
  * **ALSA (Linux):** new `NAudio.Alsa` package — `AlsaOut` (`IWavePlayer`) and `AlsaIn` (`IWaveIn`) backed by `libasound`, plus `AlsaDeviceEnumerator`. Linux-only (`[SupportedOSPlatform("linux")]`, AOT-compatible `[LibraryImport]`); reference it explicitly, it is not part of the `NAudio` meta-package (#1182)
+ * **Docs:** added `WasapiPlayer` and `WasapiRecorder` tutorials; the legacy `WasapiOut` and `WasapiLoopbackCapture` docs now point to them
 
 #### Demo apps and Test Harnesses
 


### PR DESCRIPTION
## Summary

The NAudio 3 builder-based WASAPI APIs (`WasapiPlayer` / `WasapiRecorder`) had no tutorials, and several docs still led with the legacy `WasapiOut` / `WasapiCapture` / `WasapiLoopbackCapture` / `AsioOut` types. This fills the gap and steers readers toward the modern APIs.

- **New tutorials:** `Docs/WasapiPlayer.md` and `Docs/WasapiRecorder.md` covering the fluent builders, share modes, latency/MMCSS/low-latency options, volume layers, loopback capture, `CaptureAsync` (`IAsyncEnumerable`), and async disposal.
- **Legacy markers:** `WasapiOut.md` and `WasapiLoopbackCapture.md` now open with a callout pointing to the new tutorials; README links label the old docs "(legacy)" and the new ones "(recommended for WASAPI)".
- **Reference updates:** tutorials that instantiated or recommended the legacy types now use `WasapiPlayerBuilder` / `WasapiRecorderBuilder` (`PlayAudioFromUrl`, `CrossPlatformAudioFilesWithSoundFile`, `EnumerateOutputDevices`, `PlaybackStopped`, `RecordWavFileWinFormsWaveIn`, `OutputDeviceTypes`).
- **ASIO:** the overview/enumerate docs now lead with `AsioDevice` and note `AsioOut` is the legacy facade (linking the migration guide). The dedicated ASIO docs already centred `AsioDevice`.
- Added a `RELEASE_NOTES.md` bullet.

Architecture docs (`MODERNIZATION.md`, `NAudio3AssemblyLayoutPlan.md`) and `AsioMigration.md` intentionally reference the legacy types and were left unchanged. `RecordingLevelMeter.md`'s legacy mentions are accurate descriptive context built on the `WaveInEventArgs` byte[] API, so swapping in the span-based `WasapiRecorder` there would have been misleading.

## Notes for reviewer

- Docs-only change; no code touched.
- I couldn't build/run the snippets here (no Windows/WASAPI), so they were verified against the class source — including the `WaveFileWriter.Write(ReadOnlySpan<byte>)` overload used in the recorder example. Worth a sanity check that they compile.
- `WasapiRecorder` lives in namespace `NAudio.Wasapi` while `WasapiPlayer` is in `NAudio.Wave`; the tutorials show the `using` lines accordingly. Flagging in case you'd prefer them aligned.
- `WasapiRecorderBuilder.WithProcessLoopback()` currently throws `NotImplementedException`; the recorder tutorial says so and directs readers to `WithLoopbackCapture()`.

https://claude.ai/code/session_01FFCuY3hQLCcTVNju3X5hib

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFCuY3hQLCcTVNju3X5hib)_