### PR TITLE
V3: Additional memory leak fixes on `MediaFoundationReader` and `MediaFoundationEncoder`

### DIFF
--- a/NAudio.Wasapi/MediaFoundationEncoder.cs
+++ b/NAudio.Wasapi/MediaFoundationEncoder.cs
@@ -428,11 +428,14 @@ namespace NAudio.Wave
 
         private unsafe long ConvertOneBuffer(IMFSinkWriter writer, int streamIndex, IWaveProvider inputSource, long position, int bufferSize)
         {
+            IMFSample sample = null;
             long durationConverted = 0;
+            IntPtr samplePtr = IntPtr.Zero;
+            
             var (bufferPtr, buffer) = MediaFoundationApi.CreateMemoryBuffer(bufferSize);
-            var (samplePtr, sample) = MediaFoundationApi.CreateSample();
             try
             {
+                (samplePtr, sample) = MediaFoundationApi.CreateSample();
                 MediaFoundationException.ThrowIfFailed(sample.AddBuffer(bufferPtr));
 
                 MediaFoundationException.ThrowIfFailed(buffer.Lock(out var ptr, out int maxLength, out int currentLength));

--- a/NAudio.Wasapi/MediaFoundationReader.cs
+++ b/NAudio.Wasapi/MediaFoundationReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -339,12 +339,16 @@ namespace NAudio.Wave
                 }
                 finally
                 {
+                    // Capture the hresult but defer throwing until every COM object has been
+                    // released, otherwise a failed Unlock would leak the buffer and the sample.
+                    int unlockHr = 0;
                     if (pBuffer != null && bufferLocked)
                     {
-                        MediaFoundationException.ThrowIfFailed(pBuffer.Unlock());
+                        unlockHr = pBuffer.Unlock();
                     }
                     ComActivation.ReleaseBoth(pBuffer, pBufferPtr);
                     ComActivation.ReleaseBoth(pSample, pSamplePtr);
+                    MediaFoundationException.ThrowIfFailed(unlockHr);
                 }
             }
             position += bytesWritten;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### Unreleased
+﻿### Unreleased
 
 <!--
 Bullets land here as PRs merge. The maintainer renames this section to
@@ -77,8 +77,10 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide via a reentrant lock — fixes process-killing access violations under concurrent ACM access
  * `AcmStream`: fixed double-close in finalizer by zeroing the handle field before close
  * `MediaFoundationReader`: informational source-reader flags (`STREAMTICK`, `NEWSTREAM`, `NativeMediaTypeChanged`, `AllEffectsRemoved`) are now non-fatal instead of aborting reads
+ * `MediaFoundationReader`: cleanup `finally` block on `Read` no longer leaks COM objects when `Unlock` fails — the hresult is captured and thrown only after both the buffer and the sample have been freed.
  * `MediaFoundationReader.Reposition`: fixed using a stale field instead of the parameter (seeks would default to stream start)
  * `MediaFoundationEncoder`: unselected `MediaType` instances are now disposed to prevent finalizer-thread COM ref leaks
+ * `MediaFoundationEncoder`: In the `ConvertOneBuffer` method, there was a small possibility that if the sample creation was failed, the previously allocated buffer COM object would have been leaked.
  * `StreamMediaFoundationReader` and stream-based `MediaFoundationEncoder` encoding now use a direct managed `IMFByteStream` wrapper instead of the `IStream`→`IMFByteStream` shim, improving reliability of reading and encoding audio through .NET streams (#1288)
  * `Mp3FileReader`: fixed false sample-rate-change errors near end of file
  * `WaveFormat.Serialize`: PCM formats now write the canonical 16-byte `fmt ` chunk (no `cbSize` field) instead of 18 bytes, matching the `PCMWAVEFORMAT` layout (#934, #1098)


### PR DESCRIPTION
## Summary

This is a trivial PR fixing some obscure memory leaks that could occur if exceptions were thrown at particular states.

The fixes are two:

- Media Foundation Reader `Read` call: If the buffer's `Unlock` method throws an exception, it could cause a memory leak leaking both the held buffer and the sample.

- Media Foundation Encoder `ConvertOneBuffer` call: The previous code created both the sample and the buffer outside the `try` block. If the sample creation failed, that would leak the previously allocated buffer.

## Release notes

- [X] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

No testing required. 

This is just a PR that does memory reliability fixes on the wrappers.