### PR TITLE
Make MP3 problem-file integration test recurse and use a portable path

### DIFF
--- a/tests/NAudio.Windows.Tests/Mp3/Mp3FileReaderTests.cs
+++ b/tests/NAudio.Windows.Tests/Mp3/Mp3FileReaderTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.IO;
 using NAudio.Wave;
 using System.Diagnostics;
@@ -13,14 +14,14 @@ public class Mp3FileReaderTests
     [Category("IntegrationTest")]
     public void CanLoadAndReadVariousProblemMp3Files()
     {
-        string testDataFolder = @"C:\Users\Mark\Downloads\NAudio";
+        string testDataFolder = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads", "NAudio");
         if (!Directory.Exists(testDataFolder))
         {
             Assert.Ignore($"{testDataFolder} not found");
         }
-        foreach (string file in Directory.GetFiles(testDataFolder, "*.mp3"))
+        foreach (string mp3File in Directory.GetFiles(testDataFolder, "*.mp3", SearchOption.AllDirectories))
         {
-            string mp3File = Path.Combine(testDataFolder, file);
             Debug.WriteLine($"Opening {mp3File}");
             using var reader = new Mp3FileReader(mp3File);
             byte[] buffer = new byte[4096];


### PR DESCRIPTION
The `CanLoadAndReadVariousProblemMp3Files` integration test hardcoded `C:\Users\Mark\Downloads\NAudio` and only scanned the top level of that folder.

This change:
- Resolves the folder from `%USERPROFILE%\Downloads\NAudio` (`Environment.SpecialFolder.UserProfile`) so it works regardless of the Windows username.
- Recurses with `SearchOption.AllDirectories`, so problem files organised into subfolders (e.g. `MP3 Sample Rate Changed\`) are picked up.

Test-only change; still gated behind `[Category("IntegrationTest")]` and `Assert.Ignore` when the folder is absent, so it remains skipped in headless CI. No release-notes entry needed.

Context: verified the current `Mp3FileReader` (default ACM decompressor) now loads and fully decodes all problem MP3s in that folder without the historic "sample rate changed" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)