### PR TITLE
Move WasapiRecorder to NAudio.Wave namespace for consistency

### DIFF
--- a/Docs/WasapiRecorder.md
+++ b/Docs/WasapiRecorder.md
@@ -13,7 +13,7 @@
 You create a `WasapiRecorder` through `WasapiRecorderBuilder`. With no configuration, it captures from the default capture device (microphone) in shared mode with event synchronization:
 
 ```c#
-using NAudio.Wasapi;
+using NAudio.Wave;
 
 var recorder = new WasapiRecorderBuilder().Build();
 ```
@@ -38,7 +38,6 @@ In shared mode the engine converts to the format you request via `WithFormat`. I
 The zero-copy path uses the `DataAvailable` event. The span is **only valid for the duration of the callback** — if you need to keep the data (e.g. to write to a file), copy it out. Here we record to a WAV file:
 
 ```c#
-using NAudio.Wasapi;
 using NAudio.Wave;
 
 var recorder = new WasapiRecorderBuilder().Build();

--- a/NAudio.Wasapi/WasapiRecorder.cs
+++ b/NAudio.Wasapi/WasapiRecorder.cs
@@ -1,7 +1,6 @@
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
 using NAudio.Wasapi.CoreAudioApi;
-using NAudio.Wave;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -10,7 +9,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace NAudio.Wasapi
+namespace NAudio.Wave
 {
     /// <summary>
     /// Modern WASAPI audio recorder with zero-copy buffer access, MMCSS thread priority,

--- a/NAudio.Wasapi/WasapiRecorderBuilder.cs
+++ b/NAudio.Wasapi/WasapiRecorderBuilder.cs
@@ -1,7 +1,6 @@
 using NAudio.CoreAudioApi;
-using NAudio.Wave;
 
-namespace NAudio.Wasapi
+namespace NAudio.Wave
 {
     /// <summary>
     /// Fluent builder for creating a <see cref="WasapiRecorder"/>.

--- a/NAudioConsoleTest/Wasapi/Tests/WasapiFindBestExclusiveFormatTest.cs
+++ b/NAudioConsoleTest/Wasapi/Tests/WasapiFindBestExclusiveFormatTest.cs
@@ -1,5 +1,4 @@
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioConsoleTest/Wasapi/Tests/WasapiPlayFileTest.cs
+++ b/NAudioConsoleTest/Wasapi/Tests/WasapiPlayFileTest.cs
@@ -1,5 +1,4 @@
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioConsoleTest/Wasapi/Tests/WasapiPlaySineWaveTest.cs
+++ b/NAudioConsoleTest/Wasapi/Tests/WasapiPlaySineWaveTest.cs
@@ -1,5 +1,4 @@
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared;
 using NAudioConsoleTest.Shared.Testing;

--- a/NAudioConsoleTest/Wasapi/Tests/WasapiRecordAndPlaybackTest.cs
+++ b/NAudioConsoleTest/Wasapi/Tests/WasapiRecordAndPlaybackTest.cs
@@ -1,5 +1,4 @@
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioConsoleTest/Wasapi/Tests/WasapiRecordToWavFileTest.cs
+++ b/NAudioConsoleTest/Wasapi/Tests/WasapiRecordToWavFileTest.cs
@@ -1,5 +1,4 @@
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioDemo/RecordingDemo/RecordingPanel.cs
+++ b/NAudioDemo/RecordingDemo/RecordingPanel.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 using NAudioDemo.Utils;
 

--- a/NAudioDemo/RecordingDemo/WasapiRecorderAdapter.cs
+++ b/NAudioDemo/RecordingDemo/WasapiRecorderAdapter.cs
@@ -1,6 +1,5 @@
 using System;
 using NAudio.CoreAudioApi;
-using NAudio.Wasapi;
 using NAudio.Wave;
 
 namespace NAudioDemo.RecordingDemo


### PR DESCRIPTION
## Summary

`WasapiRecorder` and `WasapiRecorderBuilder` were in the `NAudio.Wasapi` namespace, while their playback counterpart `WasapiPlayer` / `WasapiPlayerBuilder` was in `NAudio.Wave` — an inconsistency within the same new NAudio 3 feature.

This moves the recorder pair into `NAudio.Wave`, alongside `WasapiPlayer` and every other `IWavePlayer` / capture device type (`WasapiOut`, `AsioOut`, `WaveOut`, etc.). `WasapiPlayer` already implements `IWavePlayer` (defined in `NAudio.Wave`), so keeping the whole WASAPI high-level API there maximises discoverability of the now-recommended replacement for the obsoleted `WasapiOut` / `WasapiCapture`.

## Changes

- `WasapiRecorder` / `WasapiRecorderBuilder`: namespace `NAudio.Wasapi` → `NAudio.Wave` (drops their now-redundant `using NAudio.Wave;`).
- Removed the redundant `using NAudio.Wasapi;` from 7 consumers (console test harness + recording demo) — all already imported `NAudio.Wave`.
- Updated the `WasapiRecorder` tutorial code samples to `using NAudio.Wave;`.

The `NAudio.Wasapi` *namespace* is now empty; the `NAudio.Wasapi.CoreAudioApi` sub-namespaces and the `NAudio.Wasapi` assembly name are unchanged. No new public surface, just a relocation of unreleased NAudio 3 API.

## Test plan

- [ ] CI build + test on windows-latest (no .NET SDK available in the authoring environment; this is a Windows-only TFM)

https://claude.ai/code/session_013iKZYurkiTTUeNxNKQApkq

---
_Generated by [Claude Code](https://claude.ai/code/session_013iKZYurkiTTUeNxNKQApkq)_