### PR TITLE
Fix WaveViewer rendering for non-16-bit WaveStreams (#564)

### DIFF
--- a/NAudio.WinForms/Gui/WaveViewer.cs
+++ b/NAudio.WinForms/Gui/WaveViewer.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections;
 using System.ComponentModel;
 using System.Drawing;
-using System.Data;
 using System.Windows.Forms;
 using NAudio.Wave;
 
@@ -11,16 +8,19 @@ namespace NAudio.Gui
     /// <summary>
     /// Control for viewing waveforms
     /// </summary>
-    public class WaveViewer : System.Windows.Forms.UserControl
+    public class WaveViewer : UserControl
     {
-        /// <summary> 
+        /// <summary>
         /// Required designer variable.
         /// </summary>
-        private System.ComponentModel.Container components = null;
+        private Container components = null;
         private WaveStream waveStream;
+        private ISampleProvider sampleProvider;
         private int samplesPerPixel = 128;
         private long startPosition;
-        private int bytesPerSample;
+        private int bytesPerSampleFrame;
+        private int channels;
+
         /// <summary>
         /// Creates a new WaveViewer control
         /// </summary>
@@ -28,8 +28,7 @@ namespace NAudio.Gui
         {
             // This call is required by the Windows.Forms Form Designer.
             InitializeComponent();
-            this.DoubleBuffered = true;			
-
+            DoubleBuffered = true;
         }
 
         /// <summary>
@@ -46,9 +45,15 @@ namespace NAudio.Gui
                 waveStream = value;
                 if (waveStream != null)
                 {
-                    bytesPerSample = (waveStream.WaveFormat.BitsPerSample / 8) * waveStream.WaveFormat.Channels;
+                    channels = waveStream.WaveFormat.Channels;
+                    bytesPerSampleFrame = (waveStream.WaveFormat.BitsPerSample / 8) * channels;
+                    sampleProvider = waveStream.ToSampleProvider();
                 }
-                this.Invalidate();
+                else
+                {
+                    sampleProvider = null;
+                }
+                Invalidate();
             }
         }
 
@@ -64,7 +69,7 @@ namespace NAudio.Gui
             set
             {
                 samplesPerPixel = value;
-                this.Invalidate();
+                Invalidate();
             }
         }
 
@@ -83,19 +88,16 @@ namespace NAudio.Gui
             }
         }
 
-        /// <summary> 
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
-        protected override void Dispose( bool disposing )
+        protected override void Dispose(bool disposing)
         {
-            if( disposing )
+            if (disposing)
             {
-                if(components != null)
-                {
-                    components.Dispose();
-                }
+                components?.Dispose();
             }
-            base.Dispose( disposing );
+            base.Dispose(disposing);
         }
 
         /// <summary>
@@ -103,44 +105,42 @@ namespace NAudio.Gui
         /// </summary>
         protected override void OnPaint(PaintEventArgs e)
         {
-            if(waveStream != null)
+            if (sampleProvider != null)
             {
-                waveStream.Position = 0;
-                int bytesRead;
-                byte[] waveData = new byte[samplesPerPixel*bytesPerSample];
-                waveStream.Position = startPosition + (e.ClipRectangle.Left * bytesPerSample * samplesPerPixel);
-                
-                for(float x = e.ClipRectangle.X; x < e.ClipRectangle.Right; x+=1)
+                waveStream.Position = startPosition + (e.ClipRectangle.Left * bytesPerSampleFrame * samplesPerPixel);
+                float[] buffer = new float[samplesPerPixel * channels];
+
+                for (float x = e.ClipRectangle.X; x < e.ClipRectangle.Right; x += 1)
                 {
-                    short low = 0;
-                    short high = 0;
-                    bytesRead = waveStream.Read(waveData, 0, samplesPerPixel * bytesPerSample);
-                    if(bytesRead == 0)
+                    float low = 0;
+                    float high = 0;
+                    int samplesRead = sampleProvider.Read(buffer);
+                    if (samplesRead == 0)
                         break;
-                    for(int n = 0; n < bytesRead; n+=2)
+                    for (int n = 0; n < samplesRead; n++)
                     {
-                        short sample = BitConverter.ToInt16(waveData, n);
-                        if(sample < low) low = sample;
-                        if(sample > high) high = sample;
+                        float sample = buffer[n];
+                        if (sample < low) low = sample;
+                        if (sample > high) high = sample;
                     }
-                    float lowPercent = ((((float) low) - short.MinValue) / ushort.MaxValue);
-                    float highPercent = ((((float) high) - short.MinValue) / ushort.MaxValue);
-                    e.Graphics.DrawLine(Pens.Black,x,this.Height * (1 - lowPercent),x,this.Height * (1 - highPercent));
-                } 
+                    float lowPercent = (low + 1f) / 2f;
+                    float highPercent = (high + 1f) / 2f;
+                    e.Graphics.DrawLine(Pens.Black, x, Height * (1 - lowPercent), x, Height * (1 - highPercent));
+                }
             }
 
-            base.OnPaint (e);
+            base.OnPaint(e);
         }
 
 
         #region Component Designer generated code
-        /// <summary> 
-        /// Required method for Designer support - do not modify 
+        /// <summary>
+        /// Required method for Designer support - do not modify
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent()
         {
-            components = new System.ComponentModel.Container();
+            components = new Container();
         }
         #endregion
     }

--- a/NAudio.WinForms/Gui/WaveViewer.cs
+++ b/NAudio.WinForms/Gui/WaveViewer.cs
@@ -1,6 +1,8 @@
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
+using NAudio.Utils;
 using NAudio.Wave;
 
 namespace NAudio.Gui
@@ -20,6 +22,7 @@ namespace NAudio.Gui
         private long startPosition;
         private int bytesPerSampleFrame;
         private int channels;
+        private float[] readBuffer;
 
         /// <summary>
         /// Creates a new WaveViewer control
@@ -107,19 +110,20 @@ namespace NAudio.Gui
         {
             if (sampleProvider != null)
             {
+                int samplesPerColumn = samplesPerPixel * channels;
                 waveStream.Position = startPosition + (e.ClipRectangle.Left * bytesPerSampleFrame * samplesPerPixel);
-                float[] buffer = new float[samplesPerPixel * channels];
+                readBuffer = BufferHelpers.Ensure(readBuffer, samplesPerColumn);
 
                 for (float x = e.ClipRectangle.X; x < e.ClipRectangle.Right; x += 1)
                 {
                     float low = 0;
                     float high = 0;
-                    int samplesRead = sampleProvider.Read(buffer);
+                    int samplesRead = sampleProvider.Read(readBuffer.AsSpan(0, samplesPerColumn));
                     if (samplesRead == 0)
                         break;
                     for (int n = 0; n < samplesRead; n++)
                     {
-                        float sample = buffer[n];
+                        float sample = readBuffer[n];
                         if (sample < low) low = sample;
                         if (sample > high) high = sample;
                     }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `AudioSessionControl`: now supports multiple registered event clients. `RegisterEventClient` no longer leaks a prior registration, and `UnRegisterEventClient` now honours its `eventClient` argument instead of unregistering whichever handler happened to be stored (#1263)
  * `CueListInterpreter`: fixed returning null for WAV files with cue points but no labels (e.g. unnamed Wavosaur markers); cues are now returned with empty labels (#549)
  * `WaveViewer`: fixed waveform rendering upside-down (#801, #818)
+ * `WaveViewer`: now renders correctly for any source format — the legacy renderer hard-coded a 16-bit PCM byte walk, so feeding it an `AudioFileReader` (or any non-16-bit `WaveStream`) produced a garbled waveform. Rendering now goes through `ToSampleProvider()` and operates on floats (#564)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide via a reentrant lock — fixes process-killing access violations under concurrent ACM access
  * `AcmStream`: fixed double-close in finalizer by zeroing the handle field before close
  * `MediaFoundationReader`: informational source-reader flags (`STREAMTICK`, `NEWSTREAM`, `NativeMediaTypeChanged`, `AllEffectsRemoved`) are now non-fatal instead of aborting reads


### PR DESCRIPTION
## Summary

Fixes #564. The legacy `WaveViewer.OnPaint` hard-coded a 16-bit PCM byte walk (`BitConverter.ToInt16` with `n += 2`), so feeding it an `AudioFileReader` (32-bit IEEE float) reinterpreted the float bytes as Int16 pairs and produced the "block-alignment-off" waveform reported in the issue.

- Rendering now goes through `waveStream.ToSampleProvider()` and operates on floats, so any supported source format (8/16/24/32-bit PCM, 32/64-bit IEEE float) renders correctly.
- The read buffer is hoisted to a field and grown via `BufferHelpers.Ensure`, eliminating the per-paint `float[]` allocation.
- `StartPosition` semantics preserved — the seek is still in source bytes-per-sample-frame.
- Tidy-up: removed unused `System.Collections` / `System.Data` usings, dropped redundant `this.` and fully-qualified type references, renamed the misleading `bytesPerSample` field to `bytesPerSampleFrame` (it was always the block size).

## Test plan

- [x] `dotnet build NAudio.WinForms/NAudio.WinForms.csproj -p:EnableWindowsTargeting=true` — clean, 0 warnings
- [x] `dotnet test --project NAudio.Core.Tests/NAudio.Core.Tests.csproj -p:EnableWindowsTargeting=true --filter "TestCategory!=IntegrationTest"` — 985 passed, 3 skipped
- [ ] Visual smoke test on Windows: drop a `WaveViewer` on a form, point it at an `AudioFileReader` (32-bit float) and a `WaveFileReader` (16-bit PCM), confirm both render correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSD1a6PYEPgfnKjLzZmuEP)_