### PR TITLE
Fix Connector.ConnectTo source-gen COM bug + gate SYSLIB1099 as error

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -56,3 +56,28 @@ dotnet_diagnostic.CA1001.severity = warning
 
 # CA2020: Prevent behavioral change from IntPtr/UIntPtr
 dotnet_diagnostic.CA2020.severity = warning
+
+# --- Rules promoted to ERROR (genuine breakage, not style) ---
+# Source-generated COM interop diagnostics that mean the code is actually
+# broken (fails at runtime or fails to generate), as opposed to the IDE*
+# style rules and the incremental migration recommendations (SYSLIB1054
+# DllImport->LibraryImport, SYSLIB1096 ComImport->GeneratedComInterface)
+# which stay at suggestion. These must never regress silently again.
+
+# SYSLIB1090: Invalid GeneratedComInterfaceAttribute usage
+dotnet_diagnostic.SYSLIB1090.severity = error
+
+# SYSLIB1091: Methods split across partial declarations -> unreliable vtable offsets
+dotnet_diagnostic.SYSLIB1091.severity = error
+
+# SYSLIB1093: COM interface generation analysis failed
+dotnet_diagnostic.SYSLIB1093.severity = error
+
+# SYSLIB1094: Base COM interface failed to generate source
+dotnet_diagnostic.SYSLIB1094.severity = error
+
+# SYSLIB1095: Invalid GeneratedComClassAttribute usage
+dotnet_diagnostic.SYSLIB1095.severity = error
+
+# SYSLIB1099: Marshal COM interop APIs do not support source-generated COM and fail at runtime
+dotnet_diagnostic.SYSLIB1099.severity = error

--- a/NAudio.Wasapi/CoreAudioApi/Connector.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Connector.cs
@@ -22,7 +22,8 @@ namespace NAudio.CoreAudioApi
         /// </summary>
         public void ConnectTo(Connector other)
         {
-            var ptr = Marshal.GetComInterfaceForObject(other.connectorInterface, typeof(IConnector));
+            var ptr = ComActivation.ComWrappers.GetOrCreateComInterfaceForObject(
+                other.connectorInterface, CreateComInterfaceFlags.None);
             try
             {
                 connectorInterface.ConnectTo(ptr);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -102,6 +102,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 
  * `NAudio.Core`, `NAudio.Midi`, and `NAudio.Wasapi` are now `IsAotCompatible=true`. AOT compatibility is enforced at build-time by `NAudioAotSmokeTest`, which fails CI on any new trim or AOT analyzer warning
  * Most COM interop migrated from `[ComImport]` to `[GeneratedComInterface]` / `ComWrappers`. Affected interfaces include the WASAPI / Core Audio activation chain (`IActivateAudioInterfaceCompletionHandler`, `IMMNotificationClient`, `IAudioSessionNotification`, `IAudioSessionEvents`, `IAudioEndpointVolumeCallback`, `IAgileObject`, `IPropertyStore`), the Media Foundation cascade, the DMO interfaces, DirectSound, and the `ComStream` CCW (now source-generated `IStream`)
+ * `Connector.ConnectTo`: fixed a source-generated COM leftover — it now projects the target connector via `ComWrappers` instead of `Marshal.GetComInterfaceForObject`, which is unsupported for `[GeneratedComInterface]` types and would fail at runtime (SYSLIB1099) (#1311)
  * DirectSound P/Invokes migrated to `[LibraryImport]` with `[UnmanagedCallersOnly]` thunks; `BufferDescription` and `BufferCaps` converted from class to struct
  * `AcmDriver` ported from legacy `NativeMethods` to `NativeLibrary`
  * Most `MediaFoundationInterop` blittable P/Invokes migrated to `[LibraryImport]`


### PR DESCRIPTION
## Summary

Fixes #1311. `Connector.ConnectTo` used `Marshal.GetComInterfaceForObject`, which does not support `[GeneratedComInterface]` types and fails at runtime (SYSLIB1099). It was a V2 leftover — the sibling `ConnectedTo` getter in the same class was already migrated to `ComWrappers`. This PR fixes the call and adds a build-time gate so the same class of bug can't ship silently again.

### Changes

* **`NAudio.Wasapi/CoreAudioApi/Connector.cs`** — project the target connector via `ComActivation.ComWrappers.GetOrCreateComInterfaceForObject(..., CreateComInterfaceFlags.None)` instead of `Marshal.GetComInterfaceForObject`. Ref-counting (`Marshal.Release` in `finally`) is unchanged.
* **`.globalconfig`** — promote the source-generated COM interop diagnostics that mean the code is genuinely broken (SYSLIB1090/1091/1093/1094/1095/1099) from suggestion to **error**. These currently have zero occurrences, so the build stays green. The high-volume `IDE*` code-style rules and the incremental-migration recommendations (SYSLIB1054 `DllImport`→`LibraryImport`, SYSLIB1096 `ComImport`→`GeneratedComInterface`) intentionally remain at suggestion.

### Why this slipped through CI

`TreatWarningsAsErrors=true` is set, but `.globalconfig` had a blanket `dotnet_analyzer_diagnostic.severity = suggestion`, which knocked SYSLIB1099 down to a suggestion (IDE-only, never a build warning). The new explicit `error` entry overrides that bulk default for the genuinely runtime-breaking rules.

## Test plan

- [x] All six library projects (`NAudio.Core`, `NAudio.Midi`, `NAudio.Wasapi`, `NAudio.Dmo`, `NAudio.Alsa`, `NAudio.SoundFile`) build clean with the new `error` rules and `TreatWarningsAsErrors=true` (built on Linux via `-p:EnableWindowsTargeting=true`)
- [x] Verified the gate fires: temporarily reintroducing the old `Marshal.GetComInterfaceForObject` call produces `error SYSLIB1099` and `Build FAILED`
- [X] CI build + test on `windows-latest`

https://claude.ai/code/session_01TKfreRPTmtx98EkiiSLiaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKfreRPTmtx98EkiiSLiaS)_