### PR TITLE
Add DeviceCount and GetCapabilities to WaveOutEvent (#1331, #777)

### DIFF
--- a/NAudio.WinMM/WaveOutEvent.cs
+++ b/NAudio.WinMM/WaveOutEvent.cs
@@ -25,6 +25,24 @@ namespace NAudio.Wave
         public event EventHandler<StoppedEventArgs> PlaybackStopped;
 
         /// <summary>
+        /// Returns the number of Wave Out devices available in the system
+        /// </summary>
+        public static int DeviceCount => WaveInterop.waveOutGetNumDevs();
+
+        /// <summary>
+        /// Retrieves the capabilities of a waveOut device
+        /// </summary>
+        /// <param name="devNumber">Device to test</param>
+        /// <returns>The WaveOut device capabilities</returns>
+        public static WaveOutCapabilities GetCapabilities(int devNumber)
+        {
+            var caps = new WaveOutCapabilities();
+            int structSize = Marshal.SizeOf(caps);
+            MmException.Try(WaveInterop.waveOutGetDevCaps((IntPtr)devNumber, out caps, structSize), "waveOutGetDevCaps");
+            return caps;
+        }
+
+        /// <summary>
         /// Gets or sets the desired latency in milliseconds
         /// Should be set before a call to Init
         /// </summary>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+ * Added `DeviceCount` and `GetCapabilities` static methods to `WaveOutEvent` so output devices can be enumerated without referencing `NAudio.WinForms` (#1331, #777)
+
 ### 2.3.0 (12 Mar 2026)
 
  * Performance improvements for `PropertyStore` and Core Audio property access (#1206)


### PR DESCRIPTION
## What

Adds static `DeviceCount` and `GetCapabilities(int)` methods to `WaveOutEvent` on the 2.x line.

## Why

`WaveInEvent` already exposed these static helpers, but `WaveOutEvent` did not. On 2.x the only way to enumerate **output** devices and read their capabilities was through the window-callback `WaveOut` class in `NAudio.WinForms`, which forces a Windows-specific target framework (`netX.0-windows`) and pulls in a Windows Forms dependency just to call a couple of static methods.

This was raised in #777 (the WinForms dependency forcing a non-portable TFM) and, more recently, in #1331 (a Unity user pinned to 2.3.0 trying to enumerate output devices for `WaveOutEvent`).

## Change

Purely additive, and source- and binary-compatible:

```csharp
for (int n = -1; n < WaveOutEvent.DeviceCount; n++)
{
    var caps = WaveOutEvent.GetCapabilities(n);
    Console.WriteLine($"{n}: {caps.ProductName}");
}
```

The implementation mirrors the existing `WaveInEvent` methods and the window-callback `WaveOut` class. `WaveOutCapabilities` already lives in `NAudio.WinMM`, so no new assembly references are introduced — consumers can enumerate output devices with only `NAudio.WinMM`.

Note: this is the 2.x backport. In NAudio 3 these methods already exist on the renamed `WaveOut`/`WaveIn` classes in `NAudio.WinMM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183HPXRyE5NrnJbPGn3pmwJ)_