### PR TITLE
Fix DocFX API navigation dropping cross-platform namespaces

### DIFF
--- a/NAudio.Extras/NAudio.Extras.csproj
+++ b/NAudio.Extras/NAudio.Extras.csproj
@@ -1,7 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- DocFX's metadata step cannot load a multi-targeted project (it reads the
+         reference-less outer build), so collapse to the net9.0 surface when the docs
+         site is being generated. This lets every project sit in one DocFX metadata
+         block, which is what keeps the API table-of-contents unified. -->
+    <TargetFrameworks Condition=" '$(DocsBuild)' != 'true' ">net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFramework Condition=" '$(DocsBuild)' == 'true' ">net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Optional extras (extra demo/sample providers and helpers) for the NAudio audio library.</Description>
   </PropertyGroup>

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- During docs generation (DocsBuild=true) collapse to the net9.0 surface so
+         DocFX's metadata step can load this project: it is pulled in transitively by
+         NAudio.Extras, and DocFX cannot read a multi-targeted project. The Windows
+         backends are documented directly from their own projects, so nothing is lost. -->
+    <TargetFrameworks Condition=" '$(DocsBuild)' != 'true' ">net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFramework Condition=" '$(DocsBuild)' == 'true' ">net9.0</TargetFramework>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>NAudio is an open source .NET audio library — playback and recording, file readers and writers, MIDI, DSP and effects, with platform-specific backends auto-selected by target framework.</Description>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -149,6 +149,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * Renamed `license.txt` to `LICENSE` for GitHub license detection; refreshed copyright year to 2008–2026
  * Added per-package `<Description>` metadata to every shipping NAudio NuGet package so each clearly identifies itself as part of the NAudio family
  * Added a DocFX documentation site (tutorials + API reference) published to GitHub Pages, built automatically from `Docs/` and the source XML comments
+ * Fixed the published API reference dropping the cross-platform namespaces (`NAudio.Effects`, `NAudio.Dsp`, `NAudio.Codecs`, `NAudio.SoundFont`, etc.) from the navigation — DocFX's two metadata blocks both wrote to the same destination, so the second overwrote the first's table of contents. The projects are now documented from a single metadata block
 
 ### 2.3.0 (12 Mar 2026)
 

--- a/docfx.json
+++ b/docfx.json
@@ -10,23 +10,7 @@
             "NAudio.Midi/NAudio.Midi.csproj",
             "NAudio.SoundFile/NAudio.SoundFile.csproj",
             "NAudio.Alsa/NAudio.Alsa.csproj",
-            "NAudio.Extras/NAudio.Extras.csproj"
-          ]
-        }
-      ],
-      "dest": "api",
-      "namespaceLayout": "nested",
-      "memberLayout": "samePage",
-      "properties": {
-        "EnableWindowsTargeting": "true",
-        "TargetFramework": "net9.0"
-      }
-    },
-    {
-      "src": [
-        {
-          "src": ".",
-          "files": [
+            "NAudio.Extras/NAudio.Extras.csproj",
             "NAudio.Asio/NAudio.Asio.csproj",
             "NAudio.WinMM/NAudio.WinMM.csproj",
             "NAudio.Dmo/NAudio.Dmo.csproj",
@@ -39,7 +23,8 @@
       "namespaceLayout": "nested",
       "memberLayout": "samePage",
       "properties": {
-        "EnableWindowsTargeting": "true"
+        "EnableWindowsTargeting": "true",
+        "DocsBuild": "true"
       }
     }
   ],


### PR DESCRIPTION
## Problem

On the published API reference (e.g. https://naudio.github.io/NAudio/api/NAudio.html), the cross-platform namespaces — `NAudio.Effects`, `NAudio.Dsp`, `NAudio.Codecs`, `NAudio.SoundFont`, etc. — are **missing from the left-hand navigation**, even though their pages generate correctly (e.g. `NAudio.Effects.html` exists and is fine).

## Root cause

`docfx.json` had **two `metadata` blocks both writing to `dest: "api"`**. DocFX regenerates `toc.yml` per metadata block, so the second (Windows) block's `toc.yml` **overwrote** the first (cross-platform) block's. The per-type `.yml` files have unique names and survive — which is why the pages still render — but every cross-platform-only namespace gets orphaned from the navigation tree.

Reproduced with a minimal two-block test: after the run, `NAudio.Effects.yml` still exists on disk but the final `toc.yml` contains only the second block's namespaces.

## Fix

Merge the two blocks into a single `metadata` block so one `toc.yml` covers every namespace.

A single block can't keep the old `TargetFramework=net9.0` pin, because the Windows projects only target `net9.0-windows*`. That pin existed solely to collapse the multi-targeted `NAudio.Extras` and `NAudio` meta-package (DocFX can't load a multi-targeted project — it reads the reference-less outer build). So instead those two projects now collapse to `net9.0` **only when `DocsBuild=true`**, which the merged metadata block passes. Normal multi-targeted builds are untouched.

### Changes
- `docfx.json` — two metadata blocks → one; dropped `TargetFramework` pin; added `DocsBuild: true`.
- `NAudio.Extras/NAudio.Extras.csproj` — single-target `net9.0` when `DocsBuild=true`.
- `NAudio/NAudio.csproj` — same `DocsBuild` collapse (transitive dependency of Extras).
- `RELEASE_NOTES.md` — entry under *Packaging and dependencies*.

## Verification
- ✅ Merged block produces a single unified `NAudio` tree with `Effects` (and the other cross-platform namespaces) back in the TOC, no errors.
- ✅ `DocsBuild=true` collapses Extras + meta-package to `net9.0` and builds cleanly via `dotnet build`; without it, both still multi-target.
- ⚠️ The Windows projects build through DocFX only on `windows-latest` (the original config fails identically on Linux — an `EnableWindowsTargeting` propagation limit), so the full site is validated by the Docs CI on this PR.

https://claude.ai/code/session_0167PNiUhSFXF6d542nPyZdN

---
_Generated by [Claude Code](https://claude.ai/code/session_0167PNiUhSFXF6d542nPyZdN)_