### PR TITLE
Fix COM object leaks in MediaFoundationTransform finally blocks

### DIFF
--- a/NAudio.Wasapi/MediaFoundation/MediaFoundationTransform.cs
+++ b/NAudio.Wasapi/MediaFoundation/MediaFoundationTransform.cs
@@ -240,9 +240,12 @@ namespace NAudio.MediaFoundation
             }
             finally
             {
+                // Capture the hresults but defer throwing until every COM object has been
+                // released, otherwise a failed Unlock/RemoveAllBuffers would leak the rest.
+                int unlockHr = 0;
                 if (outputMediaBuffer != null && outputBufferLocked)
                 {
-                    MediaFoundationException.ThrowIfFailed(outputMediaBuffer.Unlock());
+                    unlockHr = outputMediaBuffer.Unlock();
                 }
                 ComActivation.ReleaseBoth(outputMediaBuffer, outputMediaBufferPtr);
 
@@ -257,9 +260,12 @@ namespace NAudio.MediaFoundation
                     ComActivation.ReleaseBoth(returnedSample, returnedSamplePtr);
                 }
 
-                MediaFoundationException.ThrowIfFailed(sample.RemoveAllBuffers());
+                int removeBuffersHr = sample.RemoveAllBuffers();
                 ComActivation.ReleaseBoth(sample, samplePtr);
                 ComActivation.ReleaseBoth(pBuffer, pBufferPtr);
+
+                MediaFoundationException.ThrowIfFailed(unlockHr);
+                MediaFoundationException.ThrowIfFailed(removeBuffersHr);
             }
         }
 
@@ -299,12 +305,16 @@ namespace NAudio.MediaFoundation
             }
             finally
             {
+                // Capture the hresult but defer throwing until the COM objects have been
+                // released, otherwise a failed Unlock would leak the buffer and the sample.
+                int unlockHr = 0;
                 if (bufferLocked)
                 {
-                    MediaFoundationException.ThrowIfFailed(mediaBuffer.Unlock());
+                    unlockHr = mediaBuffer.Unlock();
                 }
                 ComActivation.ReleaseBoth(mediaBuffer, mediaBufferPtr);
                 ComActivation.ReleaseBoth(sample, samplePtr);
+                MediaFoundationException.ThrowIfFailed(unlockHr);
             }
         }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -95,6 +95,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `MmException`: error messages now append a human-readable description of the `MmResult` via `waveOutGetErrorText`, e.g. `NoDriver calling waveOutSetVolume: No device driver is present` (#1192)
  * `Id3v2Tag.ReadTag`: no longer throws and catches a `FormatException` for MP3 streams without an ID3v2 tag — the header check now returns `null` directly (#265)
  * `WaveFileReader`: fixed `ArgumentException` reading WAV files whose `fmt` chunk declares more extra (`cbSize`) bytes than the fixed 100-byte buffer holds — the surplus is now discarded instead of throwing (#482)
+ * `MediaFoundationTransform`: cleanup `finally` blocks no longer leak COM objects when `Unlock`/`RemoveAllBuffers` fails — hresults are captured and thrown only after every buffer/sample has been released (#1293)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

Fixes resource leaks in `MediaFoundationTransform` where COM objects could be leaked if `Unlock()` or `RemoveAllBuffers()` calls failed in finally blocks. (As reported in #1293)

The issue: when these methods threw exceptions, the finally block would exit early via the exception, preventing subsequent `ReleaseBoth()` calls from executing. This left COM object references unreleased.

The fix: capture the HRESULT from `Unlock()` and `RemoveAllBuffers()`, defer exception throwing until after all COM objects have been released via `ReleaseBoth()`, then throw the captured errors.

Applied to two methods:
- `ReadFromTransform()`: captures both `Unlock()` and `RemoveAllBuffers()` HRESULTs
- `WriteToTransform()`: captures `Unlock()` HRESULT

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)

## Testing

No testing needed — this is a defensive fix for error paths. The change ensures cleanup always completes before throwing, preventing resource leaks without affecting normal operation.

https://claude.ai/code/session_011GL6Bo6FBMcm1dUqJuuh8f