### PR TITLE
Backport remaining WDL resampler fixes: channel reinterleave + denormal flush (#800)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -88,6 +88,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `BlockAlignReductionStream.Read`: a single read (or `Stream.CopyTo` chunk) larger than the 4-second internal buffer no longer silently discards the rest of the source and truncates the stream — e.g. converting a non-PCM WAV via `AudioFileReader` on .NET Core (#1022)
  * `MmException` messages now append a human-readable `MmResult` description (#1192); `Id3v2Tag.ReadTag` no longer throws/catches for tagless MP3 streams (#265)
  * ASIO: implemented missing `Asio64Bit` Int24LSB/Float32LSB conversions and fixed a byte-order bug in `GetSamplePosition`; `WdlResampler` backported three upstream Cockos WDL fixes
+ * `WdlResampler`: reinterleave buffered samples when the channel count changes between calls, and flush denormals in the IIR feedback path (further upstream Cockos WDL backports) (#800)
  * Hardened Media Foundation and DMO interop against COM ref leaks on error paths (`MediaFoundationReader`, `MediaFoundationEncoder`, `MediaFoundationTransform`, `MediaBuffer`, `Mf*` wrappers) (#1293)
  * Removed dead `naudio.codeplex.com` links from the README, MixDiff and source comments (#985)
 

--- a/src/NAudio.Core/Dsp/WdlResampler.cs
+++ b/src/NAudio.Core/Dsp/WdlResampler.cs
@@ -190,6 +190,10 @@ public class WdlResampler
 
         if (sreq < 0) sreq = 0;
 
+        // if decreasing channel count, reinterleave before realloc
+        if (nch < m_rsinbuf_nch && m_rsinbuf_nch > 0 && m_samples_in_rsinbuf > 0)
+            ReinterleaveBuffer(m_rsinbuf, m_rsinbuf_nch, nch, m_samples_in_rsinbuf);
+
         again:
         Array.Resize(ref m_rsinbuf, (m_samples_in_rsinbuf + sreq) * nch);
 
@@ -204,6 +208,12 @@ public class WdlResampler
             // todo: notify of error?
             sreq = sz;
         }
+
+        // if increasing channel count, reinterleave after realloc
+        if (m_rsinbuf_nch < nch && m_rsinbuf_nch > 0 && m_samples_in_rsinbuf > 0)
+            ReinterleaveBuffer(m_rsinbuf, m_rsinbuf_nch, nch, m_samples_in_rsinbuf);
+
+        m_rsinbuf_nch = nch;
 
         inbuffer = m_rsinbuf.AsSpan(m_samples_in_rsinbuf * nch, sreq * nch);
 
@@ -478,6 +488,42 @@ public class WdlResampler
         return ret;
     }
 
+    // When the channel count changes between calls while samples are still buffered,
+    // re-pack the interleaved buffer from the old channel count to the new one so the
+    // retained samples stay correctly aligned. Ported from WDL's
+    // wdl_rs_reinterleave_buffer (added upstream 2022).
+    private static void ReinterleaveBuffer(WDL_ResampleSample[] buf, int in_nch, int out_nch, int len)
+    {
+        if (len < 1 || buf == null) return;
+
+        int x = len - 1;
+        int rd = 0;
+        int wr = 0;
+        if (out_nch < in_nch)
+        {
+            if (len * in_nch > buf.Length) return; // source layout doesn't fit the buffer; nothing valid to move
+            while (x-- != 0)
+            {
+                rd += in_nch;
+                wr += out_nch;
+                Array.Copy(buf, rd, buf, wr, out_nch);
+            }
+        }
+        else if (out_nch > in_nch)
+        {
+            rd += in_nch * x;
+            wr += out_nch * x;
+            while (x-- != 0)
+            {
+                Array.Copy(buf, rd, buf, wr, in_nch);
+                Array.Clear(buf, wr + in_nch, out_nch - in_nch);
+                rd -= in_nch;
+                wr -= out_nch;
+            }
+            Array.Clear(buf, wr + in_nch, out_nch - in_nch);
+        }
+    }
+
     // only called in sinc modes
     private void BuildLowPass(double filtpos)
     {
@@ -627,6 +673,7 @@ public class WdlResampler
     private int m_last_requested;
     private int m_filtlatency;
     private int m_samples_in_rsinbuf;
+    private int m_rsinbuf_nch; // channel count the buffered samples are interleaved at
     private int m_lp_oversize;
 
     private int m_sincsize;
@@ -688,15 +735,16 @@ public class WdlResampler
             }
         }
 
-        private double denormal_filter(float x)
+        // Flush denormals (zero-exponent floats) to zero so they can't stall the IIR
+        // feedback path. Mirrors WDL's denormal_filter in denormal.h: if the exponent
+        // field is all zeros the value is zero or subnormal, so return 0.0.
+        private static double denormal_filter(float x)
         {
-            // TODO: implement denormalisation
-            return x;
+            return (BitConverter.SingleToInt32Bits(x) & 0x7f800000) != 0 ? x : 0.0;
         }
-        private double denormal_filter(double x)
+        private static double denormal_filter(double x)
         {
-            // TODO: implement denormalisation
-            return x;
+            return (BitConverter.DoubleToInt64Bits(x) & 0x7ff0000000000000L) != 0 ? x : 0.0;
         }
 
         private double m_fpos;

--- a/tests/NAudio.Core.Tests/WaveStreams/WdlResamplingSampleProviderTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WdlResamplingSampleProviderTests.cs
@@ -282,7 +282,75 @@ public class WdlResamplingSampleProviderTests
             $"Latency unexpectedly large: {maxLatencySeconds * 1000:F1} ms");
     }
 
+    [Test]
+    public void ChannelCountChangeMidStreamKeepsChannelsAligned()
+    {
+        // 2022 upstream fix (wdl_rs_reinterleave_buffer): when the channel count changes
+        // while input samples are still buffered, the retained samples must be reinterleaved
+        // from the old layout to the new one. We use point-sampling mode (no interpolation or
+        // anti-alias filtering, so output is a direct copy of input) and constant per-channel
+        // DC, so any mis-reinterleaved buffered sample shows up directly in the output. Then
+        // we switch channel counts mid-stream, decreasing then increasing.
+        const int from = 8000;
+        const int to = 48000; // upsample so a few input frames stay buffered between calls
+
+        var resampler = new WdlResampler();
+        resampler.SetMode(false, 0, false); // point sampling
+        resampler.SetFeedMode(false);
+        resampler.SetRates(from, to);
+
+        // Phase 1: stereo, L = +0.5 DC, R = -0.5 DC. Leaves a few stereo frames buffered.
+        PumpDc(resampler, nch: 2, dc: new[] { 0.5f, -0.5f }, cycles: 6, outFramesPerCycle: 256);
+
+        // Phase 2: switch to mono (decreasing). The buffered stereo frames must be repacked
+        // to channel 0 (+0.5). With the fix, every mono sample is the buffered L level or the
+        // fed level (both >= 0.25); without it, the buffered right channel (-0.5) leaks out.
+        var mono = PumpDc(resampler, nch: 1, dc: new[] { 0.25f }, cycles: 6, outFramesPerCycle: 256);
+        foreach (var v in mono)
+        {
+            Assert.That(float.IsFinite(v), Is.True, "non-finite mono output");
+            Assert.That(v, Is.GreaterThanOrEqualTo(0.2f),
+                $"mono output dipped to {v}: the buffered right channel (-0.5) leaked through a missing reinterleave");
+        }
+        AssertTailDc(mono, 1, new[] { 0.25f });
+
+        // Phase 3: switch to 3 channels (increasing). The buffered mono frames must be
+        // repacked into channel 0, with the two new channels zero-filled.
+        var three = PumpDc(resampler, nch: 3, dc: new[] { 0.1f, 0.2f, 0.3f }, cycles: 6, outFramesPerCycle: 256);
+        AssertTailDc(three, 3, new[] { 0.1f, 0.2f, 0.3f });
+    }
+
     // ---- helpers ----
+
+    private static float[] PumpDc(WdlResampler resampler, int nch, float[] dc, int cycles, int outFramesPerCycle)
+    {
+        var outAll = new System.Collections.Generic.List<float>();
+        for (int c = 0; c < cycles; c++)
+        {
+            int needed = resampler.ResamplePrepare(outFramesPerCycle, nch, out Span<float> inSpan);
+            for (int f = 0; f < needed; f++)
+                for (int ch = 0; ch < nch; ch++)
+                    inSpan[f * nch + ch] = dc[ch];
+            var outBuf = new float[outFramesPerCycle * nch];
+            int produced = resampler.ResampleOut(outBuf, needed, outFramesPerCycle, nch);
+            for (int i = 0; i < produced * nch; i++) outAll.Add(outBuf[i]);
+        }
+        return outAll.ToArray();
+    }
+
+    private static void AssertTailDc(float[] data, int nch, float[] dc)
+    {
+        int frames = data.Length / nch;
+        Assert.That(frames, Is.GreaterThan(200), "not enough output produced to assess steady state");
+        int start = frames * 3 / 4; // assess the settled tail, past any filter warmup/transition
+        for (int f = start; f < frames; f++)
+            for (int ch = 0; ch < nch; ch++)
+            {
+                float v = data[f * nch + ch];
+                Assert.That(float.IsNaN(v) || float.IsInfinity(v), Is.False, $"non-finite output at frame {f} ch {ch}");
+                Assert.That(v, Is.EqualTo(dc[ch]).Within(0.02f), $"ch {ch} DC drift at frame {f}: got {v}");
+            }
+    }
 
     private static float[] ResampleSawtooth(int from, int to, int channels, int seconds)
     {


### PR DESCRIPTION
## Summary

Finishes the `WdlResampler` update tracked in #800 by porting the two remaining upstream Cockos WDL changes that are actually reachable from how NAudio drives the resampler. (An earlier session already backported the windowing, feed-mode and `GetCurrentLatency` fixes.)

- **Reinterleave on channel-count change** (upstream 2022): the resampler now tracks the channel count its buffered samples are interleaved at (new `m_rsinbuf_nch` field) and, when `nch` changes between calls while input samples are still buffered, repacks them from the old layout to the new one — ported from `wdl_rs_reinterleave_buffer` and placed exactly where upstream calls it (decreasing-count before the realloc, increasing-count after). Without this, buffered samples were misread after a mid-stream channel change, leaking one channel into another. Added a defensive length guard the C++ doesn't need, since C# bounds-checks arrays.

- **Denormal flushing in the IIR feedback path**: `denormal_filter` was a no-op `// TODO`; it now flushes zero/subnormal values to zero (exponent-bit check, matching WDL's `denormal.h`), so a decaying filter tail can't stall on subnormal arithmetic. This touches NAudio's *default* path (`SetMode(true, 2, false)` uses 2 IIR passes). I used the bit check rather than the project's float-based `DenormalGuard` deliberately: the IIR history is double-precision and high-Q, so a round-trip through a `float` helper would lose precision.

The remaining upstream deltas were assessed and intentionally not ported — they are either inapplicable to managed code (SSE2 paths) or sinc-mode performance work (GCD/ideal-filter optimization, cache-thrash tuning, IIR overhaul) that NAudio's linear-interp + IIR default never exercises. That makes this a reasonable point to close #800.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

- Built `NAudio.Core` clean with 0 warnings (the enforced code-style rules / warnings-as-errors stay green).
- Added a property-based test `ChannelCountChangeMidStreamKeepsChannelsAligned` that drives the resampler in point-sampling mode across decreasing (stereo→mono) and increasing (mono→3ch) channel changes. Confirmed it has teeth: with the reinterleave removed it fails with the exact `mono output dipped to -0.5` channel leak; with the fix it passes.
- Full cross-platform suite: **1448 tests pass**, 0 failures (`TestCategory!=IntegrationTest`).

Closes #800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeRkic9aMf3c2GJNBgboce)_