### PR TITLE
V3: Fix `IMFByteStream` wrapper invalidly calling `FindFormat` on write mode

### DIFF
--- a/NAudio.Wasapi/MediaFoundation/MFByteStreamFromStream.cs
+++ b/NAudio.Wasapi/MediaFoundation/MFByteStreamFromStream.cs
@@ -26,18 +26,21 @@ namespace NAudio.MediaFoundation
         private IntPtr nativeAttributesPtr;
         private IMFAttributes nativeAttributesRcw;
 
-        public unsafe MfByteStreamFromStream(Stream stream)
+        public unsafe MfByteStreamFromStream(Stream stream, bool readMode = true)
         {
             this.stream = stream;
             try { wrapperInitialPosition = stream.Position; } catch { wrapperInitialPosition = 0; }
             (nativeAttributesPtr, nativeAttributesRcw) = MediaFoundationApi.CreateAttributes(1);
-            // The only way for the below to throw an exception is a critical one,
-            // which eitherwise will terminate soon the process, so we are OK and we do not need EH for this.
-            AudioFileFormat fmt = new AudioFileFormatFinder().AddDefaultFileFormats().FindFormat(this.stream);
-            if (fmt is not null)
+            if (readMode)
             {
-                Guid t = MfByteStreamAttributes.ContentType;
-                nativeAttributesRcw.SetString(t, fmt.MimeType);
+                // The only way for the below to throw an exception is a critical one,
+                // which eitherwise will terminate soon the process, so we are OK and we do not need EH for this.
+                AudioFileFormat fmt = new AudioFileFormatFinder().AddDefaultFileFormats().FindFormat(this.stream);
+                if (fmt is not null)
+                {
+                    Guid t = MfByteStreamAttributes.ContentType;
+                    nativeAttributesRcw.SetString(t, fmt.MimeType);
+                }
             }
         }
 

--- a/NAudio.Wasapi/MediaFoundation/MFByteStreamFromStream.cs
+++ b/NAudio.Wasapi/MediaFoundation/MFByteStreamFromStream.cs
@@ -26,12 +26,12 @@ namespace NAudio.MediaFoundation
         private IntPtr nativeAttributesPtr;
         private IMFAttributes nativeAttributesRcw;
 
-        public unsafe MfByteStreamFromStream(Stream stream, bool readMode = true)
+        public MfByteStreamFromStream(Stream stream, bool detectContentType = true)
         {
             this.stream = stream;
             try { wrapperInitialPosition = stream.Position; } catch { wrapperInitialPosition = 0; }
             (nativeAttributesPtr, nativeAttributesRcw) = MediaFoundationApi.CreateAttributes(1);
-            if (readMode)
+            if (detectContentType)
             {
                 // The only way for the below to throw an exception is a critical one,
                 // which eitherwise will terminate soon the process, so we are OK and we do not need EH for this.

--- a/NAudio.Wasapi/MediaFoundationEncoder.cs
+++ b/NAudio.Wasapi/MediaFoundationEncoder.cs
@@ -329,7 +329,7 @@ namespace NAudio.Wave
             }
 
             using var inputMediaType = new MediaType(inputSource.WaveFormat);
-            using var wrapper = new MfByteStreamFromStream(outputStream);
+            using var wrapper = new MfByteStreamFromStream(outputStream, false);
             var writer = CreateSinkWriter(wrapper, transcodeContainerType);
             try
             {


### PR DESCRIPTION
## Summary

This PR fixes the byte stream wrapper that was calling to find the format of a stream that was intended for writing.

The fix is to add a boolean parameter to the wrapper that controls whether to call the find format method and by default it has the `true` value which indicates that the wrapper is to be used by readers.

The current code could cause the encoder to fail, if someone was passing a write-only stream to `EncodeXXXX` methods.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [X] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

This does not possibly need a release notes entry since the byte stream wrapper is a new feature for V3.
But if you feel that this does need an entry, feel free to add one later.

## Testing

This was actually something slipped through the tests - passing a writeable stream only could cause the wrapper to fail.

It slipped because the tests are using `MemoryStream`, which it's `CanRead` property has the value `true`.
