### PR TITLE
Support WAVE_FORMAT_EXTENSIBLE in ToSampleProvider (#639)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -67,6 +67,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `WaveFileReader` / `AiffFileReader`: malformed headers declaring `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` later (#1254); `WaveFileReader` no longer throws on an oversized `fmt` `cbSize` (#482)
  * `WaveFormat.Serialize`: PCM formats now write the canonical 16-byte `fmt ` chunk (#934, #1098)
  * `WaveViewer`: fixed rendering upside-down (#801, #818) and now renders any source format correctly via `ToSampleProvider()` (#564)
+ * `ToSampleProvider()` now handles `WAVE_FORMAT_EXTENSIBLE` PCM and IEEE float sources (e.g. multichannel / >16-bit WAV files) instead of throwing `Unsupported source encoding` (#639)
  * `AudioSessionControl`: now supports multiple registered event clients without leaking, and `UnRegisterEventClient` honours its argument (#1263)
  * `AudioEndpointVolume.OnVolumeNotification`: fixed per-channel notifications all returning channel 0's volume (#351)
  * `CueListInterpreter`: WAV files with cue points but no labels now return cues with empty labels instead of null (#549)

--- a/src/NAudio.Core/Wave/SampleProviders/SampleProviderConverters.cs
+++ b/src/NAudio.Core/Wave/SampleProviders/SampleProviderConverters.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using NAudio.Dmo;
 
 namespace NAudio.Wave.SampleProviders;
 
@@ -9,48 +10,126 @@ internal static class SampleProviderConverters
 {
     /// <summary>
     /// Helper function to go from IWaveProvider to a SampleProvider
-    /// Must already be PCM or IEEE float
+    /// Must already be PCM or IEEE float (including WAVE_FORMAT_EXTENSIBLE
+    /// whose SubFormat is PCM or IEEE float)
     /// </summary>
     /// <param name="waveProvider">The WaveProvider to convert</param>
     /// <returns>A sample provider</returns>
     public static ISampleProvider ConvertWaveProviderIntoSampleProvider(IWaveProvider waveProvider)
     {
+        // Multichannel / high bit depth PCM and float audio is usually described as
+        // WAVE_FORMAT_EXTENSIBLE. Re-present such a source under the equivalent standard
+        // PCM or IEEE float format (the sample bytes are identical) so it both dispatches
+        // here and is accepted by the converters' encoding checks. See issue #639.
+        var source = AsStandardProvider(waveProvider);
+
         ISampleProvider sampleProvider;
-        if (waveProvider.WaveFormat.Encoding == WaveFormatEncoding.Pcm)
+        if (source.WaveFormat.Encoding == WaveFormatEncoding.Pcm)
         {
             // go to float
-            if (waveProvider.WaveFormat.BitsPerSample == 8)
+            if (source.WaveFormat.BitsPerSample == 8)
             {
-                sampleProvider = new Pcm8BitToSampleProvider(waveProvider);
+                sampleProvider = new Pcm8BitToSampleProvider(source);
             }
-            else if (waveProvider.WaveFormat.BitsPerSample == 16)
+            else if (source.WaveFormat.BitsPerSample == 16)
             {
-                sampleProvider = new Pcm16BitToSampleProvider(waveProvider);
+                sampleProvider = new Pcm16BitToSampleProvider(source);
             }
-            else if (waveProvider.WaveFormat.BitsPerSample == 24)
+            else if (source.WaveFormat.BitsPerSample == 24)
             {
-                sampleProvider = new Pcm24BitToSampleProvider(waveProvider);
+                sampleProvider = new Pcm24BitToSampleProvider(source);
             }
-            else if (waveProvider.WaveFormat.BitsPerSample == 32)
+            else if (source.WaveFormat.BitsPerSample == 32)
             {
-                sampleProvider = new Pcm32BitToSampleProvider(waveProvider);
+                sampleProvider = new Pcm32BitToSampleProvider(source);
             }
             else
             {
                 throw new InvalidOperationException("Unsupported bit depth");
             }
         }
-        else if (waveProvider.WaveFormat.Encoding == WaveFormatEncoding.IeeeFloat)
+        else if (source.WaveFormat.Encoding == WaveFormatEncoding.IeeeFloat)
         {
-            if (waveProvider.WaveFormat.BitsPerSample == 64)
-                sampleProvider = new WaveToSampleProvider64(waveProvider);
+            if (source.WaveFormat.BitsPerSample == 64)
+                sampleProvider = new WaveToSampleProvider64(source);
             else
-                sampleProvider = new WaveToSampleProvider(waveProvider);
+                sampleProvider = new WaveToSampleProvider(source);
         }
         else
         {
             throw new ArgumentException("Unsupported source encoding");
         }
         return sampleProvider;
+    }
+
+    /// <summary>
+    /// If the provider's format is a PCM or IEEE float WAVE_FORMAT_EXTENSIBLE, wraps it so
+    /// it reports the equivalent standard format; otherwise returns it unchanged. The wave
+    /// data is left untouched - only the reported WaveFormat differs.
+    /// </summary>
+    private static IWaveProvider AsStandardProvider(IWaveProvider waveProvider)
+    {
+        if (waveProvider.WaveFormat.Encoding != WaveFormatEncoding.Extensible)
+        {
+            return waveProvider;
+        }
+        var standardFormat = ToStandardWaveFormat(waveProvider.WaveFormat);
+        // leave unrecognised extensible subformats untouched so the dispatcher still throws
+        return standardFormat == null ? waveProvider : new WaveFormatAdapter(waveProvider, standardFormat);
+    }
+
+    /// <summary>
+    /// Returns the standard PCM or IEEE float WaveFormat equivalent to an extensible format,
+    /// or null if the SubFormat is neither PCM nor IEEE float.
+    /// </summary>
+    private static WaveFormat ToStandardWaveFormat(WaveFormat waveFormat)
+    {
+        // A WaveFormatExtensible (e.g. built in code) exposes the SubFormat directly,
+        // whereas reading from a file (WaveFileReader) yields a WaveFormatExtraData whose
+        // 22-byte extension carries it after wValidBitsPerSample (2) and dwChannelMask (4).
+        Guid subFormat;
+        if (waveFormat is WaveFormatExtensible extensible)
+        {
+            subFormat = extensible.SubFormat;
+        }
+        else if (waveFormat is WaveFormatExtraData { ExtraSize: >= 22 } extraData)
+        {
+            subFormat = new Guid(extraData.ExtraData.AsSpan(6, 16));
+        }
+        else
+        {
+            return null;
+        }
+
+        if (subFormat == AudioMediaSubtypes.MEDIASUBTYPE_PCM)
+        {
+            return new WaveFormat(waveFormat.SampleRate, waveFormat.BitsPerSample, waveFormat.Channels);
+        }
+        if (subFormat == AudioMediaSubtypes.MEDIASUBTYPE_IEEE_FLOAT)
+        {
+            return WaveFormat.CreateCustomFormat(WaveFormatEncoding.IeeeFloat,
+                waveFormat.SampleRate, waveFormat.Channels, waveFormat.AverageBytesPerSecond,
+                waveFormat.BlockAlign, waveFormat.BitsPerSample);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Re-presents a wave provider under a different (byte-compatible) WaveFormat. Reads
+    /// pass straight through to the underlying provider.
+    /// </summary>
+    private class WaveFormatAdapter : IWaveProvider
+    {
+        private readonly IWaveProvider source;
+
+        public WaveFormatAdapter(IWaveProvider source, WaveFormat waveFormat)
+        {
+            this.source = source;
+            WaveFormat = waveFormat;
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public int Read(Span<byte> buffer) => source.Read(buffer);
     }
 }

--- a/tests/NAudio.Core.Tests/WaveStreams/SampleProviderConvertersTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/SampleProviderConvertersTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using System.Text;
+using NAudio.Dmo;
+using NAudio.Wave;
+using NUnit.Framework;
+
+namespace NAudio.Core.Tests.WaveStreams;
+
+// Regression tests for issue #639: WaveFileReader.ToSampleProvider() threw
+// "Unsupported source encoding" for WAVE_FORMAT_EXTENSIBLE files, which is how
+// multichannel / >16 bit / >4GB PCM and float audio is usually described.
+[TestFixture]
+[Category("UnitTest")]
+public class SampleProviderConvertersTests
+{
+    [Test]
+    public void Extensible16BitStereoPcmIsConverted()
+    {
+        // two stereo frames: L = +0.5, R = -0.5
+        short[] samples = { 16384, -16384, 16384, -16384 };
+        var data = new byte[samples.Length * 2];
+        Buffer.BlockCopy(samples, 0, data, 0, data.Length);
+
+        var buffer = ReadAllSamples(44100, 16, 2, AudioMediaSubtypes.MEDIASUBTYPE_PCM, data, samples.Length);
+
+        Assert.That(buffer[0], Is.EqualTo(0.5f).Within(0.0001));
+        Assert.That(buffer[1], Is.EqualTo(-0.5f).Within(0.0001));
+        Assert.That(buffer[2], Is.EqualTo(0.5f).Within(0.0001));
+        Assert.That(buffer[3], Is.EqualTo(-0.5f).Within(0.0001));
+    }
+
+    [Test]
+    public void Extensible24BitMultiChannelPcmIsConverted()
+    {
+        // one 6-channel frame, every sample = +0.5 (0x400000 little-endian = 00 00 40)
+        const int channels = 6;
+        var data = new byte[channels * 3];
+        for (int ch = 0; ch < channels; ch++)
+        {
+            data[ch * 3 + 0] = 0x00;
+            data[ch * 3 + 1] = 0x00;
+            data[ch * 3 + 2] = 0x40;
+        }
+
+        var buffer = ReadAllSamples(48000, 24, channels, AudioMediaSubtypes.MEDIASUBTYPE_PCM, data, channels);
+
+        for (int ch = 0; ch < channels; ch++)
+        {
+            Assert.That(buffer[ch], Is.EqualTo(0.5f).Within(0.0001), "channel " + ch);
+        }
+    }
+
+    [Test]
+    public void Extensible32BitFloatIsConverted()
+    {
+        float[] samples = { 0.25f, -0.75f, 1.0f, -1.0f };
+        var data = new byte[samples.Length * 4];
+        Buffer.BlockCopy(samples, 0, data, 0, data.Length);
+
+        var buffer = ReadAllSamples(44100, 32, 2, AudioMediaSubtypes.MEDIASUBTYPE_IEEE_FLOAT, data, samples.Length);
+
+        for (int n = 0; n < samples.Length; n++)
+        {
+            Assert.That(buffer[n], Is.EqualTo(samples[n]).Within(0.0001), "sample " + n);
+        }
+    }
+
+    [Test]
+    public void ExtensibleWithUnsupportedSubFormatStillThrows()
+    {
+        // AC-3 spdif is a valid extensible subformat that is not raw PCM or IEEE float
+        var data = new byte[8];
+        using var wav = BuildExtensibleWav(48000, 16, 2, AudioMediaSubtypes.MEDIASUBTYPE_DOLBY_AC3_SPDIF, data);
+        using var reader = new WaveFileReader(wav);
+
+        Assert.Throws<ArgumentException>(() => reader.ToSampleProvider());
+    }
+
+    private static float[] ReadAllSamples(int rate, int bits, int channels, Guid subFormat, byte[] data, int expectedSamples)
+    {
+        using var wav = BuildExtensibleWav(rate, bits, channels, subFormat, data);
+        using var reader = new WaveFileReader(wav);
+
+        var sampleProvider = reader.ToSampleProvider();
+        Assert.That(sampleProvider.WaveFormat.Encoding, Is.EqualTo(WaveFormatEncoding.IeeeFloat));
+        Assert.That(sampleProvider.WaveFormat.SampleRate, Is.EqualTo(rate));
+        Assert.That(sampleProvider.WaveFormat.Channels, Is.EqualTo(channels));
+
+        var buffer = new float[expectedSamples];
+        int read = sampleProvider.Read(buffer.AsSpan());
+        Assert.That(read, Is.EqualTo(expectedSamples), "samples read");
+        return buffer;
+    }
+
+    // Builds an in-memory WAV file with a WAVE_FORMAT_EXTENSIBLE fmt chunk and the given
+    // SubFormat GUID, mirroring what a real multichannel / high bit depth WAV looks like.
+    private static MemoryStream BuildExtensibleWav(int rate, int bits, int channels, Guid subFormat, byte[] data)
+    {
+        var ms = new MemoryStream();
+        var w = new BinaryWriter(ms, Encoding.ASCII, leaveOpen: true);
+        short blockAlign = (short)(channels * bits / 8);
+
+        w.Write(Encoding.ASCII.GetBytes("RIFF"));
+        w.Write(0); // RIFF size placeholder, patched below
+        w.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+        w.Write(Encoding.ASCII.GetBytes("fmt "));
+        w.Write(40);                       // fmt chunk length (16 + 2 cbSize + 22 ext)
+        w.Write((ushort)0xFFFE);           // WAVE_FORMAT_EXTENSIBLE
+        w.Write((short)channels);
+        w.Write(rate);
+        w.Write(rate * blockAlign);        // average bytes per second
+        w.Write(blockAlign);
+        w.Write((short)bits);
+        w.Write((short)22);                // cbSize
+        w.Write((short)bits);              // wValidBitsPerSample
+        w.Write((1 << channels) - 1);      // dwChannelMask
+        w.Write(subFormat.ToByteArray());  // SubFormat GUID
+
+        w.Write(Encoding.ASCII.GetBytes("data"));
+        w.Write(data.Length);
+        w.Write(data);
+        w.Flush();
+
+        long fileLength = ms.Length;
+        ms.Position = 4;
+        w.Write((uint)(fileLength - 8));
+        w.Flush();
+
+        ms.Position = 0;
+        return ms;
+    }
+}


### PR DESCRIPTION
Fixes #639.

## Problem

`WaveFileReader.ToSampleProvider()` threw `"Unsupported source encoding"` for WAV files that are multichannel, more than 16 bits per sample, or larger than 4 GB. These are stored as `WAVE_FORMAT_EXTENSIBLE`, which `SampleProviderConverters.ConvertWaveProviderIntoSampleProvider` did not recognise — it only handled the bare `Pcm` and `IeeeFloat` encoding tags.

## Fix

An extensible source is now re-presented under its equivalent standard PCM or IEEE float format — the sample bytes are identical, only the reported `WaveFormat` differs — via a small pass-through adapter. It then dispatches to the existing converters by bit depth exactly as before.

Two subtleties made a naive "just add an `Extensible` case" insufficient:

1. **`WaveFileReader` does not return a `WaveFormatExtensible`.** Reading a file goes through `WaveFormat.FromFormatChunk`, which yields a `WaveFormatExtraData` whose `Encoding == Extensible`. So a `is WaveFormatExtensible` check would miss the exact scenario in the issue. The `SubFormat` GUID is now resolved from both the in-code `WaveFormatExtensible` type *and* the file-read `WaveFormatExtraData`'s 22-byte extension.
2. **`WaveToSampleProvider` / `WaveToSampleProvider64` guard their constructors** with `Encoding != IeeeFloat → throw`. Routing an extensible-float source straight to them would still throw, so the adapter presents a real `IeeeFloat` format to satisfy that guard.

Extensible formats with a non-PCM/float subformat (AC-3, DTS, etc.) still throw `ArgumentException` as before.

## Tests

Added `SampleProviderConvertersTests` covering:
- 16-bit stereo extensible PCM
- 24-bit 6-channel extensible PCM
- 32-bit float extensible
- an unsupported (AC-3 SPDIF) extensible subformat that must still throw

Each WAV is synthesised in-memory and read back through `WaveFileReader.ToSampleProvider()`.

## Verification

Built and ran the cross-platform suite on Linux: the 4 new tests pass and all 1424 tests are green (3 integration tests skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDHeEtzz9Gp4r9Sx39zqrv)_