### PR TITLE
Name background threads in DirectSoundOut and WASAPI classes (#557)

### DIFF
--- a/NAudio.Dmo/DirectSound/DirectSoundOut.cs
+++ b/NAudio.Dmo/DirectSound/DirectSoundOut.cs
@@ -154,6 +154,7 @@ namespace NAudio.Wave
                 // put this back to highest when we are confident we don't have any bugs in the thread proc
                 notifyThread.Priority = ThreadPriority.Normal;
                 notifyThread.IsBackground = true;
+                notifyThread.Name = "NAudio DirectSoundOut Playback";
                 notifyThread.Start();
             }
 

--- a/NAudio.Wasapi/WasapiCapture.cs
+++ b/NAudio.Wasapi/WasapiCapture.cs
@@ -199,6 +199,7 @@ namespace NAudio.CoreAudioApi
             captureThread = new Thread(() => CaptureThread(audioClient))
             {
                 IsBackground = true,
+                Name = "NAudio WasapiCapture Recording",
             };
             captureThread.Start();
         }

--- a/NAudio.Wasapi/WasapiOut.cs
+++ b/NAudio.Wasapi/WasapiOut.cs
@@ -289,9 +289,10 @@ namespace NAudio.Wave
                     playThread = new Thread(PlayThread)
                     {
                         IsBackground = true,
+                        Name = "NAudio WasapiOut Playback",
                     };
                     playbackState = PlaybackState.Playing;
-                    playThread.Start();                    
+                    playThread.Start();
                 }
                 else
                 {

--- a/NAudio.Wasapi/WasapiPlayer.cs
+++ b/NAudio.Wasapi/WasapiPlayer.cs
@@ -373,7 +373,7 @@ namespace NAudio.Wave
                 if (playbackState == PlaybackState.Stopped)
                 {
                     stopEvent.Reset();
-                    playThread = new Thread(PlayThread) { IsBackground = true };
+                    playThread = new Thread(PlayThread) { IsBackground = true, Name = "NAudio WasapiPlayer Playback" };
                     playbackState = PlaybackState.Playing;
                     playThread.Start();
                 }

--- a/NAudio.Wasapi/WasapiRecorder.cs
+++ b/NAudio.Wasapi/WasapiRecorder.cs
@@ -105,7 +105,7 @@ namespace NAudio.Wave
 
             captureState = CaptureState.Starting;
             InitializeAudioClient();
-            captureThread = new Thread(CaptureThread) { IsBackground = true };
+            captureThread = new Thread(CaptureThread) { IsBackground = true, Name = "NAudio WasapiRecorder Capture" };
             captureThread.Start();
         }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -104,6 +104,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `Id3v2Tag.ReadTag`: no longer throws and catches a `FormatException` for MP3 streams without an ID3v2 tag — the header check now returns `null` directly (#265)
  * `WaveFileReader`: fixed `ArgumentException` reading WAV files whose `fmt` chunk declares more extra (`cbSize`) bytes than the fixed 100-byte buffer holds — the surplus is now discarded instead of throwing (#482)
  * `MediaFoundationTransform`: cleanup `finally` blocks no longer leak COM objects when `Unlock`/`RemoveAllBuffers` fails — hresults are captured and thrown only after every buffer/sample has been released (#1293)
+ * Named the background threads created by `DirectSoundOut`, `WasapiOut`, `WasapiCapture`, `WasapiPlayer`, and `WasapiRecorder` so they show meaningful names in debuggers and profilers (#557)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

Sets `Thread.Name` on the playback / capture threads in `DirectSoundOut`, `WasapiOut`, `WasapiCapture`, `WasapiPlayer`, and `WasapiRecorder` so they show meaningful names in debuggers, profilers, and ETW traces. Matches the existing convention already used by `WaveOut` (`"NAudio WaveOut Playback"`) and `WaveIn` (`"NAudio WaveIn Recording"`).

Closes #557.

Thread names assigned:

| Class | Name |
|---|---|
| `DirectSoundOut` | `NAudio DirectSoundOut Playback` |
| `WasapiOut` (legacy) | `NAudio WasapiOut Playback` |
| `WasapiCapture` (legacy) | `NAudio WasapiCapture Recording` |
| `WasapiPlayer` | `NAudio WasapiPlayer Playback` |
| `WasapiRecorder` | `NAudio WasapiRecorder Capture` |

`AlsaPcm` already accepts a `name` parameter, and `WaveOut` / `WaveIn` were already named — no changes needed there.

## Test plan

- [x] `dotnet build NAudio.Dmo/NAudio.Dmo.csproj -p:EnableWindowsTargeting=true` — clean
- [x] `dotnet build NAudio.Wasapi/NAudio.Wasapi.csproj -p:EnableWindowsTargeting=true` — clean
- [ ] CI build + test on `windows-latest`
- [ ] Spot-check in a debugger that the thread shows the expected name during playback / capture

---
_Generated by [Claude Code](https://claude.ai/code/session_019NatduHBdKsnwQrF4t7GB6)_