### PR TITLE
Tidy up namespace inconsistencies surfaced by the docs site

### DIFF
--- a/NAudio.Core/Wave/WaveFormats/WmaWaveFormat.cs
+++ b/NAudio.Core/Wave/WaveFormats/WmaWaveFormat.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
 
-namespace NAudio.Wave.WaveFormats
+namespace NAudio.Wave
 {
     /// <summary>
     /// The WMA wave format. 

--- a/NAudio.Dmo/DmoMp3FrameDecompressor.cs
+++ b/NAudio.Dmo/DmoMp3FrameDecompressor.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using NAudio.Dmo;
 using NAudio.Wave;
 using System.Diagnostics;
 
-namespace NAudio.FileFormats.Mp3
+namespace NAudio.Dmo
 {
     /// <summary>
     /// MP3 Frame decompressor using the Windows Media MP3 Decoder DMO object

--- a/NAudio.Wasapi/CoreAudioApi/ActivateAudioInterfaceCompletionHandler.cs
+++ b/NAudio.Wasapi/CoreAudioApi/ActivateAudioInterfaceCompletionHandler.cs
@@ -1,12 +1,11 @@
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi.Interfaces;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using System.Threading.Tasks;
 
-namespace NAudio.Wasapi.CoreAudioApi
+namespace NAudio.CoreAudioApi
 {
     [GeneratedComClass]
     internal partial class ActivateAudioInterfaceCompletionHandler :

--- a/NAudio.Wasapi/CoreAudioApi/AudioCaptureClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioCaptureClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClient.cs
@@ -1,5 +1,4 @@
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using NAudio.Wave;
 using System;
 using System.Runtime.InteropServices;

--- a/NAudio.Wasapi/CoreAudioApi/AudioClockClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioClockClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;

--- a/NAudio.Wasapi/CoreAudioApi/AudioEndpointVolume.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioEndpointVolume.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/AudioMeterInformation.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioMeterInformation.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/AudioRenderClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioRenderClient.cs
@@ -1,6 +1,5 @@
 using System;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 

--- a/NAudio.Wasapi/CoreAudioApi/AudioSessionControl.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioSessionControl.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/AudioSessionManager.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioSessionManager.cs
@@ -7,7 +7,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/AudioStreamVolume.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioStreamVolume.cs
@@ -1,5 +1,4 @@
 ﻿using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;

--- a/NAudio.Wasapi/CoreAudioApi/AudioVolumeLevel.cs
+++ b/NAudio.Wasapi/CoreAudioApi/AudioVolumeLevel.cs
@@ -1,7 +1,7 @@
 ﻿using NAudio.CoreAudioApi.Interfaces;
 using System;
 
-namespace NAudio.Wasapi.CoreAudioApi
+namespace NAudio.CoreAudioApi
 {
     /// <summary>
     /// Audio Volume Level

--- a/NAudio.Wasapi/CoreAudioApi/ComActivation.cs
+++ b/NAudio.Wasapi/CoreAudioApi/ComActivation.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace NAudio.Wasapi.CoreAudioApi
+namespace NAudio.CoreAudioApi
 {
     /// <summary>
     /// Activates COM objects via raw <c>CoCreateInstance</c> and projects them onto

--- a/NAudio.Wasapi/CoreAudioApi/Connector.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Connector.cs
@@ -1,5 +1,4 @@
 ﻿using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 

--- a/NAudio.Wasapi/CoreAudioApi/DeviceTopology.cs
+++ b/NAudio.Wasapi/CoreAudioApi/DeviceTopology.cs
@@ -1,5 +1,4 @@
 ﻿using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceAsyncOperation.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceAsyncOperation.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace NAudio.Wasapi.CoreAudioApi.Interfaces
+namespace NAudio.CoreAudioApi.Interfaces
 {
     /// <summary>
     /// Represents an asynchronous operation activating a WASAPI interface and provides a method to retrieve the results of the activation.

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceCompletionHandler.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IActivateAudioInterfaceCompletionHandler.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace NAudio.Wasapi.CoreAudioApi.Interfaces
+namespace NAudio.CoreAudioApi.Interfaces
 {
     /// <summary>
     /// Provides a callback to indicate that activation of a WASAPI interface is complete.

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAgileObject.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAgileObject.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace NAudio.Wasapi.CoreAudioApi.Interfaces
+namespace NAudio.CoreAudioApi.Interfaces
 {
     /// <summary>
     /// Marks a COM object as agile (free-threaded), indicating it can be called from any apartment.

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMNotificationClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMNotificationClient.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi.Interfaces
 {

--- a/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDevice.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 

--- a/NAudio.Wasapi/CoreAudioApi/MMDeviceCollection.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDeviceCollection.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/MMDeviceEnumerator.cs
+++ b/NAudio.Wasapi/CoreAudioApi/MMDeviceEnumerator.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/NativeMethods.cs
+++ b/NAudio.Wasapi/CoreAudioApi/NativeMethods.cs
@@ -1,8 +1,8 @@
-﻿using NAudio.Wasapi.CoreAudioApi.Interfaces;
+﻿using NAudio.CoreAudioApi.Interfaces;
 using System;
 using System.Runtime.InteropServices;
 
-namespace NAudio.Wasapi.CoreAudioApi
+namespace NAudio.CoreAudioApi
 {
     static partial class NativeMethods
     {

--- a/NAudio.Wasapi/CoreAudioApi/Part.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Part.cs
@@ -1,5 +1,4 @@
 ﻿using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;

--- a/NAudio.Wasapi/CoreAudioApi/PartsList.cs
+++ b/NAudio.Wasapi/CoreAudioApi/PartsList.cs
@@ -2,7 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/CoreAudioApi/SessionCollection.cs
+++ b/NAudio.Wasapi/CoreAudioApi/SessionCollection.cs
@@ -1,5 +1,4 @@
 ﻿using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/NAudio.Wasapi/CoreAudioApi/SimpleAudioVolume.cs
+++ b/NAudio.Wasapi/CoreAudioApi/SimpleAudioVolume.cs
@@ -7,7 +7,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudio.CoreAudioApi
 {

--- a/NAudio.Wasapi/MediaFoundation/MFByteStreamFromStream.cs
+++ b/NAudio.Wasapi/MediaFoundation/MFByteStreamFromStream.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
 using NAudio.Utils;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.MediaFoundation.Interfaces;
 using NAudio.MediaFoundation.FileFormatDiscovery;
 

--- a/NAudio.Wasapi/MediaFoundation/MFByteStreamOnStreamAsyncCallback.cs
+++ b/NAudio.Wasapi/MediaFoundation/MFByteStreamOnStreamAsyncCallback.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
 using NAudio.Utils;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.MediaFoundation.Interfaces;
 
 namespace NAudio.MediaFoundation

--- a/NAudio.Wasapi/MediaFoundation/MediaFoundationHelpers.cs
+++ b/NAudio.Wasapi/MediaFoundation/MediaFoundationHelpers.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 using NAudio.Wave;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.MediaFoundation.Interfaces;
 
 namespace NAudio.MediaFoundation

--- a/NAudio.Wasapi/MediaFoundation/MediaFoundationTransform.cs
+++ b/NAudio.Wasapi/MediaFoundation/MediaFoundationTransform.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.Utils;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
 namespace NAudio.MediaFoundation

--- a/NAudio.Wasapi/MediaFoundation/MediaType.cs
+++ b/NAudio.Wasapi/MediaFoundation/MediaType.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.Utils;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
 namespace NAudio.MediaFoundation

--- a/NAudio.Wasapi/MediaFoundation/MfActivate.cs
+++ b/NAudio.Wasapi/MediaFoundation/MfActivate.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 
 namespace NAudio.MediaFoundation
 {

--- a/NAudio.Wasapi/MediaFoundation/MfSample.cs
+++ b/NAudio.Wasapi/MediaFoundation/MfSample.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 
 namespace NAudio.MediaFoundation
 {

--- a/NAudio.Wasapi/MediaFoundation/MfSourceReader.cs
+++ b/NAudio.Wasapi/MediaFoundation/MfSourceReader.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 
 namespace NAudio.MediaFoundation
 {

--- a/NAudio.Wasapi/MediaFoundation/MfTransform.cs
+++ b/NAudio.Wasapi/MediaFoundation/MfTransform.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 
 namespace NAudio.MediaFoundation
 {

--- a/NAudio.Wasapi/MediaFoundationEncoder.cs
+++ b/NAudio.Wasapi/MediaFoundationEncoder.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.MediaFoundation;
 using NAudio.Utils;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.MediaFoundation.Interfaces;
 
 namespace NAudio.Wave

--- a/NAudio.Wasapi/MediaFoundationReader.cs
+++ b/NAudio.Wasapi/MediaFoundationReader.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices.Marshalling;
 using NAudio.CoreAudioApi.Interfaces;
 using NAudio.MediaFoundation;
 using NAudio.Utils;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.MediaFoundation.Interfaces;
 
 // ReSharper disable once CheckNamespace

--- a/NAudio.Wasapi/MediaFoundationResampler.cs
+++ b/NAudio.Wasapi/MediaFoundationResampler.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using NAudio.MediaFoundation;
-using NAudio.Wasapi.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudio.MediaFoundation.Interfaces;
 
 namespace NAudio.Wave

--- a/NAudio.Wasapi/WasapiPlayer.cs
+++ b/NAudio.Wasapi/WasapiPlayer.cs
@@ -1,6 +1,5 @@
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/NAudio.Wasapi/WasapiRecorder.cs
+++ b/NAudio.Wasapi/WasapiRecorder.cs
@@ -1,6 +1,5 @@
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/NAudio.Windows.Tests/Dmo/DmoMp3FrameDecompressorTests.cs
+++ b/NAudio.Windows.Tests/Dmo/DmoMp3FrameDecompressorTests.cs
@@ -1,6 +1,5 @@
 using System;
 using NUnit.Framework;
-using NAudio.FileFormats.Mp3;
 using NAudio.Wave;
 using NAudio.Dmo;
 using System.Diagnostics;

--- a/NAudioConsoleTest/Dmo/Tests/DmoDecodeMp3Test.cs
+++ b/NAudioConsoleTest/Dmo/Tests/DmoDecodeMp3Test.cs
@@ -1,4 +1,4 @@
-using NAudio.FileFormats.Mp3;
+using NAudio.Dmo;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioConsoleTest/WinMM/Tests/WinMmDecodeMp3Test.cs
+++ b/NAudioConsoleTest/WinMM/Tests/WinMmDecodeMp3Test.cs
@@ -1,4 +1,4 @@
-using NAudio.FileFormats.Mp3;
+using NAudio.Dmo;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioConsoleTest/WinMM/Tests/WinMmPlayFileTest.cs
+++ b/NAudioConsoleTest/WinMM/Tests/WinMmPlayFileTest.cs
@@ -1,4 +1,4 @@
-using NAudio.FileFormats.Mp3;
+using NAudio.Dmo;
 using NAudio.Wave;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;

--- a/NAudioDemo/DeviceTopology/DeviceTopologyPanel.cs
+++ b/NAudioDemo/DeviceTopology/DeviceTopologyPanel.cs
@@ -11,7 +11,6 @@ using System.Windows.Forms;
 
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
-using NAudio.Wasapi.CoreAudioApi;
 
 namespace NAudioDemo.DeviceTopology
 {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 
 #### Breaking changes
 
+ * `AudioVolumeLevel` moved from `NAudio.Wasapi.CoreAudioApi` to `NAudio.CoreAudioApi` — it now lives in the same namespace as the rest of the WASAPI/Core Audio API (`MMDevice`, `Part`, `DeviceTopology`, etc.) that it's returned from. The parallel `NAudio.Wasapi.CoreAudioApi` namespace (which otherwise held only internal COM-activation plumbing) is gone
+ * `DmoMp3FrameDecompressor` moved from `NAudio.FileFormats.Mp3` to `NAudio.Dmo` — it's a DMO wrapper and now shares the namespace of the `NAudio.Dmo` assembly it ships in (alongside `DmoEffectWaveProvider`, `ResamplerDmoStream`, etc.)
  * `WaveFileChunkReader` is now `internal` (and moved from `NAudio.FileFormats.Wav` to `NAudio.Wave`) — it was internal plumbing for `WaveFileReader`. Read custom RIFF chunks via `WaveFileReader.Chunks` (`WaveChunks` / `RiffChunk` / `IWaveChunkInterpreter<T>`) instead
  * `CaptureState` enum moved from `NAudio.CoreAudioApi` to `NAudio.Wave` — it's a backend-agnostic capture-state type used by `WaveIn`, `WasapiCapture`, and `WasapiRecorder`, and was only in `NAudio.CoreAudioApi` for historical reasons. Code that named the type via `using NAudio.CoreAudioApi;` now needs `using NAudio.Wave;`
  * `IWaveProvider.Read` signature changed from `Read(byte[], int, int)` to `Read(Span<byte>)`. Existing callers with `byte[]` migrate via `source.Read(buffer.AsSpan(offset, count))`; implementations override `Read(Span<byte>)`


### PR DESCRIPTION
## Summary

The new documentation site exposed a few stray/inconsistent namespaces. This consolidates them into their logical homes for NAudio 3. Source compatibility is preserved everywhere except **two rarely-consumed public types** (both documented under Breaking changes in `RELEASE_NOTES.md`).

## Changes

**1. Collapse the phantom `NAudio.Wasapi.CoreAudioApi[.Interfaces]` namespace into `NAudio.CoreAudioApi[.Interfaces]`**
Seven COM-activation types lived in the same `CoreAudioApi/` folder as the 46 `NAudio.CoreAudioApi` types but under a second, parallel namespace (an artefact of the AOT/`GeneratedComInterface` modernization). Six are `internal` (zero external impact); the only public one, `AudioVolumeLevel`, now sits alongside its consumer `Part` and the rest of the device-topology API. Consumer `using`s updated accordingly.

**2. Move `DmoMp3FrameDecompressor` from `NAudio.FileFormats.Mp3` to `NAudio.Dmo`**
It was the lone occupant of `NAudio.FileFormats.Mp3` and is a DMO wrapper shipping in the `NAudio.Dmo` assembly, so it now shares that namespace (alongside `DmoEffectWaveProvider`, `ResamplerDmoStream`, etc.). The four in-repo consumers are updated to `using NAudio.Dmo;`.

**3. Move internal `WmaWaveFormat` from `NAudio.Wave.WaveFormats` to `NAudio.Wave`**
Matches the flat-namespace convention used by every other file in that folder. Internal, so source-private.

## Public API impact

Exactly **two** public types change namespace — everything else moved is internal:

| Public type | Old namespace | New namespace |
|---|---|---|
| `AudioVolumeLevel` | `NAudio.Wasapi.CoreAudioApi` | `NAudio.CoreAudioApi` |
| `DmoMp3FrameDecompressor` | `NAudio.FileFormats.Mp3` | `NAudio.Dmo` |

Both are in niche/rarely-consumed corners of the API (device topology; DMO-based MP3 decoding). Migration is a one-line `using` change, and both are listed in `RELEASE_NOTES.md`.

## Considered and dropped

An earlier idea to fold the WinForms `*.Designer.cs` files from `NAudio.WinForms.Gui` into `NAudio.Gui` was **dropped** — those are auto-generated strongly-typed resource classes whose class names (`Fader`, `PanSlider`, …) deliberately sit in a separate namespace from the like-named controls in `NAudio.Gui`; merging them would cause duplicate-type errors. The existing split is correct.

## Verification

Full solution builds clean (**0 errors, 0 warnings**) with `-p:EnableWindowsTargeting=true` on Linux/.NET 10; `NAudio.Core.Tests` pass (0 failed). CI on `windows-latest` will re-confirm on the real Windows toolchain.

https://claude.ai/code/session_016jqYm1YZHrc7PCyzVoFGCs

---
_Generated by [Claude Code](https://claude.ai/code/session_016jqYm1YZHrc7PCyzVoFGCs)_