### PR TITLE
Add NAudio.Vst3 to release pack list and DocFX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,7 @@ jobs:
             'NAudio.WinMM',
             'NAudio.Wasapi',
             'NAudio.Dmo',
+            'NAudio.Vst3',
             'NAudio.Alsa',
             'NAudio.SoundFile',
             'NAudio.Sampler',

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -254,6 +254,7 @@ Docs/Architecture/ReleaseStrategy.md for the release-notes process.
  * Added per-package `<Description>` metadata to every shipping NAudio NuGet package so each clearly identifies itself as part of the NAudio family
  * Added a DocFX documentation site (tutorials + API reference) published to GitHub Pages, built automatically from `Docs/` and the source XML comments
  * Fixed the published API reference dropping the cross-platform namespaces (`NAudio.Effects`, `NAudio.Dsp`, `NAudio.Codecs`, `NAudio.SoundFont`, etc.) from the navigation — DocFX's two metadata blocks both wrote to the same destination, so the second overwrote the first's table of contents. The projects are now documented from a single metadata block
+ * Fixed the `NAudio.Vst3` package being omitted from the release pack list and the DocFX API reference — it is now packed and published alongside the other NAudio packages and its API is documented on the site
 
 ### 2.3.0 (12 Mar 2026)
 

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -14,6 +14,7 @@
             "src/NAudio.Asio/NAudio.Asio.csproj",
             "src/NAudio.WinMM/NAudio.WinMM.csproj",
             "src/NAudio.Dmo/NAudio.Dmo.csproj",
+            "src/NAudio.Vst3/NAudio.Vst3.csproj",
             "src/NAudio.WinForms/NAudio.WinForms.csproj",
             "src/NAudio.Wasapi/NAudio.Wasapi.csproj"
           ]


### PR DESCRIPTION
## Summary

`NAudio.Vst3` is a packable, shipping project (it has a `<Description>` and `<PackageTags>`, no `IsPackable=false`, and is listed in `NAudio.slnx`), but it had been missed in two places:

- **`.github/workflows/release.yml`** — absent from the `$packages` array in the Pack step, so the package was never built into a `.nupkg` or published to NuGet.
- **`docfx/docfx.json`** — absent from the metadata source list, so its API never appeared on the documentation site.

This PR adds `NAudio.Vst3` to both lists so it ships alongside the other NAudio packages and is documented on the site.

## Changes

- Added `'NAudio.Vst3'` to the pack list in `release.yml` (after `NAudio.Dmo`).
- Added `src/NAudio.Vst3/NAudio.Vst3.csproj` to the DocFX metadata sources (after `NAudio.Dmo`).
- Added a release-notes bullet under **Packaging and dependencies**.

## Notes

- The package targets `net9.0-windows`, so it packs fine on the `windows-latest` release runner like the other Windows backends.
- The `NAudio.Vst3` package is already announced in the release notes (the "VST 3 hosting (preview)" bullet), so this is purely the packaging/docs plumbing that had been missed — no separate "new package" entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162oufF5Veo5brU6mSFU558

---
_Generated by [Claude Code](https://claude.ai/code/session_0162oufF5Veo5brU6mSFU558)_