### PR TITLE
Embed SPDX SBOM in each NAudio NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,16 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 
+    <!-- SBOM generation. Microsoft.Sbom.Targets (the MSBuild wrapper over
+         microsoft/sbom-tool) embeds an SPDX 2.2 manifest inside each packed
+         .nupkg under /_manifest/spdx_2.2/, alongside its SHA-256 — so every
+         package carries a Software Bill of Materials to whoever downloads it
+         from NuGet, no separate artifact to chase. Gated to Release so local
+         Debug builds/packs stay fast; CI and the release workflow both build
+         Release, so published packages always carry an SBOM. The PackageReference
+         lives in the ItemGroup below. -->
+    <GenerateSBOM Condition="'$(Configuration)' == 'Release'">true</GenerateSBOM>
+
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <!-- Enable analyzers but don't set default severities - .globalconfig controls rule severities -->
@@ -46,4 +56,12 @@
          Once fixed, remove from here to let them become errors. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2245;CA2201;CA1001</WarningsNotAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Build/pack-time only: contributes no runtime assemblies and does not
+         flow to consumers (PrivateAssets=all). Its targets only do work during
+         `pack` when GenerateSBOM is true, so test and sample/tool projects that
+         are never packed to NuGet are unaffected. -->
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -142,6 +142,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
 #### Packaging and dependencies
 
  * Each NAudio package now ships its own README in the NuGet payload
+ * Each NAudio package now embeds an SPDX 2.2 Software Bill of Materials (SBOM) under `/_manifest/spdx_2.2/` in its `.nupkg`, generated at pack time via `Microsoft.Sbom.Targets`
  * Test project migrated from VSTest to `Microsoft.Testing.Platform`
  * `NAudioTests` split into `NAudio.Core.Tests` (cross-platform, `net10.0`) and `NAudio.Windows.Tests` (Windows-only, `net10.0-windows`) — eliminates the dual-TFM double-run on Windows CI and lets non-Windows devs run just the cross-platform suite
  * `NAudio.Alsa.Tests` and `NAudio.SoundFile.Tests` now ignore MTP exit codes 8/9 so `dotnet test` succeeds on machines where the suite legitimately runs zero tests (ALSA off-Linux) or self-skips (libsndfile absent)


### PR DESCRIPTION
## What

Adds [`Microsoft.Sbom.Targets`](https://www.nuget.org/packages/Microsoft.Sbom.Targets) (the MSBuild wrapper over [`microsoft/sbom-tool`](https://github.com/microsoft/sbom-tool)) via `Directory.Build.props`, so every packed NAudio package embeds an **SPDX 2.2 Software Bill of Materials** under `/_manifest/spdx_2.2/manifest.spdx.json` (plus its `.sha256`) inside the `.nupkg`.

The SBOM travels inside the package to anyone who downloads it from NuGet — no separate artifact to publish, and the existing `release.yml` pack loop needs **no changes**.

## How

- `Directory.Build.props`:
  - `<PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />` — build/pack-time only, contributes no runtime assemblies and doesn't flow to consumers.
  - `<GenerateSBOM Condition="'$(Configuration)' == 'Release'">true</GenerateSBOM>` — gated to Release so local Debug builds/packs stay fast; CI and the release workflow both build Release, so published packages always carry an SBOM.
- `RELEASE_NOTES.md`: one bullet under *Packaging and dependencies*.

This is the idiomatic, Microsoft-first-party approach for .NET: SPDX is the format GitHub's dependency graph and most enterprise/supply-chain consumers expect by default, and embedding it in the `.nupkg` means consumers get it with whatever version they pull.

## Verification (Linux, .NET 10 SDK)

- **Release** pack of `NAudio.Core` ran the generator and the `.nupkg` contains `_manifest/spdx_2.2/manifest.spdx.json` + `.sha256`.
- **Debug** pack produced **0** manifest entries — confirms the Release gate.

The generated SBOM accurately reflects the full restore graph. For a leaf package like `NAudio.Core` the only real third-party runtime dependency captured is `System.Numerics.Tensors`; the remaining entries (`Microsoft.NETCore.App.Ref`, `Microsoft.AspNetCore.App.Ref`, `Microsoft.NET.ILLink.Tasks`, and `Microsoft.Sbom.Targets` itself) are .NET SDK targeting/reference packs and build-only tooling that the SBOM tool's component detection includes by design — none are shipped to consumers.

## Labels

Suggest `enhancement`.

https://claude.ai/code/session_0122xp1hWifdLMKhNdMFMcoD

---
_Generated by [Claude Code](https://claude.ai/code/session_0122xp1hWifdLMKhNdMFMcoD)_