### PR TITLE
Fix ResamplerDmoStream post-seek hang and EOS tail loss (#607, #608)

### DIFF
--- a/NAudio.Dmo/ResamplerDmoStream.cs
+++ b/NAudio.Dmo/ResamplerDmoStream.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using NAudio.Dmo;
 using NAudio.Utils;
-using System.Diagnostics;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave
@@ -19,6 +18,10 @@ namespace NAudio.Wave
         private DmoResampler dmoResampler;
         private MediaBuffer inputMediaBuffer;
         private byte[] inputBuffer;
+        private byte[] outputStaging;
+        private int outputStagingOffset;
+        private int outputStagingCount;
+        private bool endOfStreamSignaled;
         private long position;
 
         /// <summary>
@@ -42,7 +45,7 @@ namespace NAudio.Wave
             {
                 throw new ArgumentException("Unsupported Output Stream format", nameof(outputFormat));
             }
-         
+
             dmoResampler.MediaObject.SetOutputWaveFormat(0, outputFormat);
             if (inputStream != null)
             {
@@ -87,13 +90,13 @@ namespace NAudio.Wave
         /// </summary>
         public override long Length
         {
-            get 
+            get
             {
                 if (inputStream == null)
                 {
                     throw new InvalidOperationException("Cannot report length if the input was not a WaveStream");
                 }
-                return InputToOutputPosition(inputStream.Length); 
+                return InputToOutputPosition(inputStream.Length);
             }
         }
 
@@ -114,7 +117,14 @@ namespace NAudio.Wave
                 }
                 inputStream.Position = OutputToInputPosition(value);
                 position = InputToOutputPosition(inputStream.Position);
+                // Discontinuity puts the DMO into drain-only mode until its buffered
+                // output is flushed; do that here and discard, so the next Read starts
+                // cleanly from the new input position rather than emitting old-position tail.
                 dmoResampler.MediaObject.Discontinuity(0);
+                DrainAndDiscard();
+                outputStagingOffset = 0;
+                outputStagingCount = 0;
+                endOfStreamSignaled = false;
             }
         }
 
@@ -139,46 +149,103 @@ namespace NAudio.Wave
 
             while (outputBytesProvided < buffer.Length)
             {
-                if (dmoResampler.MediaObject.IsAcceptingData(0))
+                if (outputStagingCount > 0)
                 {
-                    int inputBytesRequired = (int)OutputToInputPosition(buffer.Length - outputBytesProvided);
-                    inputBuffer = BufferHelpers.Ensure(inputBuffer, inputBytesRequired);
-                    int inputBytesRead = inputProvider.Read(inputBuffer.AsSpan(0, inputBytesRequired));
-                    if (inputBytesRead == 0)
-                    {
-                        break;
-                    }
-                    inputMediaBuffer.LoadData(inputBuffer.AsSpan(0, inputBytesRead));
-
-                    dmoResampler.MediaObject.ProcessInput(0, inputMediaBuffer, DmoInputDataBufferFlags.None, 0, 0);
-
-                    outputBuffer.MediaBuffer.SetLength(0);
-                    outputBuffer.StatusFlags = DmoOutputDataBufferFlags.None;
-
-                    // DmoOutputDataBuffer is a struct; copy current state into the cached
-                    // single-element array so ProcessOutput sees the freshly reset flags.
-                    outputBufferArray[0] = outputBuffer;
-                    dmoResampler.MediaObject.ProcessOutput(DmoProcessOutputFlags.None, 1, outputBufferArray);
-
-                    if (outputBuffer.Length == 0)
-                    {
-                        Debug.WriteLine("ResamplerDmoStream.Read: No output data available");
-                        break;
-                    }
-
-                    outputBuffer.RetrieveData(buffer.Slice(outputBytesProvided, outputBuffer.Length));
-                    outputBytesProvided += outputBuffer.Length;
-
-                    Debug.Assert(!outputBuffer.MoreDataAvailable, "have not implemented more data available yet");
+                    outputBytesProvided += ConsumeStaging(buffer.Slice(outputBytesProvided));
+                    continue;
                 }
-                else
+
+                if (DrainOnceIntoStaging() > 0)
                 {
-                    Debug.Assert(false, "have not implemented not accepting logic yet");
+                    continue;
                 }
+
+                if (endOfStreamSignaled)
+                {
+                    break;
+                }
+
+                if (!dmoResampler.MediaObject.IsAcceptingData(0))
+                {
+                    // Defensive break: with the Position setter draining on seek and
+                    // the EOS path handled below, the DMO should always accept input
+                    // here. Spinning would replicate the historic infinite-loop bug.
+                    break;
+                }
+
+                int inputBytesRequired = (int)OutputToInputPosition(buffer.Length - outputBytesProvided);
+                int blockAlign = inputProvider.WaveFormat.BlockAlign;
+                if (inputBytesRequired < blockAlign)
+                {
+                    // For tiny remaining output sizes the block-aligned input request
+                    // can round to zero; upstream would then return 0 and look like EOS.
+                    // Ask for at least one block - any output overrun lives in staging.
+                    inputBytesRequired = blockAlign;
+                }
+                inputBuffer = BufferHelpers.Ensure(inputBuffer, inputBytesRequired);
+                int inputBytesRead = inputProvider.Read(inputBuffer.AsSpan(0, inputBytesRequired));
+                if (inputBytesRead == 0)
+                {
+                    // Upstream EOS - tell the DMO so it flushes the tail samples still
+                    // inside its resampler kernel; the next iteration drains them.
+                    dmoResampler.MediaObject.Discontinuity(0);
+                    endOfStreamSignaled = true;
+                    continue;
+                }
+                inputMediaBuffer.LoadData(inputBuffer.AsSpan(0, inputBytesRead));
+                dmoResampler.MediaObject.ProcessInput(0, inputMediaBuffer, DmoInputDataBufferFlags.None, 0, 0);
             }
 
             position += outputBytesProvided;
             return outputBytesProvided;
+        }
+
+        private int DrainOnceIntoStaging()
+        {
+            outputBuffer.MediaBuffer.SetLength(0);
+            outputBuffer.StatusFlags = DmoOutputDataBufferFlags.None;
+            // DmoOutputDataBuffer is a struct; copy current state into the cached
+            // single-element array so ProcessOutput sees the freshly reset flags.
+            outputBufferArray[0] = outputBuffer;
+            dmoResampler.MediaObject.ProcessOutput(DmoProcessOutputFlags.None, 1, outputBufferArray);
+
+            int produced = outputBuffer.Length;
+            if (produced == 0)
+            {
+                return 0;
+            }
+
+            outputStaging = BufferHelpers.Ensure(outputStaging, produced);
+            outputBuffer.RetrieveData(outputStaging.AsSpan(0, produced));
+            outputStagingOffset = 0;
+            outputStagingCount = produced;
+            return produced;
+        }
+
+        private int ConsumeStaging(Span<byte> destination)
+        {
+            int n = Math.Min(outputStagingCount, destination.Length);
+            if (n == 0)
+            {
+                return 0;
+            }
+            outputStaging.AsSpan(outputStagingOffset, n).CopyTo(destination);
+            outputStagingOffset += n;
+            outputStagingCount -= n;
+            if (outputStagingCount == 0)
+            {
+                outputStagingOffset = 0;
+            }
+            return n;
+        }
+
+        private void DrainAndDiscard()
+        {
+            while (DrainOnceIntoStaging() > 0)
+            {
+                outputStagingOffset = 0;
+                outputStagingCount = 0;
+            }
         }
 
         /// <summary>

--- a/NAudio.Windows.Tests/Dmo/ResamplerDmoStreamTests.cs
+++ b/NAudio.Windows.Tests/Dmo/ResamplerDmoStreamTests.cs
@@ -112,6 +112,69 @@ namespace NAudio.Windows.Tests.Dmo
             }
         }
 
+        [Test]
+        [Category("IntegrationTest")]
+        [CancelAfter(5000)]
+        public void CanReadAfterSeekingBackToStart()
+        {
+            // Regression: setting Position calls Discontinuity which used to wedge the next
+            // Read in an infinite loop because the "not accepting data" branch was a no-op.
+            WaveFormat inputFormat = new WaveFormat(44100, 16, 1);
+            using (WaveStream reader = new NullWaveStream(inputFormat, inputFormat.AverageBytesPerSecond * 5))
+            {
+                using (ResamplerDmoStream resampler = new ResamplerDmoStream(reader, WaveFormat.CreateIeeeFloatWaveFormat(48000, 2)))
+                {
+                    int bytesToRead = resampler.WaveFormat.AverageBytesPerSecond / 100;
+                    byte[] buffer = new byte[bytesToRead];
+
+                    int first = resampler.Read(buffer, 0, bytesToRead);
+                    Assert.That(first, Is.GreaterThan(0), "Bytes Read before seek");
+
+                    resampler.Position = 0;
+                    Assert.That(resampler.Position, Is.EqualTo(0), "Position after seek");
+
+                    int second = resampler.Read(buffer, 0, bytesToRead);
+                    Assert.That(second, Is.GreaterThan(0), "Bytes Read after seek");
+                }
+            }
+        }
+
+        [Test]
+        [Category("IntegrationTest")]
+        public void DrainsTailSamplesAtEndOfStream()
+        {
+            // Regression: at EOS the resampler used to break out of Read without telling
+            // the DMO, losing the ~32-sample tail still inside its quality-30 kernel.
+            WaveFormat inputFormat = new WaveFormat(44100, 16, 2);
+            WaveFormat outputFormat = WaveFormat.CreateIeeeFloatWaveFormat(48000, 2);
+            using (WaveStream reader = new NullWaveStream(inputFormat, inputFormat.AverageBytesPerSecond * 2))
+            {
+                using (ResamplerDmoStream resampler = new ResamplerDmoStream(reader, outputFormat))
+                {
+                    long expected = resampler.Length;
+                    int bytesToRead = outputFormat.AverageBytesPerSecond / 100;
+                    byte[] buffer = new byte[bytesToRead];
+                    long total = 0;
+                    int count;
+                    do
+                    {
+                        count = resampler.Read(buffer, 0, bytesToRead);
+                        total += count;
+                    } while (count > 0);
+
+                    // Allow one output block of slack - the DMO's resampler kernel rounds
+                    // off the very last samples, and one BlockAlign is within that tolerance.
+                    Assert.That(total, Is.GreaterThanOrEqualTo(expected - outputFormat.BlockAlign),
+                        $"Drained total {total} should match expected length {expected} within one BlockAlign");
+                    Assert.That(total, Is.LessThanOrEqualTo(expected + outputFormat.BlockAlign),
+                        $"Drained total {total} should not exceed expected length {expected} by more than one BlockAlign");
+
+                    int afterEos = resampler.Read(buffer, 0, bytesToRead);
+                    Assert.That(afterEos, Is.EqualTo(0), "Reads after EOS should return 0");
+                }
+            }
+        }
+
         /*[Test]
         public void CanResampleToWav()
         {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -104,6 +104,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `Id3v2Tag.ReadTag`: no longer throws and catches a `FormatException` for MP3 streams without an ID3v2 tag — the header check now returns `null` directly (#265)
  * `WaveFileReader`: fixed `ArgumentException` reading WAV files whose `fmt` chunk declares more extra (`cbSize`) bytes than the fixed 100-byte buffer holds — the surplus is now discarded instead of throwing (#482)
  * `MediaFoundationTransform`: cleanup `finally` blocks no longer leak COM objects when `Unlock`/`RemoveAllBuffers` fails — hresults are captured and thrown only after every buffer/sample has been released (#1293)
+ * `ResamplerDmoStream`: fixed infinite loop on `Read` after setting `Position`, and the loss of the resampler kernel's tail samples (~32 at the default quality of 30) when the input reaches end-of-stream. The DMO is now drained via `ProcessOutput` after `Discontinuity` — on seek the drained bytes are discarded so playback resumes from the new position, on EOS they're returned to the caller and subsequent reads return 0 cleanly (#607, #608)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
## Summary

Fixes two longstanding `ResamplerDmoStream` bugs that share the same root cause — a missing `ProcessOutput`-only drain path. `Read()` had three unimplemented branches that fell through to `Debug.Assert(false, "have not implemented ...")` or a silent `break`:

- **#607** — After `Position` setter called `Discontinuity(0)`, the DMO refused new input until its output was drained. The `!IsAcceptingData` branch was a no-op, so the next `Read` spun forever in Release builds.
- **#608** — When the upstream provider hit EOS, `Read` just broke without telling the DMO. The ~32 tail samples buffered inside the quality-30 resampler kernel were discarded.
- A latent `Debug.Assert(!outputBuffer.MoreDataAvailable, ...)` that would have fired if `ProcessOutput` ever returned more bytes than fit in the caller's span.

## Fix

Refactored `Read` around a managed staging buffer mirroring `MediaFoundationTransform`'s pattern:

- `DrainOnceIntoStaging()` calls `ProcessOutput` and copies the result into a staging `byte[]`, so partial reads work when the DMO produces more than the caller's span holds. Carryover survives across `Read` calls.
- The `Read` loop drains staging first, then pulls from the DMO, only feeding input when the DMO has nothing to give. `MoreDataAvailable` is handled implicitly by iteration.
- Upstream EOS calls `Discontinuity(0)` once and sets `endOfStreamSignaled`; subsequent iterations drain the kernel tail and return it to the caller. Further `Read`s return 0 cleanly.
- `Position` setter calls `Discontinuity(0)` + `DrainAndDiscard()` inside the setter so old-position audio doesn't leak into post-seek reads, and clears the EOS flag and staging buffer.

All three `Debug.Assert(false, ...)` sites are gone; `using System.Diagnostics;` is no longer needed.

## Test plan

- [x] `dotnet build NAudio.Dmo/NAudio.Dmo.csproj -p:EnableWindowsTargeting=true` — clean on Linux
- [x] `dotnet build NAudio.Windows.Tests/NAudio.Windows.Tests.csproj -p:EnableWindowsTargeting=true` — clean on Linux
- [x] `dotnet test --project NAudio.Core.Tests/NAudio.Core.Tests.csproj -p:EnableWindowsTargeting=true --filter "TestCategory!=IntegrationTest"` — 988 cross-platform tests pass, no regressions
- [x] New integration tests pass locally on Windows (reporter validated):
  - `CanReadAfterSeekingBackToStart` — read, seek to 0, read again; `[CancelAfter(5000)]` catches the historic infinite loop
  - `DrainsTailSamplesAtEndOfStream` — drain to EOS, assert total within one `BlockAlign` of `resampler.Length`, and that further reads return 0
- [ ] CI build + test on `windows-latest`

Closes #607, closes #608.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGzUXN5fG7fPXEWchWrkte)_