### PR TITLE
V3: Update `Spectre.Console` dependency of `NAudioConsoleTest`

### DIFF
--- a/NAudioConsoleTest/NAudioConsoleTest.csproj
+++ b/NAudioConsoleTest/NAudioConsoleTest.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

While I was working on my PR #1288, I used the `NAudioConsoleTest` app to test the wrapper. 

Sometimes, the below error was popping up to the environment and caused the build to fail:

`error CS8002: Referenced assembly 'Spectre.Console, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name.`

This PR just updates the dependency to 0.55.2 which I tested and does not get the above error anymore.

This was also caused even by a simple `dotnet run`.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [X] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

No testing needed, this is just a dep update of the `NAudioConsoleTest` project.
