### PR TITLE
Fix WaveFileWriter.WriteSample writing near-silence for 32-bit extensible WAV (#651)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,7 +62,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
 
  * `WaveOut`: fixed a race where stopping/disposing faster than the buffer latency could throw a `NullReferenceException` via `PlaybackStopped` (#804)
  * `WaveFileWriter`: removed the finalizer that fired an unconditional `Debug.Assert` and could crash the process on the finalizer thread when construction had thrown
- * `WaveFileWriter.WriteSample`: fixed 32-bit PCM output writing near-silence — the normalised float was truncated to an `Int32` before scaling, so almost every sample was written as zero (#651)
+ * `WaveFileWriter.WriteSample`: fixed 32-bit `WaveFormatExtensible` output writing near-silence — the normalised float was truncated to an `Int32` before scaling (writing zero for almost every sample), and the branch ignored the format's SubFormat; it now writes IEEE-float or integer-PCM samples according to the declared subformat (#651)
  * `AudioClient.Dispose` is now idempotent and safe against concurrent/re-entrant disposal, fixing an intermittent interop `NullReferenceException` (#1183)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide, fixing process-killing access violations under concurrent ACM use
  * `WaveFileReader` / `AiffFileReader`: malformed headers declaring `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` later (#1254); `WaveFileReader` no longer throws on an oversized `fmt` `cbSize` (#482)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,6 +62,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
 
  * `WaveOut`: fixed a race where stopping/disposing faster than the buffer latency could throw a `NullReferenceException` via `PlaybackStopped` (#804)
  * `WaveFileWriter`: removed the finalizer that fired an unconditional `Debug.Assert` and could crash the process on the finalizer thread when construction had thrown
+ * `WaveFileWriter.WriteSample`: fixed 32-bit PCM output writing near-silence — the normalised float was truncated to an `Int32` before scaling, so almost every sample was written as zero (#651)
  * `AudioClient.Dispose` is now idempotent and safe against concurrent/re-entrant disposal, fixing an intermittent interop `NullReferenceException` (#1183)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide, fixing process-killing access violations under concurrent ACM use
  * `WaveFileReader` / `AiffFileReader`: malformed headers declaring `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` later (#1254); `WaveFileReader` no longer throws on an oversized `fmt` `cbSize` (#482)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -63,6 +63,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `WaveOut`: fixed a race where stopping/disposing faster than the buffer latency could throw a `NullReferenceException` via `PlaybackStopped` (#804)
  * `WaveFileWriter`: removed the finalizer that fired an unconditional `Debug.Assert` and could crash the process on the finalizer thread when construction had thrown
  * `WaveFileWriter.WriteSample`: fixed 32-bit `WaveFormatExtensible` output writing near-silence — the normalised float was truncated to an `Int32` before scaling (writing zero for almost every sample), and the branch ignored the format's SubFormat; it now writes IEEE-float or integer-PCM samples according to the declared subformat (#651)
+ * `WaveExtensionMethods.AsStandardWaveFormat`: now also resolves the SubFormat of a `WaveFormatExtraData` (how an extensible format read from a file/stream is materialised), not just a `WaveFormatExtensible`
  * `AudioClient.Dispose` is now idempotent and safe against concurrent/re-entrant disposal, fixing an intermittent interop `NullReferenceException` (#1183)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide, fixing process-killing access violations under concurrent ACM use
  * `WaveFileReader` / `AiffFileReader`: malformed headers declaring `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` later (#1254); `WaveFileReader` no longer throws on an oversized `fmt` `cbSize` (#482)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,7 +62,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
 
  * `WaveOut`: fixed a race where stopping/disposing faster than the buffer latency could throw a `NullReferenceException` via `PlaybackStopped` (#804)
  * `WaveFileWriter`: removed the finalizer that fired an unconditional `Debug.Assert` and could crash the process on the finalizer thread when construction had thrown
- * `WaveFileWriter.WriteSample`: fixed 32-bit `WaveFormatExtensible` output writing near-silence — the normalised float was truncated to an `Int32` before scaling (writing zero for almost every sample), and the branch ignored the format's SubFormat; it now writes IEEE-float or integer-PCM samples according to the declared subformat (#651)
+ * `WaveFileWriter.WriteSample` / `WriteSamples`: fixed 32-bit `WaveFormatExtensible` output writing near-silence or corrupt data — `WriteSample(float)` truncated the normalised float to an `Int32` before scaling (writing zero for almost every sample), and both paths ignored the format's SubFormat; they now write IEEE-float or integer-PCM samples according to the declared subformat (#651)
  * `WaveExtensionMethods.AsStandardWaveFormat`: now also resolves the SubFormat of a `WaveFormatExtraData` (how an extensible format read from a file/stream is materialised), not just a `WaveFormatExtensible`
  * `AudioClient.Dispose` is now idempotent and safe against concurrent/re-entrant disposal, fixing an intermittent interop `NullReferenceException` (#1183)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide, fixing process-killing access violations under concurrent ACM use

--- a/src/NAudio.Core/Wave/WaveExtensionMethods.cs
+++ b/src/NAudio.Core/Wave/WaveExtensionMethods.cs
@@ -28,14 +28,31 @@ public static class WaveExtensionMethods
     }
 
     /// <summary>
-    /// Turns WaveFormatExtensible into a standard waveformat if possible
+    /// Turns a WAVE_FORMAT_EXTENSIBLE into a standard waveformat if possible. Copes with
+    /// both <see cref="WaveFormatExtensible"/> (e.g. one you constructed) and
+    /// <see cref="WaveFormatExtraData"/> (how an extensible format read from a file or stream
+    /// is materialised), unpacking the SubFormat GUID from the raw extra data in the latter case.
     /// </summary>
     /// <param name="waveFormat">Input wave format</param>
     /// <returns>A standard PCM or IEEE waveformat, or the original waveformat</returns>
     public static WaveFormat AsStandardWaveFormat(this WaveFormat waveFormat)
     {
-        var wfe = waveFormat as WaveFormatExtensible;
-        return wfe != null ? wfe.ToStandardWaveFormat() : waveFormat;
+        if (waveFormat is WaveFormatExtensible wfe)
+        {
+            return wfe.ToStandardWaveFormat();
+        }
+        // A WaveFormatExtensible read back from a stream arrives as a WaveFormatExtraData whose
+        // SubFormat GUID lives in the extra data (after the 2-byte wValidBitsPerSample and
+        // 4-byte dwChannelMask fields).
+        if (waveFormat is WaveFormatExtraData { Encoding: WaveFormatEncoding.Extensible } extra && extra.ExtraSize >= 22)
+        {
+            var subFormat = new Guid(extra.ExtraData.AsSpan(6, 16));
+            if (subFormat == NAudio.Dmo.AudioMediaSubtypes.MEDIASUBTYPE_IEEE_FLOAT && waveFormat.BitsPerSample == 32)
+                return WaveFormat.CreateIeeeFloatWaveFormat(waveFormat.SampleRate, waveFormat.Channels);
+            if (subFormat == NAudio.Dmo.AudioMediaSubtypes.MEDIASUBTYPE_PCM)
+                return new WaveFormat(waveFormat.SampleRate, waveFormat.BitsPerSample, waveFormat.Channels);
+        }
+        return waveFormat;
     }
 
     /// <summary>

--- a/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -489,12 +489,25 @@ public class WaveFileWriter : Stream
             }
             dataChunkSize += (count * 3);
         }
-        // 32 bit PCM data
+        // 32 bit PCM or IEEE float data
         else if (WaveFormat.BitsPerSample == 32 && WaveFormat.Encoding == WaveFormatEncoding.Extensible)
         {
-            for (int sample = 0; sample < count; sample++)
+            // As in WriteSample, a 32-bit extensible format may carry an IEEE-float subformat,
+            // in which case the 16-bit samples must be normalised to float rather than written
+            // as integer PCM (which would leave float-declared data unreadable).
+            if (WaveFormat.AsStandardWaveFormat().Encoding == WaveFormatEncoding.IeeeFloat)
             {
-                writer.Write(UInt16.MaxValue * samples[sample + offset]);
+                for (int sample = 0; sample < count; sample++)
+                {
+                    writer.Write(samples[sample + offset] / (float)(Int16.MaxValue + 1));
+                }
+            }
+            else
+            {
+                for (int sample = 0; sample < count; sample++)
+                {
+                    writer.Write(UInt16.MaxValue * samples[sample + offset]);
+                }
             }
             dataChunkSize += (count * 4);
         }

--- a/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using NAudio.Wave.SampleProviders;
 using NAudio.Utils;
-using NAudio.Dmo;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
@@ -407,10 +406,10 @@ public class WaveFileWriter : Stream
         else if (WaveFormat.BitsPerSample == 32 && WaveFormat.Encoding == WaveFormatEncoding.Extensible)
         {
             // A 32-bit WAVE_FORMAT_EXTENSIBLE can be either integer PCM or IEEE float,
-            // distinguished by its SubFormat GUID (NAudio's WaveFormatExtensible defaults
-            // 32-bit to IEEE float). Honour the declared subformat rather than assuming PCM.
-            if (WaveFormat is WaveFormatExtensible { SubFormat: var subFormat } &&
-                subFormat == AudioMediaSubtypes.MEDIASUBTYPE_IEEE_FLOAT)
+            // distinguished by its SubFormat GUID (NAudio defaults 32-bit extensible to IEEE
+            // float). AsStandardWaveFormat resolves the subformat for both WaveFormatExtensible
+            // and WaveFormatExtraData, so honour it rather than assuming PCM.
+            if (WaveFormat.AsStandardWaveFormat().Encoding == WaveFormatEncoding.IeeeFloat)
             {
                 writer.Write(sample);
             }

--- a/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using NAudio.Wave.SampleProviders;
 using NAudio.Utils;
+using NAudio.Dmo;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
@@ -405,7 +406,18 @@ public class WaveFileWriter : Stream
         }
         else if (WaveFormat.BitsPerSample == 32 && WaveFormat.Encoding == WaveFormatEncoding.Extensible)
         {
-            writer.Write((Int32)(Int32.MaxValue * sample));
+            // A 32-bit WAVE_FORMAT_EXTENSIBLE can be either integer PCM or IEEE float,
+            // distinguished by its SubFormat GUID (NAudio's WaveFormatExtensible defaults
+            // 32-bit to IEEE float). Honour the declared subformat rather than assuming PCM.
+            if (WaveFormat is WaveFormatExtensible { SubFormat: var subFormat } &&
+                subFormat == AudioMediaSubtypes.MEDIASUBTYPE_IEEE_FLOAT)
+            {
+                writer.Write(sample);
+            }
+            else
+            {
+                writer.Write((Int32)(Int32.MaxValue * sample));
+            }
             dataChunkSize += 4;
         }
         else if (WaveFormat.Encoding == WaveFormatEncoding.IeeeFloat)

--- a/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -405,7 +405,7 @@ public class WaveFileWriter : Stream
         }
         else if (WaveFormat.BitsPerSample == 32 && WaveFormat.Encoding == WaveFormatEncoding.Extensible)
         {
-            writer.Write(UInt16.MaxValue * (Int32)sample);
+            writer.Write((Int32)(Int32.MaxValue * sample));
             dataChunkSize += 4;
         }
         else if (WaveFormat.Encoding == WaveFormatEncoding.IeeeFloat)

--- a/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
@@ -107,6 +107,39 @@ public class WaveFileWriterTests
     }
 
     [Test]
+    public void WriteSampleTo32BitPcmRoundTripsCorrectly()
+    {
+        // Regression test for https://github.com/naudio/NAudio/issues/651
+        // Previously WriteSample truncated the normalised float to an Int32 before
+        // scaling, so almost every sample was written as zero.
+        var samples = new[] { 0.0f, 0.5f, -0.5f, 0.25f, -0.25f, 1.0f, -1.0f };
+        var ms = new MemoryStream();
+        using (var writer = new WaveFileWriter(new IgnoreDisposeStream(ms), new WaveFormatExtensible(44100, 32, 1)))
+        {
+            foreach (var sample in samples)
+            {
+                writer.WriteSample(sample);
+            }
+        }
+
+        ms.Position = 0;
+        using var reader = new WaveFileReader(ms);
+        Assert.That(reader.WaveFormat.BitsPerSample, Is.EqualTo(32), "Bits Per Sample");
+        Assert.That(reader.Length, Is.EqualTo(samples.Length * 4), "Data length");
+
+        var buffer = new byte[samples.Length * 4];
+        int read = reader.Read(buffer, 0, buffer.Length);
+        Assert.That(read, Is.EqualTo(buffer.Length), "Bytes read");
+
+        for (int n = 0; n < samples.Length; n++)
+        {
+            int actual = BitConverter.ToInt32(buffer, n * 4);
+            int expected = (int)(int.MaxValue * samples[n]);
+            Assert.That(actual, Is.EqualTo(expected), $"Sample {n} ({samples[n]})");
+        }
+    }
+
+    [Test]
     [Explicit]
     public void CanCreateWaveFileGreaterThan2Gb()
     {

--- a/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
@@ -183,6 +183,31 @@ public class WaveFileWriterTests
     }
 
     [Test]
+    public void WriteShortSamplesTo32BitExtensibleFloatRoundTripsCorrectly()
+    {
+        // The WriteSamples(short[]) path shared the WriteSample bug: it wrote integer PCM into a
+        // 32-bit extensible format even when that format's subformat is IEEE float.
+        var samples = new short[] { 0, 16384, -16384, short.MaxValue, short.MinValue };
+        var ms = new MemoryStream();
+        using (var writer = new WaveFileWriter(new IgnoreDisposeStream(ms), new WaveFormatExtensible(44100, 32, 1)))
+        {
+            writer.WriteSamples(samples, 0, samples.Length);
+        }
+
+        ms.Position = 0;
+        using var reader = new WaveFileReader(ms);
+        Assert.That(reader.Length, Is.EqualTo(samples.Length * 4), "Data length");
+        var buffer = new byte[samples.Length * 4];
+        int read = reader.Read(buffer, 0, buffer.Length);
+        Assert.That(read, Is.EqualTo(buffer.Length), "Bytes read");
+        for (int n = 0; n < samples.Length; n++)
+        {
+            float expected = samples[n] / (float)(short.MaxValue + 1);
+            Assert.That(BitConverter.ToSingle(buffer, n * 4), Is.EqualTo(expected), $"Sample {n} ({samples[n]})");
+        }
+    }
+
+    [Test]
     [Explicit]
     public void CanCreateWaveFileGreaterThan2Gb()
     {

--- a/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using NAudio.Wave;
 using System.IO;
 using NAudio.Utils;
+using NAudio.Dmo;
 using NAudio.Tests.Shared;
 
 namespace NAudio.Core.Tests.WaveStreams;
@@ -107,14 +108,18 @@ public class WaveFileWriterTests
     }
 
     [Test]
-    public void WriteSampleTo32BitPcmRoundTripsCorrectly()
+    public void WriteSampleTo32BitExtensibleFloatRoundTripsCorrectly()
     {
         // Regression test for https://github.com/naudio/NAudio/issues/651
-        // Previously WriteSample truncated the normalised float to an Int32 before
-        // scaling, so almost every sample was written as zero.
+        // A 32-bit WaveFormatExtensible defaults to an IEEE-float subformat, so WriteSample
+        // must write the float verbatim. Previously it truncated the normalised float to an
+        // Int32 before scaling, so almost every sample was written as zero.
         var samples = new[] { 0.0f, 0.5f, -0.5f, 0.25f, -0.25f, 1.0f, -1.0f };
+        var format = new WaveFormatExtensible(44100, 32, 1);
+        Assert.That(format.SubFormat, Is.EqualTo(AudioMediaSubtypes.MEDIASUBTYPE_IEEE_FLOAT), "Sanity: default 32-bit extensible is IEEE float");
+
         var ms = new MemoryStream();
-        using (var writer = new WaveFileWriter(new IgnoreDisposeStream(ms), new WaveFormatExtensible(44100, 32, 1)))
+        using (var writer = new WaveFileWriter(new IgnoreDisposeStream(ms), format))
         {
             foreach (var sample in samples)
             {
@@ -125,6 +130,7 @@ public class WaveFileWriterTests
         ms.Position = 0;
         using var reader = new WaveFileReader(ms);
         Assert.That(reader.WaveFormat.BitsPerSample, Is.EqualTo(32), "Bits Per Sample");
+        Assert.That(reader.WaveFormat.Encoding, Is.EqualTo(WaveFormatEncoding.Extensible), "Encoding");
         Assert.That(reader.Length, Is.EqualTo(samples.Length * 4), "Data length");
 
         var buffer = new byte[samples.Length * 4];
@@ -133,9 +139,8 @@ public class WaveFileWriterTests
 
         for (int n = 0; n < samples.Length; n++)
         {
-            int actual = BitConverter.ToInt32(buffer, n * 4);
-            int expected = (int)(int.MaxValue * samples[n]);
-            Assert.That(actual, Is.EqualTo(expected), $"Sample {n} ({samples[n]})");
+            float actual = BitConverter.ToSingle(buffer, n * 4);
+            Assert.That(actual, Is.EqualTo(samples[n]), $"Sample {n} ({samples[n]})");
         }
     }
 

--- a/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
@@ -145,6 +145,44 @@ public class WaveFileWriterTests
     }
 
     [Test]
+    public void WriteSampleResolvesSubFormatFromReadBackExtensibleFormat()
+    {
+        // When an extensible format is read back from a stream it materialises as a
+        // WaveFormatExtraData (not a WaveFormatExtensible), so WriteSample must still be able to
+        // resolve the IEEE-float subformat when that format is reused to write a new file.
+        var samples = new[] { 0.0f, 0.5f, -0.5f, 1.0f, -1.0f };
+
+        var firstPass = new MemoryStream();
+        using (var writer = new WaveFileWriter(new IgnoreDisposeStream(firstPass), new WaveFormatExtensible(44100, 32, 1)))
+        {
+            foreach (var sample in samples) writer.WriteSample(sample);
+        }
+
+        firstPass.Position = 0;
+        using var reader = new WaveFileReader(firstPass);
+        var readBackFormat = reader.WaveFormat;
+        Assert.That(readBackFormat, Is.InstanceOf<WaveFormatExtraData>(), "Read-back format type");
+        Assert.That(readBackFormat.AsStandardWaveFormat().Encoding, Is.EqualTo(WaveFormatEncoding.IeeeFloat), "Resolved subformat");
+
+        // Reuse the read-back (WaveFormatExtraData) format to write a fresh file.
+        var secondPass = new MemoryStream();
+        using (var writer = new WaveFileWriter(new IgnoreDisposeStream(secondPass), readBackFormat))
+        {
+            foreach (var sample in samples) writer.WriteSample(sample);
+        }
+
+        secondPass.Position = 0;
+        using var reader2 = new WaveFileReader(secondPass);
+        var buffer = new byte[samples.Length * 4];
+        int read = reader2.Read(buffer, 0, buffer.Length);
+        Assert.That(read, Is.EqualTo(buffer.Length), "Bytes read");
+        for (int n = 0; n < samples.Length; n++)
+        {
+            Assert.That(BitConverter.ToSingle(buffer, n * 4), Is.EqualTo(samples[n]), $"Sample {n} ({samples[n]})");
+        }
+    }
+
+    [Test]
     [Explicit]
     public void CanCreateWaveFileGreaterThan2Gb()
     {


### PR DESCRIPTION
Fixes #651.

## Problem

`WaveFileWriter.WriteSample(float)` produced near-silent / corrupted output for 32-bit `WaveFormatExtensible`. The branch was:

```csharp
writer.Write(UInt16.MaxValue * (Int32)sample);
```

Two issues:

1. **Truncation before scaling.** Samples are normalised floats in `[-1, 1]`, so `(Int32)sample` truncates toward zero — every value except exactly `±1.0` became `0`. This is the bug reported in #651 and confirmed by the maintainer.
2. **Wrong subformat assumption.** A 32-bit `WAVE_FORMAT_EXTENSIBLE` is *not* necessarily integer PCM — it can be IEEE float, distinguished by its `SubFormat` GUID. In fact NAudio's own `new WaveFormatExtensible(rate, 32, channels)` **defaults 32-bit to `KSDATAFORMAT_SUBTYPE_IEEE_FLOAT`**. The branch ignored this and always wrote integer PCM, so for the common (default) float format it produced an internally inconsistent file: a float header with integer-PCM data, which a subformat-honouring reader decodes as garbage.

The same subformat-assumption flaw was present in `WaveFileWriter.WriteSamples(short[])`.

## Fix

Resolve the subformat via `AsStandardWaveFormat()` and route on it. Crucially, reading an extensible WAV back yields a `WaveFormatExtraData` (not a `WaveFormatExtensible`), so `AsStandardWaveFormat` was **extended to unpack the SubFormat GUID from a `WaveFormatExtraData`'s raw extra data** — otherwise reusing a read-back format to write would silently fall back to integer PCM.

- `WriteSample(float)`: IEEE-float subformat → write the float; otherwise → scaled 32-bit integer PCM.
- `WriteSamples(short[])`: IEEE-float subformat → normalise the 16-bit sample to float; otherwise → integer PCM.

`AiffFileWriter` was reviewed and is **unaffected**: its `WriteSample(float)` uses `ConvertFloatTo32BitPcm` (correct scaling, no truncation), and AIFF stores no subformat GUID, so its `Extensible` branch is correctly 32-bit integer PCM (float is handled by the separate `IeeeFloat` branch).

## Tests

- `WriteSampleTo32BitExtensibleFloatRoundTripsCorrectly` — float `WriteSample` round-trip via `WaveFileReader`.
- `WriteSampleResolvesSubFormatFromReadBackExtensibleFormat` — writes, reads the format back as `WaveFormatExtraData`, reuses it to write again, and verifies the floats survive (this fails under a plain `is WaveFormatExtensible` check).
- `WriteShortSamplesTo32BitExtensibleFloatRoundTripsCorrectly` — `WriteSamples(short[])` round-trip.
- Full `NAudio.Core.Tests` suite passes (1423 passed, 0 failed, 3 explicit skipped).

`RELEASE_NOTES.md` entries added under *Notable bug fixes* for the `WriteSample`/`WriteSamples` fix and the `AsStandardWaveFormat` enhancement.

## Note

The 24-bit `WriteSamples(short[])` branch scales via `UInt16.MaxValue` and the upper-3-bytes trick, giving a result off by up to ~128 LSBs from an exact `s << 8`. That's a pre-existing cosmetic imprecision (24-bit is always integer PCM, so no subformat ambiguity), not the reported bug — left unchanged to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DTbUWmfuVPUBByVYPC1js