### PR TITLE
Move CaptureState enum from NAudio.CoreAudioApi to NAudio.Wave

### DIFF
--- a/Docs/WasapiLoopbackCapture.md
+++ b/Docs/WasapiLoopbackCapture.md
@@ -45,7 +45,7 @@ All that remains is for us to start recording with `StartRecording` and wait for
 
 ```c#
 capture.StartRecording();
-while (capture.CaptureState != NAudio.CoreAudioApi.CaptureState.Stopped)
+while (capture.CaptureState != NAudio.Wave.CaptureState.Stopped)
 {
     Thread.Sleep(500);
 }

--- a/NAudio.Core/Wave/WaveInputs/CaptureState.cs
+++ b/NAudio.Core/Wave/WaveInputs/CaptureState.cs
@@ -1,6 +1,4 @@
-﻿// for consistency this should be in NAudio.Wave namespace, but left as it is for backwards compatibility
-// ReSharper disable once CheckNamespace
-namespace NAudio.CoreAudioApi
+﻿namespace NAudio.Wave
 {
     /// <summary>
     /// Represents state of a capture device

--- a/NAudio.WinMM/WaveIn.cs
+++ b/NAudio.WinMM/WaveIn.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using NAudio.Mixer;
 using System.Threading;
-using NAudio.CoreAudioApi;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 #### Breaking changes
 
  * `WaveFileChunkReader` is now `internal` (and moved from `NAudio.FileFormats.Wav` to `NAudio.Wave`) — it was internal plumbing for `WaveFileReader`. Read custom RIFF chunks via `WaveFileReader.Chunks` (`WaveChunks` / `RiffChunk` / `IWaveChunkInterpreter<T>`) instead
+ * `CaptureState` enum moved from `NAudio.CoreAudioApi` to `NAudio.Wave` — it's a backend-agnostic capture-state type used by `WaveIn`, `WasapiCapture`, and `WasapiRecorder`, and was only in `NAudio.CoreAudioApi` for historical reasons. Code that named the type via `using NAudio.CoreAudioApi;` now needs `using NAudio.Wave;`
  * `IWaveProvider.Read` signature changed from `Read(byte[], int, int)` to `Read(Span<byte>)`. Existing callers with `byte[]` migrate via `source.Read(buffer.AsSpan(offset, count))`; implementations override `Read(Span<byte>)`
  * `ISampleProvider.Read` signature changed from `Read(float[], int, int)` to `Read(Span<float>)` (same migration pattern)
  * `MidiIn`, `MidiOut`, `MidiInCapabilities`, and `MidiOutCapabilities` moved from `NAudio.Midi` to `NAudio.WinMM` — all `winmm.dll` interop now lives in one assembly


### PR DESCRIPTION
## What

Moves the `CaptureState` enum from the `NAudio.CoreAudioApi` namespace to `NAudio.Wave`. It stays **public** — it's the return type of the public `WasapiCapture.CaptureState` and `WasapiRecorder.CaptureState` properties, so it can't be made `internal`.

## Why

`CaptureState` was the only `NAudio.CoreAudioApi` type living in the `NAudio.Core` assembly — every other type in that namespace ships in `NAudio.Wasapi`. The source file already documented this as deferred tech debt:

```csharp
// for consistency this should be in NAudio.Wave namespace, but left as it is for backwards compatibility
// ReSharper disable once CheckNamespace
namespace NAudio.CoreAudioApi
```

It's a backend-agnostic capture-state enum (`Stopped` / `Starting` / `Capturing` / `Stopping`) used by `WaveIn` (winmm), `WasapiCapture`, and `WasapiRecorder` — not a Core Audio / WASAPI-specific concept. All of its neighbours (`IWaveIn`, `WaveIn`) and consumers are `NAudio.Wave`. NAudio 3 is the breaking release in which to fix it.

## Changes

- `CaptureState.cs`: namespace `NAudio.CoreAudioApi` → `NAudio.Wave`; removed the back-compat comment and the `CheckNamespace` suppression. File stays in `NAudio.Core/Wave/WaveInputs/` (already the right folder).
- `WaveIn.cs`: removed `using NAudio.CoreAudioApi;` — it existed only for `CaptureState`, and `WaveIn` is itself in `NAudio.Wave`, so the type now resolves natively. (`WasapiRecorder` and `WasapiCapture` needed no changes.)
- `Docs/WasapiLoopbackCapture.md`: updated the one fully-qualified `NAudio.CoreAudioApi.CaptureState` reference.
- `RELEASE_NOTES.md`: added a breaking-changes entry.

## Breaking change

Code that named the type via `using NAudio.CoreAudioApi;` now needs `using NAudio.Wave;`. Only three files in the repo reference the type by name (all updated); no sample or test code names it directly. Suggested label: `breaking`.

## Verification

`NAudio.Core`, `NAudio.WinMM`, and `NAudio.Wasapi` all build clean with **0 warnings** (with `EnableWindowsTargeting` on Linux). Since `TreatWarningsAsErrors` and `EnforceCodeStyleInBuild` are enabled, 0 warnings also confirms no unused-using / IDE0005 fallout from removing the `WaveIn` import.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgtCkiDGj7DAkKFBSRSJtK)_