### PR TITLE
Fix BlockAlignReductionStream truncating reads larger than its buffer (#1022)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -78,6 +78,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `Mp3FileReader`: fixed false sample-rate-change errors near end of file, and more robust MP3 frame parsing against album art / trailing metadata
  * `MidiFile`: preserve running-status across meta events (fixes "Read too far")
  * `BlockAlignReductionStream.Position`: validates the incoming value, so a block-aligned seek after an arbitrary read no longer wrongly throws (#368)
+ * `BlockAlignReductionStream.Read`: a single read (or `Stream.CopyTo` chunk) larger than the 4-second internal buffer no longer silently discards the rest of the source and truncates the stream — e.g. converting a non-PCM WAV via `AudioFileReader` on .NET Core (#1022)
  * `MmException` messages now append a human-readable `MmResult` description (#1192); `Id3v2Tag.ReadTag` no longer throws/catches for tagless MP3 streams (#265)
  * ASIO: implemented missing `Asio64Bit` Int24LSB/Float32LSB conversions and fixed a byte-order bug in `GetSamplePosition`; `WdlResampler` backported three upstream Cockos WDL fixes
  * Hardened Media Foundation and DMO interop against COM ref leaks on error paths (`MediaFoundationReader`, `MediaFoundationEncoder`, `MediaFoundationTransform`, `MediaBuffer`, `Mf*` wrappers) (#1293)

--- a/src/NAudio.Core/Wave/WaveStreams/BlockAlignReductionStream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/BlockAlignReductionStream.cs
@@ -129,13 +129,22 @@ public class BlockAlignReductionStream : WaveStream
         int count = buffer.Length;
         lock (lockObject)
         {
-            // 1. attempt to fill the circular buffer with enough data to meet our request
+            // 1. attempt to fill the circular buffer with enough data to meet our request.
+            // We must never ask the source for more than will fit in the free space: the
+            // circular buffer silently discards any overflow, so a request larger than the
+            // buffer would otherwise read and drop the rest of the source stream, truncating
+            // the output to the buffer's capacity (#1022). Each source read is rounded down to
+            // a whole number of source blocks; a request bigger than the buffer is satisfied
+            // across multiple passes / Read calls instead.
             while (BufferEndPosition < position + count)
             {
-                int sourceReadCount = count;
-                if (sourceReadCount % sourceStream.BlockAlign != 0)
+                int freeSpace = circularBuffer.MaxLength - circularBuffer.Count;
+                int sourceReadCount = freeSpace - (freeSpace % sourceStream.BlockAlign);
+                if (sourceReadCount == 0)
                 {
-                    sourceReadCount = (count + sourceStream.BlockAlign) - (count % sourceStream.BlockAlign);
+                    // buffer is full to within less than one source block - we have staged
+                    // as much as we can for now
+                    break;
                 }
 
                 byte[] sourceBuf = GetSourceBuffer(sourceReadCount);

--- a/tests/NAudio.Core.Tests/WaveStreams/BlockAlignmentReductionStreamTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/BlockAlignmentReductionStreamTests.cs
@@ -91,6 +91,39 @@ public class BlockAlignmentReductionStreamTests
     }
 
     [Test]
+    public void ReadLargerThanBufferReturnsAllData()
+    {
+        // Reproduces #1022: a single read (or CopyTo chunk) larger than the
+        // internal circular buffer - sized at WaveFormat.AverageBytesPerSecond * 4 -
+        // used to truncate the stream. The fill loop asked the source for the whole
+        // request at once; CircularBuffer.Write silently dropped everything past its
+        // capacity and the loop then drained and discarded the rest of the source.
+        // The whole stream must come back regardless of read size.
+        const int streamLength = 80000;
+        BlockAlignedWaveStream inputStream = new BlockAlignedWaveStream(726, streamLength);
+        BlockAlignReductionStream blockStream = new BlockAlignReductionStream(inputStream);
+
+        // 8000 Hz * 2 bytes = 16000 AverageBytesPerSecond -> 64000 byte buffer.
+        // Read more than that in one call to exercise the overflow path.
+        Assert.That(blockStream.WaveFormat.AverageBytesPerSecond * 4, Is.LessThan(streamLength),
+            "test must request more than one buffer's worth in a single read");
+
+        byte[] readBuffer = new byte[streamLength];
+        int total = 0;
+        int read;
+        // Read may legitimately return a partial buffer (capacity-limited); keep
+        // reading until the stream is exhausted, exactly as Stream.CopyTo does.
+        while (total < streamLength && (read = blockStream.Read(readBuffer, total, streamLength - total)) > 0)
+        {
+            total += read;
+        }
+
+        Assert.That(total, Is.EqualTo(streamLength), "total bytes read");
+        Assert.That(blockStream.Position, Is.EqualTo(streamLength), "final position");
+        CheckReadBuffer(readBuffer, streamLength, 0);
+    }
+
+    [Test]
     public void RepositionToNonBlockAlignedPositionThrows()
     {
         // The setter must reject a non-block-aligned target value.


### PR DESCRIPTION
Fixes #1022.

## Problem

`BlockAlignReductionStream` is inserted by `AudioFileReader` only for non-PCM/IEEE-float WAV files (ACM-decoded), and buffers the source through a `CircularBuffer` sized at `WaveFormat.AverageBytesPerSecond * 4` (4 seconds).

The fill loop in `Read` asked the source for the full requested `count` regardless of free space:

```csharp
int sourceReadCount = count; // rounded up to block align
int sourceRead = sourceStream.Read(sourceBuf, 0, sourceReadCount);
circularBuffer.Write(sourceBuf.AsSpan(0, sourceRead));
```

`CircularBuffer.Write` **silently discards** anything past its capacity. So when a single read (or `Stream.CopyTo` chunk) exceeded the 4-second buffer, the first source read filled the buffer and dropped the overflow, then the loop — whose exit condition can never be met because the buffer physically can't hold `count` — read and discarded the rest of the source until EOF. The stream was truncated to its first ~4 seconds.

This is why the reporter saw it only on **.NET Core** and only for **mono** files:
- `.NET Framework` `Stream.CopyTo` uses an 81,920-byte chunk; `.NET Core`/`.NET 6` uses ~128 KB.
- Mono telephony codecs have a small `AverageBytesPerSecond`, shrinking the 4-second buffer below the .NET Core chunk size (e.g. 8 kHz mono float → 128,000-byte buffer, overshot by the 128 KB read but not the 81,920 one).

## Fix

Clamp each source read to the block-aligned free space in the circular buffer; a request larger than the buffer is now satisfied across multiple passes / `Read` calls instead of overflowing. Any buffer size is safe afterwards.

## Test

Adds `ReadLargerThanBufferReturnsAllData`, which reads more than `AverageBytesPerSecond * 4` in a single call and asserts the entire stream is returned with correct data. Verified it **fails on the old code and passes on the fix**. Full `NAudio.Core.Tests` suite: 1431 passed, 0 failed, 3 skipped (integration).

## Notes

- The 4-second buffer size is left unchanged; correctness no longer depends on it. Shrinking it (memory only) could be a separate follow-up.
- The unrelated MP3-frame-concatenation comment later in #1022 (sean-m-cooper) is a different code path and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPZTZ5ddqeuY9CYwcT1RCs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPZTZ5ddqeuY9CYwcT1RCs)_