### PR TITLE
Document IMMNotificationClient no-block / no-reentrancy constraint

### DIFF
--- a/src/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMNotificationClient.cs
+++ b/src/NAudio.Wasapi/CoreAudioApi/Interfaces/IMMNotificationClient.cs
@@ -9,6 +9,16 @@ namespace NAudio.CoreAudioApi.Interfaces;
 /// <c>[GeneratedComClass]</c> and declared <c>partial</c> so a CCW vtable
 /// can be generated at compile time (NativeAOT / trim safe).
 /// </summary>
+/// <remarks>
+/// These methods are called on a Windows audio system worker thread that holds an
+/// internal lock while dispatching the notification. Handlers must return quickly and
+/// must <b>not</b> block, wait on another thread, or call back into the audio stack
+/// (for example disposing a <c>WaveIn</c>/<c>WaveOut</c>/<c>WasapiOut</c>, or calling
+/// back into the device enumerator). Doing so risks a deadlock. To react to a
+/// notification, marshal the work to your own thread asynchronously — e.g.
+/// <c>Control.BeginInvoke</c> rather than <c>Control.Invoke</c>, or a queued
+/// <c>Task.Run</c> — so the callback returns and releases the lock first.
+/// </remarks>
 [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16),
     Guid("7991EEC9-7E89-4D85-8390-6C703CEC60C0"),
     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]

--- a/src/NAudio.Wasapi/CoreAudioApi/MMDeviceEnumerator.cs
+++ b/src/NAudio.Wasapi/CoreAudioApi/MMDeviceEnumerator.cs
@@ -146,6 +146,13 @@ public class MMDeviceEnumerator : IDisposable
     /// Subscribes <paramref name="client"/> to endpoint change notifications
     /// (device added / removed / state change / default changed / property value change).
     /// </summary>
+    /// <remarks>
+    /// The client's callbacks run on a Windows audio system worker thread that holds an
+    /// internal lock for the duration of the call. Handlers must not block, wait on another
+    /// thread, or call back into the audio stack (e.g. disposing a player/recorder); doing so
+    /// risks a deadlock. Marshal any reaction to your own thread asynchronously
+    /// (<c>BeginInvoke</c>, a queued <c>Task.Run</c>, etc.). See <see cref="IMMNotificationClient"/>.
+    /// </remarks>
     /// <returns>The HRESULT from the underlying COM call.</returns>
     public int RegisterEndpointNotificationCallback(IMMNotificationClient client)
     {


### PR DESCRIPTION
## Summary

Adds XML-doc `<remarks>` explaining that `IMMNotificationClient` callbacks must not block or re-enter the audio stack — the root cause of the hang reported in #989.

The submitter''s repro does a synchronous `Control.Invoke(...)` from `OnDefaultDeviceChanged` that disposes a `WaveIn`/`WaveOut`. The notification is delivered on a Windows audio worker thread holding an internal lock; the blocking `Invoke` parks that thread while the UI thread tries to tear down a device that needs the same subsystem → deadlock. This is an inherent constraint of the Core Audio notification contract (it reproduces on current `main` and with `WasapiOut` too), not a library bug, so the fix is guidance rather than code.

## Changes

- `IMMNotificationClient` — `<remarks>` spelling out: callbacks run on an audio worker thread under an internal lock; don''t block, wait on another thread, or call back into the audio stack / enumerator; marshal asynchronously (`BeginInvoke`, not `Invoke`; or a queued `Task.Run`).
- `MMDeviceEnumerator.RegisterEndpointNotificationCallback` — condensed version of the same guidance with a `<see cref>` back to the interface.

Docs-only; flows into the generated API reference. No `RELEASE_NOTES.md` entry (comment-only change is exempt per `CLAUDE.md`).

Refs #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)