### PR TITLE
Add ChannelMixerSampleProvider for matrix-based channel remixing

### DIFF
--- a/NAudio.Core.Tests/WaveStreams/ChannelMixerSampleProviderTests.cs
+++ b/NAudio.Core.Tests/WaveStreams/ChannelMixerSampleProviderTests.cs
@@ -1,0 +1,138 @@
+using System;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using NUnit.Framework;
+
+namespace NAudio.Core.Tests.WaveStreams
+{
+    [TestFixture]
+    [Category("UnitTest")]
+    public class ChannelMixerSampleProviderTests
+    {
+        [Test]
+        public void NullSourceThrows()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new ChannelMixerSampleProvider(null, ChannelMixMatrix.MonoToStereo));
+        }
+
+        [Test]
+        public void NullMatrixThrows()
+        {
+            var source = new TestSampleProvider(44100, 1);
+            Assert.Throws<ArgumentNullException>(
+                () => new ChannelMixerSampleProvider(source, null));
+        }
+
+        [Test]
+        public void MatrixRowsMustMatchSourceChannels()
+        {
+            // StereoToMono expects 2 input rows, but the source is mono.
+            var source = new TestSampleProvider(44100, 1);
+            Assert.Throws<ArgumentException>(
+                () => new ChannelMixerSampleProvider(source, ChannelMixMatrix.StereoToMono));
+        }
+
+        [Test]
+        public void ZeroOutputColumnsThrows()
+        {
+            var source = new TestSampleProvider(44100, 1);
+            var matrix = new float[1, 0];
+            Assert.Throws<ArgumentException>(
+                () => new ChannelMixerSampleProvider(source, matrix));
+        }
+
+        [Test]
+        public void OutputFormatReflectsMatrixColumns()
+        {
+            var source = new TestSampleProvider(48000, 2);
+            var mixer = new ChannelMixerSampleProvider(source, ChannelMixMatrix.StereoTo5_1);
+            Assert.That(mixer.WaveFormat.Encoding, Is.EqualTo(WaveFormatEncoding.IeeeFloat));
+            Assert.That(mixer.WaveFormat.Channels, Is.EqualTo(6));
+            Assert.That(mixer.WaveFormat.SampleRate, Is.EqualTo(48000));
+        }
+
+        [Test]
+        public void MonoToStereoDuplicatesInput()
+        {
+            var source = new TestSampleProvider(44100, 1) { UseConstValue = true, ConstValue = 3 };
+            var mixer = new ChannelMixerSampleProvider(source, ChannelMixMatrix.MonoToStereo);
+
+            var buffer = new float[10];
+            var read = mixer.Read(buffer.AsSpan());
+
+            Assert.That(read, Is.EqualTo(10));
+            foreach (var sample in buffer)
+            {
+                Assert.That(sample, Is.EqualTo(3f));
+            }
+        }
+
+        [Test]
+        public void StereoToMonoAveragesChannels()
+        {
+            // TestSampleProvider emits a ramp 0,1,2,3,... so frame n has left=2n, right=2n+1.
+            var source = new TestSampleProvider(44100, 2);
+            var mixer = new ChannelMixerSampleProvider(source, ChannelMixMatrix.StereoToMono);
+
+            var buffer = new float[4];
+            var read = mixer.Read(buffer.AsSpan());
+
+            Assert.That(read, Is.EqualTo(4));
+            for (int frame = 0; frame < 4; frame++)
+            {
+                var expected = (2 * frame + (2 * frame + 1)) * 0.5f;
+                Assert.That(buffer[frame], Is.EqualTo(expected), "frame #" + frame);
+            }
+        }
+
+        [Test]
+        public void IdentityMatrixPassesChannelsThrough()
+        {
+            var identity = new float[,]
+            {
+                { 1.0f, 0.0f },
+                { 0.0f, 1.0f },
+            };
+            var source = new TestSampleProvider(44100, 2);
+            var mixer = new ChannelMixerSampleProvider(source, identity);
+
+            var buffer = new float[8];
+            var read = mixer.Read(buffer.AsSpan());
+
+            Assert.That(read, Is.EqualTo(8));
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                Assert.That(buffer[i], Is.EqualTo((float)i), "sample #" + i);
+            }
+        }
+
+        [Test]
+        public void ReadOnlyFillsWholeBlocks()
+        {
+            // Output is stereo (2 columns); a 5-sample buffer holds 2 whole frames + 1 leftover.
+            var source = new TestSampleProvider(44100, 1) { UseConstValue = true, ConstValue = 1 };
+            var mixer = new ChannelMixerSampleProvider(source, ChannelMixMatrix.MonoToStereo);
+
+            var buffer = new float[5];
+            var read = mixer.Read(buffer.AsSpan());
+
+            Assert.That(read, Is.EqualTo(4), "only whole output frames are produced");
+            Assert.That(buffer[4], Is.EqualTo(0f), "trailing partial frame is left untouched");
+        }
+
+        [Test]
+        public void ReadHonoursEndOfStream()
+        {
+            // Mono source with only 3 samples available.
+            var source = new TestSampleProvider(44100, 1, length: 3);
+            var mixer = new ChannelMixerSampleProvider(source, ChannelMixMatrix.MonoToStereo);
+
+            var buffer = new float[20];
+            var read = mixer.Read(buffer.AsSpan());
+
+            // 3 input samples = 3 input frames -> 3 output frames -> 6 output samples.
+            Assert.That(read, Is.EqualTo(6));
+        }
+    }
+}

--- a/NAudio.Core/Wave/SampleProviders/ChannelMixMatrix.cs
+++ b/NAudio.Core/Wave/SampleProviders/ChannelMixMatrix.cs
@@ -1,0 +1,76 @@
+using System;
+
+namespace NAudio.Wave.SampleProviders
+{
+    /// <summary>
+    /// Defines common channel mixing matrices for use with <see cref="ChannelMixerSampleProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// Each matrix has one row per input channel and one column per output channel. The values
+    /// returned are fresh copies, so callers may mutate them without affecting other callers.
+    /// </remarks>
+    public static class ChannelMixMatrix
+    {
+        /// <summary>
+        /// Converts a mono source to a 2-channel source by copying the input to both outputs.
+        /// </summary>
+        public static float[,] MonoToStereo => new float[,]
+        {
+            { 1.0f, 1.0f }
+        };
+
+        /// <summary>
+        /// Converts a 2-channel source to a mono source by mixing the channels together using equal weight.
+        /// </summary>
+        public static float[,] StereoToMono => new float[,]
+        {
+            { 0.5f },
+            { 0.5f },
+        };
+
+        /// <summary>
+        /// Modifies a 2-channel stream by selecting only the first channel. The output is 2-channel.
+        /// </summary>
+        public static float[,] StereoLeft => new float[,]
+        {
+            { 1.0f, 0.0f },
+            { 0.0f, 0.0f },
+        };
+
+        /// <summary>
+        /// Modifies a 2-channel stream by selecting only the second channel. The output is 2-channel.
+        /// </summary>
+        public static float[,] StereoRight => new float[,]
+        {
+            { 0.0f, 0.0f },
+            { 0.0f, 1.0f },
+        };
+
+        /// <summary>
+        /// Converts a 2-channel source to a canonical 5.1 output. The output has 6 channels:
+        /// FrontLeft, FrontRight, Center, Sub, RearLeft, RearRight, in that order.
+        /// </summary>
+        /// <remarks>
+        /// The matrix is designed so that the aggregate output volume from the 6-channel output
+        /// is the same output volume that would've occurred if the original input was applied to
+        /// two channels; if the original audio would've produced 200W of output spread across 2
+        /// speakers, the transformed output would also produce 200W of output, instead spread
+        /// across 6 speakers.
+        ///
+        /// This can be noted by the fact that no column in the matrix sums to 1.0. The loudest
+        /// channel is the center channel, receiving a sum of 0.444 of its inputs (0.222 from left,
+        /// 0.222 from right).
+        ///
+        /// If you would like a matrix that maximizes output volume, scale the matrix by a factor of
+        /// 2.25. One might do this to preserve entropy during processing, with a final gain
+        /// reduction step at the output to maintain intended power output.
+        /// </remarks>
+        public static float[,] StereoTo5_1 => new float[,]
+        {
+            // Output Channels:
+            //FL      FR      Centr   Subwf   RL      RR
+            {0.314f, 0.000f, 0.222f, 0.031f, 0.268f, 0.164f}, // Left  Input
+            {0.000f, 0.314f, 0.222f, 0.031f, 0.164f, 0.268f}  // Right Input
+        };
+    }
+}

--- a/NAudio.Core/Wave/SampleProviders/ChannelMixerSampleProvider.cs
+++ b/NAudio.Core/Wave/SampleProviders/ChannelMixerSampleProvider.cs
@@ -1,0 +1,122 @@
+using System;
+using NAudio.Utils;
+
+namespace NAudio.Wave.SampleProviders
+{
+    /// <summary>
+    /// Produces an output stream by mixing together the channels of a single source using an
+    /// arbitrary mixing matrix, where the number of output channels is determined by the number of
+    /// columns in the matrix.
+    /// </summary>
+    /// <remarks>See <see cref="ChannelMixMatrix"/> for some pre-defined matrices.</remarks>
+    public class ChannelMixerSampleProvider : ISampleProvider
+    {
+        private readonly ISampleProvider source;
+        private readonly float[,] matrix;
+
+        private readonly int inputChannels;
+        private readonly int outputChannels;
+
+        private float[] sourceBuffer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChannelMixerSampleProvider"/> class. The
+        /// number of output channels from the mixer depends on the structure of the provided matrix.
+        /// </summary>
+        /// <param name="source">The provider to read from.</param>
+        /// <param name="matrix">
+        /// Specifies the matrix that converts input samples to output samples. The number of rows in
+        /// the matrix must match the number of input channels from <paramref name="source"/>. The
+        /// number of columns in the matrix determines the number of output channels.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Occurs if any argument is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Occurs if the matrix has no output columns, or if the number of rows in the matrix does
+        /// not match the number of channels in <paramref name="source"/>.
+        /// </exception>
+        public ChannelMixerSampleProvider(ISampleProvider source, float[,] matrix)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (matrix == null)
+                throw new ArgumentNullException(nameof(matrix));
+
+            this.source = source;
+            this.matrix = matrix;
+            this.inputChannels = matrix.GetLength(0);
+            this.outputChannels = matrix.GetLength(1);
+
+            if (this.outputChannels < 1)
+            {
+                throw new ArgumentException(
+                    "The matrix must have at least one output column.",
+                    nameof(matrix)
+                );
+            }
+
+            if (this.inputChannels != source.WaveFormat.Channels)
+            {
+                throw new ArgumentException(
+                    "The number of channels in the source do not match the number of input rows in the matrix.",
+                    nameof(matrix)
+                );
+            }
+
+            this.WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(
+                this.source.WaveFormat.SampleRate,
+                this.outputChannels
+            );
+        }
+
+        /// <summary>
+        /// Gets the WaveFormat of the output from the mixer. The encoding is always <see
+        /// cref="WaveFormatEncoding.IeeeFloat"/>. The number of channels present in the <see
+        /// cref="WaveFormat"/> depends on the channel mixing matrix in use.
+        /// </summary>
+        public WaveFormat WaveFormat { get; }
+
+        /// <summary>
+        /// Reads samples from the mixer into the provided buffer.
+        /// </summary>
+        /// <param name="buffer">A buffer to which to write output samples.</param>
+        /// <returns>The total number of samples that were obtained.</returns>
+        public int Read(Span<float> buffer)
+        {
+            // 1. Figure out how many whole blocks we can produce, then how many source samples that needs.
+            int numBlocks = buffer.Length / this.outputChannels;
+            int numSourceSamples = numBlocks * this.inputChannels;
+
+            this.sourceBuffer = BufferHelpers.Ensure(this.sourceBuffer, numSourceSamples);
+
+            // 2. Read from the source and figure out how much we actually got.
+            numSourceSamples = source.Read(this.sourceBuffer.AsSpan(0, numSourceSamples));
+            numBlocks = numSourceSamples / this.inputChannels;
+
+            for (int i = 0; i < numBlocks; i++)
+            {
+                var sourceBlock = this.sourceBuffer.AsSpan(this.inputChannels * i, this.inputChannels);
+                var destBlock = buffer.Slice(this.outputChannels * i, this.outputChannels);
+
+                TransformBlock(sourceBlock, destBlock);
+            }
+
+            return numBlocks * this.outputChannels;
+        }
+
+        private void TransformBlock(Span<float> sourceBlock, Span<float> destBlock)
+        {
+            for (int outCh = 0; outCh < this.outputChannels; outCh++)
+            {
+                float value = 0;
+
+                for (int inCh = 0; inCh < this.inputChannels; inCh++)
+                {
+                    value += sourceBlock[inCh] * matrix[inCh, outCh];
+                }
+
+                destBlock[outCh] = value;
+            }
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * **ALSA (Linux):** new `NAudio.Alsa` package — `AlsaOut` (`IWavePlayer`) and `AlsaIn` (`IWaveIn`) backed by `libasound`, plus `AlsaDeviceEnumerator`. Linux-only (`[SupportedOSPlatform("linux")]`, AOT-compatible `[LibraryImport]`); reference it explicitly, it is not part of the `NAudio` meta-package (#1182)
  * **Docs:** added `WasapiPlayer` and `WasapiRecorder` tutorials; the legacy `WasapiOut` and `WasapiLoopbackCapture` docs now point to them
  * **Core:** `NAudio.Utils.HResult` gained constants for common COM/storage HRESULTs plus an `IsError` helper (#1288)
+ * **Sample providers:** new `ChannelMixerSampleProvider` remixes a source's channels through an arbitrary mixing matrix (downmix, upmix, weighted routing), with ready-made matrices in `ChannelMixMatrix` (mono↔stereo, stereo→5.1, etc.). Thanks to @antiduh (#982)
 
 #### Demo apps and Test Harnesses
 


### PR DESCRIPTION
## Summary

Brings the contribution from #982 into NAudio 3. `ChannelMixerSampleProvider` remixes a source's channels through an arbitrary mixing matrix — downmix, upmix, or weighted routing — with the output channel count derived from the matrix's column count. `ChannelMixMatrix` provides ready-made matrices (mono↔stereo, stereo left/right isolation, stereo→5.1).

This fills a real gap: `MultiplexingSampleProvider` only does 1:1 channel routing (no weighting/summing), and `PanningSampleProvider`/`StereoToMonoSampleProvider` are fixed-purpose. Nothing else could do a weighted matrix mix.

## What changed vs the original PR #982

The original targeted `release/2.x`, so this is a re-implementation rather than a rebase:

* Migrated to the span-based `int Read(Span<float>)` (NAudio 3's `ISampleProvider`).
* Corrected the namespace to `NAudio.Wave.SampleProviders` (the original used `NAudio.Core.Wave.SampleProviders`).
* Dropped the hand-rolled `FloatSpan` helper in favour of `Span.Slice`.
* Added a guard against a zero-column (zero-output) matrix to avoid a divide-by-zero in `Read`.
* `ChannelMixMatrix` presets now return fresh arrays, so the shared matrices can't be mutated by a caller.
* Fixed the broken `<see cref="ChannelMixer"/>` doc reference and the inaccurate "not 2-dimensional" exception note.

## Test plan

* [x] `dotnet build NAudio.Core.Tests -p:EnableWindowsTargeting=true` — 0 warnings, 0 errors
* [x] 10 new `ChannelMixerSampleProviderTests` pass (arg validation, output format, mono→stereo, stereo→mono averaging, identity pass-through, partial-block reads, end-of-stream)
* [x] Full `NAudio.Core.Tests` suite green (981 passed, 0 failed, 3 pre-existing skips) excluding `IntegrationTest`

Credit: original work by @antiduh (#982), preserved via a `Co-authored-by` trailer.

https://claude.ai/code/session_01PH7JepZzgtGb62T7EmpY3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH7JepZzgtGb62T7EmpY3s)_