### PR TITLE
Fix DirectSoundOut startup race that skipped buffer priming (#759)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -64,6 +64,7 @@ In addition to the fixes below, the new sampler/SFZ/SoundFont subsystem saw
 extensive correctness work during development — see [Docs/Sampler.md](Docs/Sampler.md).
 
  * `WaveOut`: fixed a race where stopping/disposing faster than the buffer latency could throw a `NullReferenceException` via `PlaybackStopped` (#804)
+ * `DirectSoundOut`: fixed a startup race where the secondary buffer could begin LOOPING playback before it was primed (the priming `Feed` was gated on `PlaybackState`, which `Play()` flips to `Playing` on the calling thread), so playback could collapse immediately — most visibly when a caller spun on `PlaybackState` (#759)
  * `WaveFileWriter`: removed the finalizer that fired an unconditional `Debug.Assert` and could crash the process on the finalizer thread when construction had thrown
  * `WaveFileWriter.WriteSample` / `WriteSamples`: fixed 32-bit `WaveFormatExtensible` output writing near-silence or corrupt data — `WriteSample(float)` truncated the normalised float to an `Int32` before scaling (writing zero for almost every sample), and both paths ignored the format's SubFormat; they now write IEEE-float or integer-PCM samples according to the declared subformat (#651)
  * `WaveExtensionMethods.AsStandardWaveFormat`: now also resolves the SubFormat of a `WaveFormatExtraData` (how an extensible format read from a file/stream is materialised), not just a `WaveFormatExtensible`

--- a/src/NAudio.Dmo/DirectSound/DirectSoundOut.cs
+++ b/src/NAudio.Dmo/DirectSound/DirectSoundOut.cs
@@ -489,14 +489,17 @@ public partial class DirectSoundOut : IWavePlayer
         try
         {
             InitializeDirectSound();
-            int lResult = 1;
 
-            if (PlaybackState == PlaybackState.Stopped)
-            {
-                DirectSoundException.ThrowIfFailed(secondaryBuffer.SetCurrentPosition(0));
-                nextSamplesWriteIndex = 0;
-                lResult = Feed(samplesTotalSize);
-            }
+            // Prime the buffer before playback starts. This thread is only ever started from
+            // a Stopped state (see Play()), so a fresh start always needs priming. This used to
+            // be gated on PlaybackState == Stopped, but Play() sets PlaybackState = Playing on the
+            // calling thread immediately after starting this thread, so the check raced: if the
+            // calling thread won (made far more likely by a caller that spins on PlaybackState),
+            // priming was skipped and a LOOPING play started on an unprimed buffer, causing
+            // playback to collapse at startup.
+            DirectSoundException.ThrowIfFailed(secondaryBuffer.SetCurrentPosition(0));
+            nextSamplesWriteIndex = 0;
+            int lResult = Feed(samplesTotalSize);
 
             // Incase the previous Feed method returns 0
             if (lResult > 0)


### PR DESCRIPTION
Addresses the second problem reported in #759 (playback collapsing almost immediately on `DirectSoundOut`).

## The bug

`PlaybackThreadFunc` primes the secondary buffer — `SetCurrentPosition(0)` plus the initial `Feed(samplesTotalSize)` — only inside `if (PlaybackState == PlaybackState.Stopped)`. But `Play()` starts that thread and then **immediately sets `PlaybackState = Playing` on the calling thread**:

```csharp
// Play()
notifyThread.Start();          // worker begins InitializeDirectSound()...
lock (m_LockObject) { playbackState = PlaybackState.Playing; }   // ...and this races the gate
```

So the priming gate races the calling thread. When the calling thread wins, the worker sees `Playing`, **skips priming**, and starts a `DSBPLAY_LOOPING` play on an unprimed buffer — playback collapses at startup.

Because the playback thread runs at `ThreadPriority.Normal`, a caller that spins on `PlaybackState` (`while (out.PlaybackState == PlaybackState.Playing) { ... }`) starves the worker and makes losing the race the common case — which is exactly the "stops after a random 110–170 iterations, varies every run" symptom in the issue.

## The fix

`PlaybackThreadFunc` is only ever started from a `Stopped` state (`Play()` creates the thread solely in that branch), so a fresh start *always* needs priming. Prime unconditionally and drop the racy `PlaybackState` gate. The existing `lResult > 0` guard still suppresses playback when the source yields no data on the first feed, so the empty-source behaviour is unchanged.

Resume-from-`Paused` is unaffected: pausing keeps the same worker thread running (the loop continues while `PlaybackState != Stopped`, and `Feed` emits silence while paused), so `PlaybackThreadFunc` is not re-entered and priming-on-fresh-start remains correct.

## Notes

The user-facing guidance for the issue is still "don't busy-wait on `PlaybackState` — use the `PlaybackStopped` event," but the startup race was a genuine latent bug worth removing regardless. (The thread's other failure modes — stop-on-zero-read, buffer-timeout, and swallowing setup exceptions into `PlaybackStopped` — are inherent to this legacy output and out of scope here.)

## Test plan

- [x] `NAudio.Dmo` builds clean (`-p:EnableWindowsTargeting=true`, 0 warnings / 0 errors)
- [ ] CI on windows-latest
- [ ] Manual smoke test on Windows: play a file through `DirectSoundOut` immediately followed by a tight `while (PlaybackState == Playing)` loop, confirm playback now runs to completion instead of collapsing at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014f4vEbhPo8Rcq6bbk9fGWk)_