### PR TITLE
Document Linux build/test setup and branch-naming convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This file gives AI agents (Claude, etc.) the conventions for contributing to NAu
 ## Orientation
 
 - **NAudio 3 development happens on `main`.** NAudio 2 maintenance happens on `release/2.x`. Default to targeting `main` unless explicitly told otherwise. `main` and `release/*` are protected — all changes go through PRs.
+- **Use descriptive branch names.** Cloud agents are often started on an auto-generated branch (e.g. `claude/loving-galileo-Wpz4o`). Do not push that name to the NAudio repo. Before the first push, rename the branch to something that describes the work, referencing an issue or PR number where relevant — e.g. `feature/channel-mixer-sample-provider`, `fix/1234-wasapi-leak`, `docs/release-strategy`. Keep your existing commits; just move them with `git branch -m <new-name>` before `git push -u origin <new-name>`.
 - **Architecture docs** in [Docs/Architecture/](Docs/Architecture/) are the source of truth for cross-cutting decisions:
   - [ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md) — release/branch/version flow
   - [NAudio3AssemblyLayoutPlan.md](Docs/Architecture/NAudio3AssemblyLayoutPlan.md) — package structure
@@ -27,6 +28,19 @@ When opening a PR (where you have permission), apply one of: `breaking`, `enhanc
 ## Versioning
 
 Package versions are centralised in [Directory.Build.props](Directory.Build.props) as `<VersionPrefix>`. Do **not** add a per-csproj `<Version>` to NAudio packages — they're meant to stay in lockstep. The tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` and are exempt.
+
+## Building & testing on Linux
+
+Some cloud and CI environments start without a .NET SDK on the PATH — this isn't a property of the repo but of the host. The default Anthropic cloud-agent sandbox is one example, and other infrastructure (GitHub Copilot agents, fresh CI runners, etc.) may differ now or in the future. So **first check whether `dotnet` is available**; only install it if it isn't. On Debian/Ubuntu, install .NET 10 via apt: add Microsoft's feed with `wget -q https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O /tmp/ms.deb && sudo dpkg -i /tmp/ms.deb && sudo apt-get update`, then `sudo apt-get install -y dotnet-sdk-10.0` (the SDK builds the `net9.0` libraries fine).
+
+Because `NAudio.Core.Tests` references the `NAudio` meta-package, which pulls in Windows-only projects (`NAudio.WinForms`, `NAudio.Wasapi`), you must pass `-p:EnableWindowsTargeting=true` on Linux or the build fails with `NETSDK1100`. Build and run the cross-platform tests with:
+
+```
+dotnet build NAudio.Core.Tests/NAudio.Core.Tests.csproj -p:EnableWindowsTargeting=true
+dotnet test --project NAudio.Core.Tests/NAudio.Core.Tests.csproj -p:EnableWindowsTargeting=true --filter "TestCategory!=IntegrationTest"
+```
+
+The `TestCategory!=IntegrationTest` filter skips tests needing real audio hardware; note that .NET 10's `dotnet test` wants `--project` rather than a positional path.
 
 ## CI
 


### PR DESCRIPTION
## Summary

Adds two pieces of agent-facing guidance to `CLAUDE.md`:

* **Building & testing on Linux** — a new section covering how to install the .NET 10 SDK on Debian/Ubuntu when `dotnet` isn't already present, and the `-p:EnableWindowsTargeting=true` flag needed so `NAudio.Core.Tests` (which references the Windows-only meta-package) builds on Linux. Includes the build/test commands and the `.NET 10` `--project` gotcha. The opening clarifies this is a property of the host environment (Anthropic cloud sandbox, GitHub Copilot agents, fresh CI runners, etc.), not of the repo, and that agents should check before installing.
* **Use descriptive branch names** — an Orientation bullet asking agents to rename auto-generated cloud branches (e.g. `claude/loving-galileo-Wpz4o`) to something descriptive, referencing an issue/PR number where relevant, before the first push.

Docs-only change; no code or behaviour affected.

## Test plan

* [x] Markdown reviewed — renders as expected, no broken links

https://claude.ai/code/session_01PH7JepZzgtGb62T7EmpY3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH7JepZzgtGb62T7EmpY3s)_