### PR TITLE
Add DocFX documentation site published to GitHub Pages

### DIFF
--- a/.github/scripts/check-docs-toc.sh
+++ b/.github/scripts/check-docs-toc.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verifies every tutorial in Docs/ is referenced by Docs/toc.yml, so that a
+# newly added tutorial can't silently become an orphan page (DocFX still
+# builds it and it's reachable by URL/search, but it's missing from the
+# sidebar navigation, and --warningsAsErrors does not catch that).
+#
+# Docs/Architecture/ is contributor-facing and excluded from the docs site,
+# so it is excluded from this check too.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+docs_dir="$repo_root/Docs"
+toc="$docs_dir/toc.yml"
+
+# Tutorial files: *.md directly under Docs/ (not recursing into Architecture/).
+mapfile -t tutorials < <(find "$docs_dir" -maxdepth 1 -name '*.md' -printf '%f\n' | sort)
+
+# href targets referenced by the TOC.
+mapfile -t referenced < <(grep -oE 'href:[[:space:]]*[^[:space:]]+\.md' "$toc" \
+  | sed -E 's/href:[[:space:]]*//' | sort -u)
+
+status=0
+
+for md in "${tutorials[@]}"; do
+  if ! printf '%s\n' "${referenced[@]}" | grep -qxF "$md"; then
+    echo "::error::Docs/$md is not listed in Docs/toc.yml"
+    status=1
+  fi
+done
+
+for ref in "${referenced[@]}"; do
+  if [[ ! -f "$docs_dir/$ref" ]]; then
+    echo "::error::Docs/toc.yml references Docs/$ref which does not exist"
+    status=1
+  fi
+done
+
+if [[ $status -ne 0 ]]; then
+  echo ""
+  echo "Update Docs/toc.yml: add entries for new tutorials (or remove stale ones)."
+  exit 1
+fi
+
+echo "All ${#tutorials[@]} tutorials in Docs/ are referenced by Docs/toc.yml."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         run: dotnet tool update -g docfx
 
       - name: Build docs
-        run: docfx docfx.json
+        run: docfx docfx.json --warningsAsErrors
 
       - name: Upload Pages artifact
         # Only needed for the deploy job, which only runs on main.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Docs/**'
+      - 'NAudio.*/**/*.cs'
+      - 'docfx.json'
+      - 'toc.yml'
+      - 'index.md'
+      - 'api/index.md'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'Docs/**'
+      - 'docfx.json'
+      - 'toc.yml'
+      - 'index.md'
+      - 'api/index.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do not cancel in-progress runs.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    # windows-latest so the Windows-only projects (WASAPI, ASIO, WinMM, DMO,
+    # WinForms) generate API metadata without EnableWindowsTargeting shims.
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install DocFX
+        run: dotnet tool update -g docfx
+
+      - name: Build docs
+        run: docfx docfx.json
+
+      - name: Upload Pages artifact
+        # Only needed for the deploy job, which only runs on main.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    # Publish to GitHub Pages only from main.
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
       - 'index.md'
       - 'api/index.md'
       - '.github/workflows/docs.yml'
+      - '.github/scripts/check-docs-toc.sh'
   pull_request:
     paths:
       - 'Docs/**'
@@ -19,6 +20,7 @@ on:
       - 'index.md'
       - 'api/index.md'
       - '.github/workflows/docs.yml'
+      - '.github/scripts/check-docs-toc.sh'
   workflow_dispatch:
 
 # Allow only one concurrent deployment, skipping runs queued between the run
@@ -36,6 +38,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check every tutorial is in the TOC
+        shell: bash
+        run: ./.github/scripts/check-docs-toc.sh
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ MfStressTest/dumps/
 # procdump.exe (used by MfStressTest watchdog) writes a 0-byte log to the
 # target process's working directory each time it captures a dump.
 myeasylog.log
+# DocFX generated output
+_site/
+api/*.yml
+api/.manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,10 @@ When you make a **user-visible change** — new public API, behaviour change, bu
 
 **Skip the release-notes entry only for:** purely internal refactors, test-only changes, dependency bumps with no observable effect, docs/comment fixes. If unsure whether a change is user-visible, **add the entry** and let the maintainer remove it if not needed.
 
+## Documentation site
+
+Tutorials live in [Docs/](Docs/) as Markdown and are published to a DocFX site on GitHub Pages by [.github/workflows/docs.yml](.github/workflows/docs.yml); the API reference is generated automatically from the source XML doc comments. When you **add a new tutorial**, also add an entry for it in [Docs/toc.yml](Docs/toc.yml) so it appears in the sidebar — a CI check fails the build if any `Docs/*.md` is missing from the TOC (an unlisted page still builds but is orphaned from the navigation). Internal `Docs/Architecture/` docs are excluded from the published site.
+
 ## PR labelling
 
 When opening a PR (where you have permission), apply one of: `breaking`, `enhancement`, `bug`, `documentation`. These feed the auto-generated changelog at release time. Use `release-notes-skip` for PRs that should not appear in the changelog at all.

--- a/Docs/AsioMigration.md
+++ b/Docs/AsioMigration.md
@@ -193,6 +193,6 @@ A small number of behaviors don't have a 1:1 mapping:
 
 ## Breaking changes within `AsioOut` itself
 
-`AsioOut`'s public surface is byte-for-byte identical to NAudio 2.x — there are no breaking changes. A snapshot test in `NAudioTests` ([AsioOutPublicSurfaceTests](../NAudioTests/Asio/AsioOutPublicSurfaceTests.cs)) pins this; if a future change breaks the surface, the test catches it.
+`AsioOut`'s public surface is byte-for-byte identical to NAudio 2.x — there are no breaking changes. A snapshot test in `NAudio.Windows.Tests` ([AsioOutPublicSurfaceTests](https://github.com/naudio/NAudio/blob/main/NAudio.Windows.Tests/Asio/AsioOutPublicSurfaceTests.cs)) pins this; if a future change breaks the surface, the test catches it.
 
 The internal implementation routes through `AsioDevice`, picking up the F1 (auto-stop deadlock) and F2 (dispose drain) fixes, but the contract you call against is unchanged.

--- a/Docs/PlayAudioFileLinuxAlsa.md
+++ b/Docs/PlayAudioFileLinuxAlsa.md
@@ -50,7 +50,7 @@ foreach (var device in AlsaDeviceEnumerator.GetPlaybackDevices())
 
 ### Playing compressed formats
 
-The cross-platform [`NAudio.SoundFile`](../NAudio.SoundFile/README.md)
+The cross-platform [`NAudio.SoundFile`](https://github.com/naudio/NAudio/blob/main/NAudio.SoundFile/README.md)
 package is the Linux equivalent of `MediaFoundationReader`: its
 `SoundFileReader` (a `WaveStream` / `ISampleProvider` over libsndfile)
 decodes FLAC, Ogg-Vorbis, Opus and MP3. It needs a system libsndfile

--- a/Docs/toc.yml
+++ b/Docs/toc.yml
@@ -1,0 +1,100 @@
+- name: Playback
+  items:
+    - name: Play an audio file (console)
+      href: PlayAudioFileConsoleApp.md
+    - name: Play an audio file (WinForms)
+      href: PlayAudioFileWinForms.md
+    - name: Play audio from a URL
+      href: PlayAudioFromUrl.md
+    - name: Choose an output device type
+      href: OutputDeviceTypes.md
+    - name: Enumerate and select output devices
+      href: EnumerateOutputDevices.md
+    - name: Play audio with WasapiPlayer (recommended)
+      href: WasapiPlayer.md
+    - name: Configure a WasapiOut device (legacy)
+      href: WasapiOut.md
+    - name: Handling playback stopped
+      href: PlaybackStopped.md
+    - name: WaveStream, IWavePlayer and ISampleProvider
+      href: WaveProviders.md
+    - name: Play audio with ASIO
+      href: AsioPlayback.md
+    - name: Migrating from AsioOut to AsioDevice
+      href: AsioMigration.md
+- name: Working with codecs
+  items:
+    - name: Convert MP3 to WAV
+      href: ConvertMp3ToWav.md
+    - name: Encode with MediaFoundationEncoder
+      href: MediaFoundationEncoder.md
+    - name: Enumerate Media Foundation Transforms
+      href: EnumerateMediaFoundationTransforms.md
+    - name: Enumerate ACM codecs
+      href: EnumerateAcmDrivers.md
+- name: Working with audio files
+  items:
+    - name: Mix two audio files to WAV
+      href: MixTwoAudioFilesToWav.md
+- name: Manipulating audio
+  items:
+    - name: Convert between mono and stereo
+      href: ConvertBetweenStereoAndMono.md
+    - name: Concatenating audio
+      href: ConcatenatingAudio.md
+    - name: Skip and take with OffsetSampleProvider
+      href: OffsetSampleProvider.md
+    - name: Resample audio
+      href: Resampling.md
+    - name: Using RawSourceWaveStream
+      href: RawSourceWaveStream.md
+    - name: Pitch shifting with SmbPitchShiftingSampleProvider
+      href: SmbPitchShiftingSampleProvider.md
+    - name: Fade audio in and out
+      href: FadeInOutSampleProvider.md
+    - name: Apply audio effects with NAudio.Effects
+      href: AudioEffects.md
+- name: Generating audio
+  items:
+    - name: Play sine waves and other signals
+      href: PlaySineWave.md
+- name: Recording
+  items:
+    - name: Record a WAV file (WinForms)
+      href: RecordWavFileWinFormsWaveIn.md
+    - name: Record with WasapiRecorder (recommended)
+      href: WasapiRecorder.md
+    - name: Capture system audio with WasapiLoopbackCapture (legacy)
+      href: WasapiLoopbackCapture.md
+    - name: Record audio with ASIO
+      href: AsioRecording.md
+    - name: Duplex processing with ASIO
+      href: AsioDuplex.md
+    - name: ASIO channel mapping
+      href: AsioChannelMapping.md
+    - name: Handling ASIO driver resets
+      href: AsioDriverReset.md
+- name: Visualization
+  items:
+    - name: Waveform rendering to PNG
+      href: WaveFormRendering.md
+    - name: Implement a recording level meter
+      href: RecordingLevelMeter.md
+- name: MIDI
+  items:
+    - name: Sending and receiving MIDI events
+      href: MidiInAndOut.md
+    - name: Exploring MIDI files with MidiFile
+      href: MidiFile.md
+    - name: MIDI event types
+      href: MidiEvent.md
+- name: Cross-platform & Linux
+  items:
+    - name: Cross-platform audio files with SoundFile
+      href: CrossPlatformAudioFilesWithSoundFile.md
+    - name: Play an audio file on Linux (ALSA)
+      href: PlayAudioFileLinuxAlsa.md
+    - name: Record an audio file on Linux (ALSA)
+      href: RecordAudioFileLinuxAlsa.md
+    - name: Validating ALSA on Linux
+      href: ValidatingAlsaOnLinux.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -144,6 +144,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * Migrated to the modern `.slnx` solution format
  * Renamed `license.txt` to `LICENSE` for GitHub license detection; refreshed copyright year to 2008–2026
  * Added per-package `<Description>` metadata to every shipping NAudio NuGet package so each clearly identifies itself as part of the NAudio family
+ * Added a DocFX documentation site (tutorials + API reference) published to GitHub Pages, built automatically from `Docs/` and the source XML comments
 
 ### 2.3.0 (12 Mar 2026)
 

--- a/api/index.md
+++ b/api/index.md
@@ -1,0 +1,22 @@
+# API Reference
+
+This section is the full NAudio class library reference, generated automatically from the source code XML documentation comments. It always reflects the latest code on the `main` branch.
+
+Use the table of contents on the left to browse namespaces, or the search box at the top of the page to jump straight to a type.
+
+## Packages covered
+
+| Package | Description |
+| --- | --- |
+| `NAudio.Core` | Cross-platform core: wave streams, sample providers, file readers/writers, DSP. |
+| `NAudio.WinMM` | Windows Multimedia (waveOut/waveIn, MME, ACM). |
+| `NAudio.Wasapi` | Windows Audio Session API (WASAPI) and Media Foundation. |
+| `NAudio.Asio` | ASIO low-latency playback and recording. |
+| `NAudio.Dmo` | DirectX Media Objects. |
+| `NAudio.WinForms` | Windows Forms helper controls. |
+| `NAudio.Midi` | MIDI file and device support. |
+| `NAudio.SoundFile` | Cross-platform file I/O via libsndfile. |
+| `NAudio.Extras` | Additional utilities and effects. |
+
+> [!NOTE]
+> The `NAudio` meta-package simply re-exports the packages above, so its types appear under their originating namespaces.

--- a/docfx.json
+++ b/docfx.json
@@ -81,7 +81,8 @@
     "output": "_site",
     "template": [
       "default",
-      "modern"
+      "modern",
+      "templates/naudio"
     ],
     "globalMetadata": {
       "_appName": "NAudio",

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": ".",
+          "files": [
+            "NAudio.Core/NAudio.Core.csproj",
+            "NAudio.Midi/NAudio.Midi.csproj",
+            "NAudio.SoundFile/NAudio.SoundFile.csproj",
+            "NAudio.Alsa/NAudio.Alsa.csproj",
+            "NAudio.Extras/NAudio.Extras.csproj"
+          ]
+        }
+      ],
+      "dest": "api",
+      "namespaceLayout": "nested",
+      "memberLayout": "samePage",
+      "properties": {
+        "EnableWindowsTargeting": "true",
+        "TargetFramework": "net9.0"
+      }
+    },
+    {
+      "src": [
+        {
+          "src": ".",
+          "files": [
+            "NAudio.Asio/NAudio.Asio.csproj",
+            "NAudio.WinMM/NAudio.WinMM.csproj",
+            "NAudio.Dmo/NAudio.Dmo.csproj",
+            "NAudio.WinForms/NAudio.WinForms.csproj",
+            "NAudio.Wasapi/NAudio.Wasapi.csproj"
+          ]
+        }
+      ],
+      "dest": "api",
+      "namespaceLayout": "nested",
+      "memberLayout": "samePage",
+      "properties": {
+        "EnableWindowsTargeting": "true"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "src": "api",
+        "dest": "api"
+      },
+      {
+        "files": [
+          "toc.yml",
+          "index.md"
+        ]
+      },
+      {
+        "files": [
+          "**/*.md",
+          "**/toc.yml"
+        ],
+        "exclude": [
+          "Architecture/**"
+        ],
+        "src": "Docs",
+        "dest": "docs"
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "naudio-logo.png",
+          "naudio-icon.png"
+        ]
+      }
+    ],
+    "output": "_site",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appName": "NAudio",
+      "_appTitle": "NAudio",
+      "_appLogoPath": "naudio-icon.png",
+      "_appFaviconPath": "naudio-icon.png",
+      "_enableSearch": true,
+      "_disableContribution": false,
+      "_gitContribute": {
+        "repo": "https://github.com/naudio/NAudio",
+        "branch": "main"
+      }
+    }
+  }
+}

--- a/index.md
+++ b/index.md
@@ -27,12 +27,12 @@ Playing an audio file is just a few lines:
 using NAudio.Wave;
 
 using var audioFile = new AudioFileReader("myfile.mp3");
-using var outputDevice = new WaveOutEvent();
-outputDevice.Init(audioFile);
-outputDevice.Play();
-while (outputDevice.PlaybackState == PlaybackState.Playing)
+using var player = new WasapiPlayerBuilder().Build();
+player.Init(audioFile);
+player.Play();
+while (player.PlaybackState == PlaybackState.Playing)
 {
-    Thread.Sleep(1000);
+    Thread.Sleep(500);
 }
 ```
 

--- a/index.md
+++ b/index.md
@@ -1,0 +1,39 @@
+---
+_layout: landing
+---
+
+# NAudio
+
+NAudio is an open source .NET audio library written by [Mark Heath](https://markheath.net). It provides a comprehensive set of classes for playing, recording, converting and manipulating audio in .NET applications.
+
+## Get started
+
+- **[Tutorials](Docs/PlayAudioFileConsoleApp.md)** — task-focused how-to guides covering playback, recording, codecs, MIDI, visualisation and more.
+- **[API Reference](api/index.md)** — the full class library reference, generated from the source XML documentation.
+- **[NAudio on NuGet](https://www.nuget.org/packages/NAudio/)** — install the package into your project.
+- **[Source on GitHub](https://github.com/naudio/NAudio)** — browse the code, demos and issues.
+
+## Installation
+
+```
+dotnet add package NAudio
+```
+
+## A quick example
+
+Playing an audio file is just a few lines:
+
+```csharp
+using NAudio.Wave;
+
+using var audioFile = new AudioFileReader("myfile.mp3");
+using var outputDevice = new WaveOutEvent();
+outputDevice.Init(audioFile);
+outputDevice.Play();
+while (outputDevice.PlaybackState == PlaybackState.Playing)
+{
+    Thread.Sleep(1000);
+}
+```
+
+See the [tutorials](Docs/PlayAudioFileConsoleApp.md) for many more worked examples.

--- a/templates/naudio/public/main.css
+++ b/templates/naudio/public/main.css
@@ -1,0 +1,9 @@
+/* NAudio DocFX customizations. */
+
+/* Constrain the navbar logo so it fits within the header bar, with a small
+   gap before the "NAudio" wordmark. Interim sizing until an SVG logo lands. */
+#logo {
+  max-height: 1.75rem;
+  width: auto;
+  margin-right: 0.5rem;
+}

--- a/toc.yml
+++ b/toc.yml
@@ -1,0 +1,6 @@
+- name: Home
+  href: index.md
+- name: Tutorials
+  href: Docs/
+- name: API Reference
+  href: api/


### PR DESCRIPTION
## What

Adds a [DocFX](https://dotnet.github.io/docfx/) documentation site that combines the existing `Docs/` tutorials with an API reference generated from the source XML doc comments, published to GitHub Pages via GitHub Actions.

## Why

The tutorials in `Docs/` are currently only reachable by browsing the repo, and the XML doc comments (already generated for every library package) weren't surfaced anywhere. DocFX is the .NET-idiomatic choice: one tool renders both the conceptual docs and the API reference, with minimal ongoing maintenance — new tutorials and API changes publish automatically.

## Changes

- **`docfx.json`** — builds the tutorials plus API metadata for all library packages. Two metadata groups so the Windows-only TFMs build cleanly alongside the cross-platform ones.
- **`index.md` / `toc.yml`** — landing page and top-level navigation (Home / Tutorials / API Reference).
- **`Docs/toc.yml`** — tutorial sidebar navigation, grouped to mirror the README (Playback, Codecs, Recording, MIDI, etc.).
- **`api/index.md`** — API reference landing page.
- **`templates/naudio/public/main.css`** — small template override constraining the navbar logo so it fits the header bar (interim until an SVG logo lands).
- **`.github/workflows/docs.yml`** — builds on `windows-latest` (so the Windows-only projects produce API metadata) and deploys to GitHub Pages on push to `main`; build-only on PRs. Build runs with `--warningsAsErrors` so broken links/xrefs fail the check.
- **`.github/scripts/check-docs-toc.sh`** — pre-build check that fails if any `Docs/*.md` tutorial is missing from `Docs/toc.yml` (DocFX silently builds an unlisted tutorial as an orphan page, and `--warningsAsErrors` doesn't catch that).
- **`CLAUDE.md`** — documents the docs site and the TOC requirement for contributors.
- **`Docs/AsioMigration.md` / `Docs/PlayAudioFileLinuxAlsa.md`** — fixed two pre-existing broken file links surfaced by the build.
- **`.gitignore`** — ignore generated `_site/` and `api/*.yml`.

## Notes

- **Latest-only**, tracking `main` (no per-NuGet-version docs) to keep maintenance low.
- The docs build runs on `windows-latest` because several packages (Wasapi, Asio, WinMM, Dmo, WinForms) are Windows-only and won't produce API metadata on Linux.
- **After merge:** enable **Settings → Pages → Source = GitHub Actions** to go live at `https://naudio.github.io/NAudio/`.

## Verification

Built locally (Linux): all 43 tutorials render and the orphan-tutorial check, link checks, and logo override were each verified (pass + failure cases). Full API reference for the Windows-only packages will generate on the `windows-latest` runner.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgtCkiDGj7DAkKFBSRSJtK)_