### PR TITLE
Fix LoopStream infinite loop (100% CPU) when the source can't satisfy a read

### DIFF
--- a/NAudio.Extras/LoopStream.cs
+++ b/NAudio.Extras/LoopStream.cs
@@ -69,20 +69,14 @@ namespace NAudio.Extras
             {
                 int required = count - read;
                 int readThisTime = sourceStream.Read(buffer.Slice(read, required));
-                if (readThisTime == 0)
+                if (readThisTime == 0 && sourceStream.Position == 0)
                 {
-                    // The source returned nothing. If we're not already at the
-                    // start it has simply reached the end of this pass, so rewind
-                    // and read again to continue the loop. If we're already at the
-                    // start, the source has no data it can return (an empty stream,
-                    // or a request smaller than its block alignment), so stop rather
-                    // than spin forever re-reading it.
-                    if (sourceStream.Position == 0)
-                    {
-                        break;
-                    }
-                    sourceStream.Position = 0;
-                    continue;
+                    // Nothing read from the very start of the source: it's empty
+                    // (or can't satisfy a request smaller than its block alignment),
+                    // so stop rather than spin forever. A zero read when we're not
+                    // at the start just means end-of-pass - the rewind below loops
+                    // us back to the start to keep filling the buffer.
+                    break;
                 }
 
                 if (readThisTime < required)

--- a/NAudio.Extras/LoopStream.cs
+++ b/NAudio.Extras/LoopStream.cs
@@ -71,10 +71,18 @@ namespace NAudio.Extras
                 int readThisTime = sourceStream.Read(buffer.Slice(read, required));
                 if (readThisTime == 0)
                 {
-                    // Source produced nothing even from the start of the stream
-                    // (e.g. an empty/zero-length source). Stop rather than spin
-                    // forever rewinding and re-reading the same empty stream.
-                    break;
+                    // The source returned nothing. If we're not already at the
+                    // start it has simply reached the end of this pass, so rewind
+                    // and read again to continue the loop. If we're already at the
+                    // start, the source has no data it can return (an empty stream,
+                    // or a request smaller than its block alignment), so stop rather
+                    // than spin forever re-reading it.
+                    if (sourceStream.Position == 0)
+                    {
+                        break;
+                    }
+                    sourceStream.Position = 0;
+                    continue;
                 }
 
                 if (readThisTime < required)

--- a/NAudio.Extras/LoopStream.cs
+++ b/NAudio.Extras/LoopStream.cs
@@ -69,6 +69,14 @@ namespace NAudio.Extras
             {
                 int required = count - read;
                 int readThisTime = sourceStream.Read(buffer.Slice(read, required));
+                if (readThisTime == 0)
+                {
+                    // Source produced nothing even from the start of the stream
+                    // (e.g. an empty/zero-length source). Stop rather than spin
+                    // forever rewinding and re-reading the same empty stream.
+                    break;
+                }
+
                 if (readThisTime < required)
                 {
                     sourceStream.Position = 0;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -204,7 +204,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `MediaFoundationTransform`: cleanup `finally` blocks no longer leak COM objects when `Unlock`/`RemoveAllBuffers` fails — hresults are captured and thrown only after every buffer/sample has been released (#1293)
  * `ResamplerDmoStream`: fixed infinite loop on `Read` after setting `Position`, and the loss of the resampler kernel's tail samples (~32 at the default quality of 30) when the input reaches end-of-stream. The DMO is now drained via `ProcessOutput` after `Discontinuity` — on seek the drained bytes are discarded so playback resumes from the new position, on EOS they're returned to the caller and subsequent reads return 0 cleanly (#607, #608)
  * Named the background threads created by `DirectSoundOut`, `WasapiOut`, `WasapiCapture`, `WasapiPlayer`, and `WasapiRecorder` so they show meaningful names in debuggers and profilers (#557)
- * `LoopStream.Read`: no longer spins forever at 100% CPU when the wrapped source is empty (`Length == 0` / decodes to zero frames) — it now returns `0` instead of endlessly rewinding and re-reading an empty stream (#1338)
+ * `LoopStream.Read`: no longer spins forever at 100% CPU when the wrapped source can't satisfy a read (an empty source with `Length == 0` / zero frames, or a block-aligned reader asked for less than one block). A zero-byte read now rewinds and retries once to continue the loop, and returns whatever has been read so far if the source is still empty from its start, instead of looping endlessly (#1338)
 
 #### Modernisation (Native AOT, source-generated COM)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -204,6 +204,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * `MediaFoundationTransform`: cleanup `finally` blocks no longer leak COM objects when `Unlock`/`RemoveAllBuffers` fails — hresults are captured and thrown only after every buffer/sample has been released (#1293)
  * `ResamplerDmoStream`: fixed infinite loop on `Read` after setting `Position`, and the loss of the resampler kernel's tail samples (~32 at the default quality of 30) when the input reaches end-of-stream. The DMO is now drained via `ProcessOutput` after `Discontinuity` — on seek the drained bytes are discarded so playback resumes from the new position, on EOS they're returned to the caller and subsequent reads return 0 cleanly (#607, #608)
  * Named the background threads created by `DirectSoundOut`, `WasapiOut`, `WasapiCapture`, `WasapiPlayer`, and `WasapiRecorder` so they show meaningful names in debuggers and profilers (#557)
+ * `LoopStream.Read`: no longer spins forever at 100% CPU when the wrapped source is empty (`Length == 0` / decodes to zero frames) — it now returns `0` instead of endlessly rewinding and re-reading an empty stream (#1338)
 
 #### Modernisation (Native AOT, source-generated COM)
 


### PR DESCRIPTION
Fixes #1338.

## Problem

`NAudio.Extras.LoopStream.Read` spins forever at 100% CPU when the wrapped source can't satisfy a read. The reported case is a valid PCM WAV whose data chunk is empty (`Length == 0`, zero audio frames): `sourceStream.Read` returns 0 every iteration, so `read` never advances toward `count` and the `while (read < count)` loop never terminates, pinning the calling (e.g. rendering) thread.

The same hang also affects a second, more common case: a block-aligned reader such as `WaveFileReader` rounds a requested count *down* to a `BlockAlign` multiple, so once the loop has only a trailing sub-block remainder left to fill (e.g. `required == 1` with `BlockAlign == 3`), the read aligns down to 0 and returns 0 even though the source isn't empty — and the old loop spun on that forever too.

## Fix

Treat a zero-byte read by *position*: if it happens part-way through the source it just means end-of-pass, so the existing `readThisTime < required` rewind loops back to the start and keeps filling the buffer; if it happens with the source already at position 0, the source genuinely has nothing it can return, so `Read` stops and returns what it has so far instead of spinning.

```csharp
int readThisTime = sourceStream.Read(buffer.Slice(read, required));
if (readThisTime == 0 && sourceStream.Position == 0)
{
    break;
}
```

This terminates in all cases (at most one rewind before either making progress or stopping) and preserves the normal looping behaviour for non-empty sources.

## Notes

- I couldn't build/run locally — the cloud environment's network policy blocks the .NET install endpoints — so this is hand-verified only and relies on CI to compile. `LoopStream` lives in `NAudio.Extras`, which only `NAudio.Windows.Tests` references, so there's currently no cross-platform harness for it; happy to add a regression test there (empty-WAV repro + a block-aligned odd-count case) if you'd like.
- Release note added under *Reliability and bug fixes*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018z2wYhY8KCZrhZ43eft1Gj)_