### PR TITLE
Fix WaveFileReader throwing on oversized data chunk length (#1090)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `AudioClient.Dispose` is now idempotent and safe against concurrent/re-entrant disposal, fixing an intermittent interop `NullReferenceException` (#1183)
  * `AcmInterop`: serialised all `msacm32` P/Invokes process-wide, fixing process-killing access violations under concurrent ACM use
  * `WaveFileReader` / `AiffFileReader`: malformed headers declaring `BlockAlign=0` now throw `InvalidDataException` from the constructor instead of `DivideByZeroException` later (#1254); `WaveFileReader` no longer throws on an oversized `fmt` `cbSize` (#482)
+ * `WaveFileReader`: a `data` chunk declaring a bogus/oversized length (e.g. FFmpeg's `0xFFFF1000` placeholder when writing to a non-seekable pipe) is now clamped to the bytes actually present, so reading from a `MemoryStream` no longer throws and the reported length reflects the available audio (#1090)
  * `WaveFormat.Serialize`: PCM formats now write the canonical 16-byte `fmt ` chunk (#934, #1098)
  * `WaveViewer`: fixed rendering upside-down (#801, #818) and now renders any source format correctly via `ToSampleProvider()` (#564)
  * `ToSampleProvider()` now handles `WAVE_FORMAT_EXTENSIBLE` PCM and IEEE float sources (e.g. multichannel / >16-bit WAV files) instead of throwing `Unsupported source encoding` (#639)

--- a/src/NAudio.Core/Wave/WaveStreams/WaveFileChunkReader.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveFileChunkReader.cs
@@ -69,7 +69,13 @@ internal class WaveFileChunkReader
                 dataChunkPosition = stream.Position;
                 if (!isRf64) // we already know the dataChunkLength if this is an RF64 file
                 {
-                    dataChunkLength = chunkLength;
+                    // Some encoders (e.g. FFmpeg writing WAV to a non-seekable pipe) leave a
+                    // placeholder data chunk size such as 0xFFFF1000 that is larger than the
+                    // bytes actually present. Clamp to what the stream really contains so a
+                    // MemoryStream (which cannot seek past its end) doesn't throw, and so the
+                    // reported length reflects the available samples. See issue #1090.
+                    long availableBytes = stream.Length - dataChunkPosition;
+                    dataChunkLength = chunkLength > availableBytes ? availableBytes : chunkLength;
                 }
                 stream.Position += dataChunkLength;
             }

--- a/tests/NAudio.Core.Tests/WaveStreams/WaveFileReaderTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WaveFileReaderTests.cs
@@ -340,4 +340,47 @@ public class WaveFileReaderTests
         Assert.That(BitConverter.ToInt32(data, 0), Is.EqualTo(2));
     }
 
+
+    // Regression: some encoders (e.g. FFmpeg writing WAV to a non-seekable pipe) leave a
+    // placeholder data chunk size that is far larger than the bytes actually present
+    // (such as 0xFFFF1000). Reading from a FileStream tolerated this (seeking past EOF is
+    // allowed) but a MemoryStream threw because the position exceeded the stream length.
+    // The reader must clamp to the available bytes and expose the real length. See issue #1090.
+    [Test]
+    [Category("UnitTest")]
+    public void OversizedDataChunkLengthIsClampedToAvailableBytes()
+    {
+        var audio = new byte[] { 1, 0, 2, 0, 3, 0, 4, 0 }; // 4 mono 16-bit samples
+
+        using var ms = new MemoryStream();
+        using (var w = new BinaryWriter(ms, Encoding.ASCII, leaveOpen: true))
+        {
+            w.Write(Encoding.ASCII.GetBytes("RIFF"));
+            w.Write(0); // RIFF size placeholder, patched below
+            w.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+            w.Write(Encoding.ASCII.GetBytes("fmt "));
+            new WaveFormat(8000, 16, 1).Serialize(w);
+
+            w.Write(Encoding.ASCII.GetBytes("data"));
+            w.Write(0xFFFF1000u); // bogus placeholder size, much larger than the actual data
+            w.Write(audio);
+
+            long fileLength = ms.Length;
+            ms.Position = 4;
+            w.Write((uint)(fileLength - 8));
+        }
+        ms.Position = 0;
+
+        using var reader = new WaveFileReader(ms);
+
+        // length is clamped to what's actually present, not the bogus declared size
+        Assert.That(reader.Length, Is.EqualTo(audio.Length));
+
+        var buffer = new byte[audio.Length];
+        int read = reader.Read(buffer, 0, buffer.Length);
+        Assert.That(read, Is.EqualTo(audio.Length));
+        Assert.That(buffer, Is.EqualTo(audio));
+        Assert.That(reader.Read(buffer, 0, buffer.Length), Is.EqualTo(0));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1090. Some encoders (e.g. FFmpeg writing WAV to a non-seekable pipe) leave a placeholder `data` chunk size such as `0xFFFF1000` that is larger than the bytes actually present. Reading such a file from a `FileStream` worked (seeking past EOF is allowed) but from a `MemoryStream` it threw, because the data-chunk branch in `WaveFileChunkReader` did `stream.Position += dataChunkLength` with no bounds check and the resulting position exceeded the stream length.

`WaveFileChunkReader.ReadWaveHeader` now clamps the non-RF64 `data` chunk length to the bytes actually available (`stream.Length - dataChunkPosition`), so:

- a `MemoryStream` no longer throws, and
- `WaveFileReader.Length` reflects the real available audio.

The RF64 path is untouched (the clamp sits inside `if (!isRf64)`, where the length comes from the `ds64` chunk), and normal valid files are unaffected since the clamp is a no-op when the declared length matches the data present.

No new stream-capability requirement is introduced: `ReadWaveHeader` already reads `stream.Length` unconditionally (and seeks via `stream.Position`) earlier in the method, so the reader already required a seekable, length-reporting stream — the FFmpeg/pipe case is handled by buffering into a `MemoryStream`, which reports both.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

- Added regression test `WaveFileReaderTests.OversizedDataChunkLengthIsClampedToAvailableBytes`: builds an in-memory WAV with a `data` length of `0xFFFF1000` over 8 real bytes, opens it from a `MemoryStream`, and asserts the reported length is clamped and the audio reads back intact.
- Verified the test is a genuine regression catch: it **fails without** the source change and **passes with** it.
- Full cross-platform suite green: **1438 passed, 3 skipped, 0 failed** (`dotnet test tests/NAudio.Core.Tests --filter "TestCategory!=IntegrationTest"`). Normal valid WAVs are covered by the existing read-back tests, which all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016tf17yDtp6cP4bWxS29pzS)_