### PR TITLE
Stop file writers disposing caller-supplied streams (#1040)

### DIFF
--- a/Docs/MigratingFromNAudio2.md
+++ b/Docs/MigratingFromNAudio2.md
@@ -149,6 +149,49 @@ The old ad-hoc effect types were removed in favour of the new
   (wrap it with `EffectSampleProvider` instead of passing a source to the
   constructor).
 
+## Stream ownership in file writers (`WaveFileWriter` / `AiffFileWriter`)
+
+`WaveFileWriter` and `AiffFileWriter` now follow the same stream-ownership rule the
+readers (`WaveFileReader`, `AiffFileReader`, `Mp3FileReader`) already use, and which the
+.NET BCL follows: **you dispose what you own.**
+
+- The **filename** constructors (`new WaveFileWriter("out.wav", format)`) open the
+  underlying `FileStream` themselves, so they still own and close it on `Dispose` —
+  unchanged behaviour.
+- The **stream** constructors (`new WaveFileWriter(stream, format)`) now treat the stream
+  as caller-owned. Disposing the writer still **finalizes the header and flushes** so the
+  file is valid, but it **no longer disposes the stream you passed in** — that is left for
+  you to dispose.
+
+Previously the stream constructor disposed the caller's stream unconditionally, which is
+why `IgnoreDisposeStream` was needed to write to a `MemoryStream` you wanted to keep
+(`new WaveFileWriter(new IgnoreDisposeStream(ms), format)`). That wrapper is no longer
+necessary — passing the stream directly leaves it open. (`IgnoreDisposeStream` still
+exists and existing code that uses it keeps working.)
+
+**What to check when upgrading.** The one case that changes behaviour is passing a
+*throwaway* stream you didn't keep a reference to and relying on the writer to close it,
+classically:
+
+```csharp
+// before: the writer closed this FileStream for you
+new WaveFileWriter(File.Create(path), format);   // <-- handle now leaks
+```
+
+After the upgrade that `FileStream` handle is left open. Either use the filename overload
+(which owns the file), or dispose the stream yourself:
+
+```csharp
+// preferred - the writer owns the file
+using var writer = new WaveFileWriter(path, format);
+
+// or keep and dispose the stream yourself
+using var stream = File.Create(path);
+using var writer = new WaveFileWriter(stream, format);
+```
+
+The common `new WaveFileWriter(path, format)` filename usage is unaffected.
+
 ## Other type moves and API changes
 
 - `AudioVolumeLevel` moved from `NAudio.Wasapi.CoreAudioApi` to

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ apps need only re-target to `net9.0` and adjust custom providers to the new
  * `WaveOut` / `WaveIn` now default to event-driven callbacks; the window-based variants are renamed `WaveOutWindow` / `WaveInWindow` in `NAudio.WinForms`
  * Some types moved package/namespace as part of the split — classic Windows MIDI I/O and `winmm` types to `NAudio.WinMM`; the DMO/DirectSound types into the new `NAudio.Dmo` package; plus smaller moves (`AudioVolumeLevel`, `CaptureState`, `DmoMp3FrameDecompressor`). Meta-package consumers are unaffected
  * `SimpleCompressorStream`, `ImpulseResponseConvolution` and `NAudio.Extras.Equalizer` were removed — superseded by `NAudio.Effects` (`CompressorEffect`, `ConvolutionReverbEffect`, `Equalizer`)
+ * `WaveFileWriter` / `AiffFileWriter` no longer dispose a caller-supplied stream — the stream constructor now leaves the stream open (it still flushes/finalizes the header on `Dispose`), matching the readers' ownership rule; only the filename constructor owns and closes the file. The `IgnoreDisposeStream` wrapper is no longer needed when writing to a stream you want to keep. If you passed a throwaway stream and relied on the writer closing it, dispose it yourself or use the filename overload (#1040)
 
 #### Notable bug fixes
 
@@ -79,6 +80,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `CueListInterpreter`: WAV files with cue points but no labels now return cues with empty labels instead of null (#549)
  * `ResamplerDmoStream`: fixed an infinite loop on `Read` after seeking and the loss of the resampler tail at end-of-stream (#607, #608)
  * `LoopStream.Read`: no longer spins at 100% CPU when the wrapped source can't satisfy a read (#1338)
+ * `RawSourceWaveStream`: the `byte[]` constructor now disposes the `MemoryStream` it creates internally when the stream is disposed (it previously leaked); a caller-supplied source stream is still left open
  * `Mp3FileReader`: fixed false sample-rate-change errors near end of file, and more robust MP3 frame parsing against album art / trailing metadata
  * `MidiFile`: preserve running-status across meta events (fixes "Read too far")
  * `BlockAlignReductionStream.Position`: validates the incoming value, so a block-aligned seek after an arbitrary read no longer wrongly throws (#368)

--- a/src/NAudio.Core/Wave/WaveOutputs/AiffFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/AiffFileWriter.cs
@@ -16,6 +16,7 @@ public class AiffFileWriter : Stream
     private long dataChunkSize = 8;
     private readonly WaveFormat format;
     private readonly string filename;
+    private readonly bool ownsStream;
 
     /// <summary>
     /// Creates an Aiff file by reading all the data from a WaveProvider
@@ -49,9 +50,20 @@ public class AiffFileWriter : Stream
     /// </summary>
     /// <param name="outStream">Stream to be written to</param>
     /// <param name="format">Wave format to use</param>
+    /// <remarks>
+    /// The supplied stream is <b>not</b> owned by the writer: disposing the writer finalizes
+    /// the AIFF header and flushes the stream, but leaves it open for the caller to dispose.
+    /// Use the filename constructor if you want the writer to own and close the underlying file.
+    /// </remarks>
     public AiffFileWriter(Stream outStream, WaveFormat format)
+        : this(outStream, format, ownsStream: false)
+    {
+    }
+
+    private AiffFileWriter(Stream outStream, WaveFormat format, bool ownsStream)
     {
         this.outStream = outStream;
+        this.ownsStream = ownsStream;
         this.format = format;
         this.writer = new BinaryWriter(outStream, System.Text.Encoding.UTF8);
         this.writer.Write(System.Text.Encoding.UTF8.GetBytes("FORM"));
@@ -68,7 +80,7 @@ public class AiffFileWriter : Stream
     /// <param name="filename">The filename to write to</param>
     /// <param name="format">The Wave Format of the output data</param>
     public AiffFileWriter(string filename, WaveFormat format)
-        : this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read), format)
+        : this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read), format, ownsStream: true)
     {
         this.filename = filename;
     }
@@ -374,7 +386,17 @@ public class AiffFileWriter : Stream
                 {
                     // in a finally block as we don't want the FileStream to run its disposer in
                     // the GC thread if the code above caused an IOException (e.g. due to disk full)
-                    outStream.Dispose(); // will close the underlying base stream
+                    if (ownsStream)
+                    {
+                        // We opened the file (filename constructor), so we close it.
+                        outStream.Dispose(); // will close the underlying base stream
+                    }
+                    else
+                    {
+                        // The caller handed us the stream; finalize the file by flushing,
+                        // but leave the stream open for them to dispose.
+                        outStream.Flush();
+                    }
                     outStream = null;
                 }
             }

--- a/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using NAudio.Wave.SampleProviders;
-using NAudio.Utils;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
@@ -48,6 +47,7 @@ public class WaveFileWriter : Stream
     private long dataChunkSize;
     private readonly WaveFormat format;
     private readonly string filename;
+    private readonly bool ownsStream;
     private readonly bool enableRf64;
     private readonly long rf64PromotionThreshold;
     private readonly long junkChunkPos = -1;
@@ -106,14 +106,15 @@ public class WaveFileWriter : Stream
     /// <param name="source">The source audio</param>
     public static void WriteWavFileToStream(Stream outStream, IWaveProvider source)
     {
-        using var writer = new WaveFileWriter(new IgnoreDisposeStream(outStream), source.WaveFormat);
+        // The stream constructor leaves the caller's stream open; disposing the writer
+        // finalizes the header and flushes, so no IgnoreDisposeStream wrapper is needed.
+        using var writer = new WaveFileWriter(outStream, source.WaveFormat);
         var buffer = new byte[source.WaveFormat.AverageBytesPerSecond * 4];
         while (true)
         {
             var bytesRead = source.Read(buffer.AsSpan());
             if (bytesRead == 0)
             {
-                outStream.Flush();
                 break;
             }
             writer.Write(buffer.AsSpan(0, bytesRead));
@@ -136,10 +137,21 @@ public class WaveFileWriter : Stream
     /// <param name="outStream">Stream to be written to</param>
     /// <param name="format">Wave format to use</param>
     /// <param name="options">Writer configuration; <c>null</c> uses defaults.</param>
+    /// <remarks>
+    /// The supplied stream is <b>not</b> owned by the writer: disposing the writer finalizes
+    /// the WAV header and flushes the stream, but leaves it open for the caller to dispose.
+    /// Use the filename constructor if you want the writer to own and close the underlying file.
+    /// </remarks>
     public WaveFileWriter(Stream outStream, WaveFormat format, WaveFileWriterOptions options)
+        : this(outStream, format, options, ownsStream: false)
+    {
+    }
+
+    private WaveFileWriter(Stream outStream, WaveFormat format, WaveFileWriterOptions options, bool ownsStream)
     {
         options ??= new WaveFileWriterOptions();
         this.outStream = outStream;
+        this.ownsStream = ownsStream;
         this.format = format;
         this.enableRf64 = options.EnableRf64;
         this.rf64PromotionThreshold = options.Rf64PromotionThreshold;
@@ -170,7 +182,7 @@ public class WaveFileWriter : Stream
     /// <param name="filename">The filename to write to</param>
     /// <param name="format">The Wave Format of the output data</param>
     public WaveFileWriter(string filename, WaveFormat format)
-        : this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read), format)
+        : this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read), format, options: null, ownsStream: true)
     {
         this.filename = filename;
     }
@@ -182,7 +194,7 @@ public class WaveFileWriter : Stream
     /// <param name="format">The Wave Format of the output data</param>
     /// <param name="options">Writer configuration; <c>null</c> uses defaults.</param>
     public WaveFileWriter(string filename, WaveFormat format, WaveFileWriterOptions options)
-        : this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read), format, options)
+        : this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read), format, options, ownsStream: true)
     {
         this.filename = filename;
     }
@@ -569,7 +581,17 @@ public class WaveFileWriter : Stream
                 }
                 finally
                 {
-                    outStream.Dispose();
+                    if (ownsStream)
+                    {
+                        // We opened the file (filename constructor), so we close it.
+                        outStream.Dispose();
+                    }
+                    else
+                    {
+                        // The caller handed us the stream; finalize the file by flushing,
+                        // but leave the stream open for them to dispose.
+                        outStream.Flush();
+                    }
                     outStream = null;
                     isDisposed = true;
                 }

--- a/src/NAudio.Core/Wave/WaveStreams/AiffFileReader.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/AiffFileReader.cs
@@ -37,6 +37,8 @@ public class AiffFileReader : WaveStream
     /// <param name="inputStream">The input stream containing a AIF file including header</param>
     public AiffFileReader(Stream inputStream)
     {
+        // The caller owns a stream they passed in; only the filename constructor sets ownInput = true.
+        ownInput = false;
         waveStream = inputStream;
         ReadAiffHeader(waveStream, out waveFormat, out dataPosition, out dataChunkLength, chunks);
         if (waveFormat.BlockAlign <= 0)

--- a/src/NAudio.Core/Wave/WaveStreams/RawSourceWaveStream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/RawSourceWaveStream.cs
@@ -12,12 +12,15 @@ public class RawSourceWaveStream : WaveStream
 {
     private readonly Stream sourceStream;
     private readonly WaveFormat waveFormat;
+    private readonly bool ownsStream;
 
     /// <summary>
     /// Initialises a new instance of RawSourceWaveStream
     /// </summary>
     /// <param name="sourceStream">The source stream containing raw audio</param>
     /// <param name="waveFormat">The waveformat of the audio in the source stream</param>
+    /// <remarks>The caller retains ownership of <paramref name="sourceStream"/>; it is not
+    /// disposed when this <see cref="RawSourceWaveStream"/> is disposed.</remarks>
     public RawSourceWaveStream(Stream sourceStream, WaveFormat waveFormat)
     {
         this.sourceStream = sourceStream;
@@ -33,7 +36,9 @@ public class RawSourceWaveStream : WaveStream
     /// <param name="waveFormat">The waveformat of the audio in the source stream</param>
     public RawSourceWaveStream(byte[] byteStream, int offset, int count, WaveFormat waveFormat)
     {
+        // We create this MemoryStream ourselves, so we own it and dispose it.
         sourceStream = new MemoryStream(byteStream, offset, count);
+        ownsStream = true;
         this.waveFormat = waveFormat;
     }
 
@@ -82,5 +87,19 @@ public class RawSourceWaveStream : WaveStream
     /// </summary>
     public override int Read(byte[] buffer, int offset, int count)
         => Read(buffer.AsSpan(offset, count));
+
+    /// <summary>
+    /// Disposes this RawSourceWaveStream, disposing the internally-created MemoryStream
+    /// when the <c>byte[]</c> constructor was used. A caller-supplied source stream is
+    /// left open.
+    /// </summary>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && ownsStream)
+        {
+            sourceStream.Dispose();
+        }
+        base.Dispose(disposing);
+    }
 }
 

--- a/tests/NAudio.Core.Tests/Aiff/AiffFileWriterTests.cs
+++ b/tests/NAudio.Core.Tests/Aiff/AiffFileWriterTests.cs
@@ -123,6 +123,28 @@ public class AiffFileWriterTests
         }
     }
 
+    [Test]
+    public void StreamConstructorLeavesCallerSuppliedStreamOpen()
+    {
+        // The stream constructor must not dispose a stream the caller handed in. Disposing
+        // the writer still finalizes the header, but leaves the MemoryStream usable.
+        var ms = new MemoryStream();
+        var sourceData = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60 };
+        using (var writer = new AiffFileWriter(ms, new WaveFormat(16000, 24, 1)))
+        {
+            writer.Write(sourceData, 0, sourceData.Length);
+        }
+
+        // If the writer had disposed ms, accessing it would throw ObjectDisposedException.
+        Assert.That(ms.CanRead, Is.True, "Caller's stream should still be open");
+        ms.Position = 0;
+        using var reader = new AiffFileReader(ms);
+        var buffer = new byte[(int)reader.Length];
+        var read = reader.Read(buffer, 0, buffer.Length);
+        Assert.That(read, Is.EqualTo(buffer.Length));
+        Assert.That(buffer, Is.EqualTo(sourceData));
+    }
+
     private static byte[] WriteAndRead(WaveFormat format, Action<AiffFileWriter> writeAction)
     {
         var ms = new MemoryStream();

--- a/tests/NAudio.Core.Tests/WaveStreams/RawSourceWaveStreamTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/RawSourceWaveStreamTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using NAudio.Wave;
+using NUnit.Framework;
+
+namespace NAudio.Core.Tests.WaveStreams;
+
+[TestFixture]
+[Category("UnitTest")]
+public class RawSourceWaveStreamTests
+{
+    private static readonly WaveFormat Format = new(44100, 16, 1);
+
+    [Test]
+    public void DisposeLeavesCallerSuppliedStreamOpen()
+    {
+        // The caller owns a stream they pass to the constructor, so it must not be disposed.
+        var ms = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+        var raw = new RawSourceWaveStream(ms, Format);
+        raw.Dispose();
+
+        Assert.That(ms.CanRead, Is.True, "Caller's stream should still be open after dispose");
+    }
+
+    [Test]
+    public void DisposeDisposesInternallyCreatedMemoryStream()
+    {
+        // The byte[] constructor creates a MemoryStream internally; disposing the
+        // RawSourceWaveStream should dispose it too (previously it was leaked).
+        var raw = new RawSourceWaveStream(new byte[] { 1, 2, 3, 4 }, 0, 4, Format);
+
+        // Reading works before dispose...
+        var buffer = new byte[4];
+        int readBeforeDispose = raw.Read(buffer, 0, buffer.Length);
+        Assert.That(readBeforeDispose, Is.EqualTo(4));
+
+        raw.Dispose();
+
+        // ...and the internal stream is disposed, so reads now throw.
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            int readAfterDispose = raw.Read(buffer, 0, buffer.Length);
+            Assert.That(readAfterDispose, Is.Zero); // unreachable - the read above throws
+        });
+    }
+}

--- a/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WaveFileWriterTests.cs
@@ -73,6 +73,53 @@ public class WaveFileWriterTests
 
 
     [Test]
+    public void StreamConstructorLeavesCallerSuppliedStreamOpen()
+    {
+        // Regression test for https://github.com/naudio/NAudio/issues/1040
+        // The stream constructor must not dispose a stream the caller handed in.
+        // Disposing the writer still finalizes the header (flush), but leaves the
+        // MemoryStream usable - no IgnoreDisposeStream wrapper required.
+        var ms = new MemoryStream();
+        var testSequence = new byte[] { 0x1, 0x2, 0xFF, 0xFE }; // 2 samples of 16-bit mono (block align 2)
+        using (var writer = new WaveFileWriter(ms, new WaveFormat(16000, 16, 1)))
+        {
+            writer.Write(testSequence, 0, testSequence.Length);
+        }
+
+        // If the writer had disposed ms, accessing it would throw ObjectDisposedException.
+        Assert.That(ms.CanRead, Is.True, "Caller's stream should still be open");
+        ms.Position = 0;
+        using var reader = new WaveFileReader(ms);
+        Assert.That(reader.Length, Is.EqualTo(testSequence.Length), "Header finalized / data flushed");
+        var buffer = new byte[testSequence.Length];
+        int read = reader.Read(buffer, 0, buffer.Length);
+        Assert.That(read, Is.EqualTo(testSequence.Length), "Data length");
+        Assert.That(buffer, Is.EqualTo(testSequence));
+    }
+
+    [Test]
+    public void FilenameConstructorClosesTheUnderlyingFile()
+    {
+        // The filename constructor owns the FileStream it opened, so disposing the writer
+        // must release the file handle (otherwise the file cannot be reopened/deleted).
+        string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".wav");
+        try
+        {
+            using (var writer = new WaveFileWriter(tempFile, new WaveFormat(16000, 16, 1)))
+            {
+                writer.WriteSample(0.5f);
+            }
+            // Re-opening for read+write share would fail if the writer still held the handle.
+            using var reopened = new FileStream(tempFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            Assert.That(reopened.Length, Is.GreaterThan(0));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
     public void CreateWaveFileCreatesFileOfCorrectLength()
     {
         string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".wav");


### PR DESCRIPTION
## Summary

`WaveFileWriter` and `AiffFileWriter` disposed the caller's output stream unconditionally on `Dispose`. That violates the .NET convention "you dispose what you own", and it's the long-standing papercut behind #1040 (and #90) — writing to a `MemoryStream` you want to keep required the unintuitive `IgnoreDisposeStream` wrapper, which even the reporter of #1040 didn't find.

NAudio 3's readers (`WaveFileReader`, `AiffFileReader`, `Mp3FileReader`) already solved this with an `ownInput` flag set only by the filename constructor. This PR finishes that house style on the writers rather than inventing a new mechanism:

- **Filename constructors** open the `FileStream` themselves, so they still own and close it — unchanged behaviour.
- **Stream constructors** now treat the stream as caller-owned. `Dispose` still **finalizes the header and flushes** (so the file is valid), but no longer disposes the stream you passed in.

The decorator wrappers (`WaveChannel32`, `Wave32To16Stream`, …) that cascade-dispose their inner source are **left as-is** — that matches the BCL decorator convention (`GZipStream`, `CryptoStream`) and flipping them would break far more than #1040.

### Changes
- `WaveFileWriter` / `AiffFileWriter`: route all constructors through a private ctor with an `ownsStream` flag (filename → owns, stream → doesn't); `Dispose` flushes a non-owned stream instead of disposing it.
- `WaveFileWriter.WriteWavFileToStream`: drops the now-unnecessary `IgnoreDisposeStream` wrapper.
- `RawSourceWaveStream`: the `byte[]` constructor now disposes the `MemoryStream` it creates internally (previously leaked); a caller-supplied stream is left open.
- `AiffFileReader`: stream constructor sets `ownInput = false` explicitly rather than relying on field initialisation.
- Documents the breaking change in `Docs/MigratingFromNAudio2.md` (with the one footgun: a throwaway stream passed to the stream ctor now leaks — use the filename overload or dispose it yourself).

`IgnoreDisposeStream` still exists, so existing code that uses it keeps working.

Closes #1040. Also improves the scenario in #90.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)

(A `breaking` bullet for the writer ownership change, plus a bug-fix bullet for the `RawSourceWaveStream` leak.)

## Testing

`dotnet test tests/NAudio.Core.Tests` on `net10.0`: **1444 passed, 0 failed, 3 skipped**. New tests assert:
- a caller-supplied `MemoryStream` stays open after disposing `WaveFileWriter` / `AiffFileWriter`, with the header still finalized;
- the filename constructor still releases the file handle;
- `RawSourceWaveStream`'s internally-created `MemoryStream` is disposed.

The existing tests that wrap `MemoryStream` in `IgnoreDisposeStream` keep passing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A24TThQ3gtsAhCGvvRoKhC)_