### PR TITLE
Fix inexact seeking in MediaFoundationReader (#628)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -91,6 +91,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * ASIO: implemented missing `Asio64Bit` Int24LSB/Float32LSB conversions and fixed a byte-order bug in `GetSamplePosition`; `WdlResampler` backported three upstream Cockos WDL fixes
  * `WdlResampler`: reinterleave buffered samples when the channel count changes between calls, and flush denormals in the IIR feedback path (further upstream Cockos WDL backports) (#800)
  * Hardened Media Foundation and DMO interop against COM ref leaks on error paths (`MediaFoundationReader`, `MediaFoundationEncoder`, `MediaFoundationTransform`, `MediaBuffer`, `Mf*` wrappers) (#1293)
+ * `MediaFoundationReader`: seeking is now sample-accurate — since `IMFSourceReader.SetCurrentPosition` only seeks to the nearest container keyframe, the reader now reads forward and skips into the decoded buffer to reach the exact requested position, instead of restarting playback from the keyframe (audible on audio extracted from video, e.g. Vorbis/AAC). `Position` now reflects the byte position actually reached (#628)
  * Removed dead `naudio.codeplex.com` links from the README, MixDiff and source comments (#985)
 
 #### Performance

--- a/samples/NAudioDemo/Utils/SeekableTrackBar.cs
+++ b/samples/NAudioDemo/Utils/SeekableTrackBar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 
 namespace NAudioDemo.Utils;
@@ -16,6 +16,11 @@ public class SeekableTrackBar : TrackBar
     // Good enough for the seek-to-click feel; perfect pixel accuracy would require P/Invoking TBM_GETTHUMBLENGTH.
     private const int ThumbInset = 13;
 
+    // The last value we raised Scroll for, so a single click (MouseDown + MouseUp both want to
+    // commit) or a drag that pauses on one value doesn't fire two seeks to the same position.
+    // Two seeks to the same point queue the post-seek audio twice and play it back doubled.
+    private int? lastCommittedValue;
+
     /// <summary>
     /// True while the user is mid-drag with the left mouse button down. External code
     /// (e.g. a position-update timer) should skip writing <see cref="TrackBar.Value"/> while this is true.
@@ -28,6 +33,7 @@ public class SeekableTrackBar : TrackBar
         {
             IsScrubbing = true;
             Capture = true;
+            lastCommittedValue = null; // start a fresh interaction
             SeekToMouseX(e.X);
             Focus();
             return; // suppress default LargeChange-jump behaviour
@@ -52,7 +58,7 @@ public class SeekableTrackBar : TrackBar
             IsScrubbing = false;
             Capture = false;
             base.OnMouseUp(e);
-            OnScroll(EventArgs.Empty); // give Scroll handlers a final position to commit on release
+            Commit(); // commit the final position on release (no-op if MouseDown/Move already did)
             return;
         }
         base.OnMouseUp(e);
@@ -62,13 +68,20 @@ public class SeekableTrackBar : TrackBar
     {
         int track = Math.Max(1, Width - 2 * ThumbInset);
         int clamped = Math.Max(0, Math.Min(track, x - ThumbInset));
-        int newValue = Minimum + (int)((double)clamped / track * (Maximum - Minimum));
-        if (newValue < Minimum) newValue = Minimum;
-        else if (newValue > Maximum) newValue = Maximum;
+        int newValue = Math.Clamp(Minimum + (int)((double)clamped / track * (Maximum - Minimum)), Minimum, Maximum);
         if (newValue != Value)
         {
             Value = newValue;
-            OnScroll(EventArgs.Empty); // programmatic Value writes don't fire Scroll, so do it explicitly
         }
+        Commit();
+    }
+
+    private void Commit()
+    {
+        // Programmatic Value writes don't raise Scroll, so we raise it explicitly - but only once
+        // per distinct position, so a single click doesn't seek twice to the same place.
+        if (lastCommittedValue == Value) return;
+        lastCommittedValue = Value;
+        OnScroll(EventArgs.Empty);
     }
 }

--- a/src/NAudio.Wasapi/MediaFoundationReader.cs
+++ b/src/NAudio.Wasapi/MediaFoundationReader.cs
@@ -284,14 +284,35 @@ public class MediaFoundationReader : WaveStream
 
         while (bytesWritten < buffer.Length)
         {
+            if (!ReadNextDecoderBuffer(out _))
+            {
+                break; // end of stream
+            }
+            bytesWritten += ReadFromDecoderBuffer(buffer.Slice(bytesWritten));
+        }
+        position += bytesWritten;
+        return bytesWritten;
+    }
+
+    /// <summary>
+    /// Pulls the next decoded sample from the source reader into <see cref="decoderOutputBuffer"/>,
+    /// resetting <see cref="decoderOutputOffset"/> to 0 and <see cref="decoderOutputCount"/> to the
+    /// number of decoded bytes. Returns false at end of stream (leaving the decoder buffer empty).
+    /// <paramref name="timestamp"/> is the presentation time of the sample in 100-nanosecond units.
+    /// </summary>
+    private bool ReadNextDecoderBuffer(out long timestamp)
+    {
+        timestamp = 0;
+        while (true)
+        {
             MediaFoundationException.ThrowIfFailed(
                 pReader.ReadSample(MediaFoundationInterop.MF_SOURCE_READER_FIRST_AUDIO_STREAM, 0,
-                    out int actualStreamIndex, out int dwFlagsInt, out long timestamp, out IntPtr pSamplePtr));
+                    out int actualStreamIndex, out int dwFlagsInt, out long sampleTimestamp, out IntPtr pSamplePtr));
             var dwFlags = (SourceReaderFlags)dwFlagsInt;
             if ((dwFlags & SourceReaderFlags.EndOfStream) != 0)
             {
                 if (pSamplePtr != IntPtr.Zero) Marshal.Release(pSamplePtr);
-                break;
+                return false;
             }
             else if ((dwFlags & SourceReaderFlags.CurrentMediaTypeChanged) != 0)
             {
@@ -334,8 +355,8 @@ public class MediaFoundationReader : WaveStream
                 Marshal.Copy(pAudioData, decoderOutputBuffer, 0, cbBuffer);
                 decoderOutputOffset = 0;
                 decoderOutputCount = cbBuffer;
-
-                bytesWritten += ReadFromDecoderBuffer(buffer.Slice(bytesWritten));
+                timestamp = sampleTimestamp;
+                return true;
             }
             finally
             {
@@ -351,8 +372,6 @@ public class MediaFoundationReader : WaveStream
                 MediaFoundationException.ThrowIfFailed(unlockHr);
             }
         }
-        position += bytesWritten;
-        return bytesWritten;
     }
 
     /// <summary>
@@ -400,7 +419,15 @@ public class MediaFoundationReader : WaveStream
 
     private void Reposition(long desiredPosition)
     {
-        long nsPosition = (10000000L * desiredPosition) / waveFormat.AverageBytesPerSecond;
+        if (pReader == null)
+        {
+            pReader = CreateReader(settings);
+        }
+
+        int averageBytesPerSecond = waveFormat.AverageBytesPerSecond;
+        long nsPosition = averageBytesPerSecond > 0
+            ? (10000000L * desiredPosition) / averageBytesPerSecond
+            : 0;
         var pv = PropVariant.FromLong(nsPosition);
         var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(pv));
         try
@@ -416,8 +443,63 @@ public class MediaFoundationReader : WaveStream
         }
         decoderOutputCount = 0;
         decoderOutputOffset = 0;
-        position = desiredPosition;
         repositionTo = -1;// clear the flag
+
+        // IMFSourceReader.SetCurrentPosition is documented as inexact: it seeks to the nearest
+        // container keyframe at or before the requested time, so the next decoded sample can begin
+        // earlier than desiredPosition. Per MS guidance we must read forward and skip into the
+        // decoded buffer to land on the exact byte position; without this, playback audibly
+        // restarts from the keyframe (very visible on audio extracted from video - Vorbis/AAC).
+        // (We can only do this when the byte rate is known; streaming sources report 0.)
+        long achievedPosition = desiredPosition;
+        if (averageBytesPerSecond > 0)
+        {
+            while (true)
+            {
+                if (!ReadNextDecoderBuffer(out long timestamp))
+                {
+                    // Ran past the end of the stream while seeking; leave the decoder buffer empty
+                    // so the next Read reports end-of-stream, and snap position to the known length.
+                    decoderOutputCount = 0;
+                    decoderOutputOffset = 0;
+                    achievedPosition = length > 0 ? length : desiredPosition;
+                    break;
+                }
+
+                // The decoder output is PCM (constant bit rate), so the sample timestamp maps to an
+                // exact byte position. MF can return several buffers carrying the same timestamp, so
+                // we gate on the end of the buffer rather than its start.
+                long decoderPosition = (long)((ulong)timestamp * (ulong)averageBytesPerSecond / 10000000UL);
+                long bufferEnd = decoderPosition + decoderOutputCount;
+
+                if (bufferEnd <= desiredPosition)
+                {
+                    // Entire buffer is still before the target; discard it and keep reading.
+                    decoderOutputCount = 0;
+                    decoderOutputOffset = 0;
+                    continue;
+                }
+
+                if (decoderPosition < desiredPosition)
+                {
+                    int skip = (int)(desiredPosition - decoderPosition);
+                    // Round the skip down to a frame boundary; starting mid-sample produces loud
+                    // static. This lands us at most BlockAlign-1 bytes before the requested position.
+                    skip -= skip % BlockAlign;
+                    decoderOutputOffset = skip;
+                    decoderOutputCount -= skip;
+                    achievedPosition = decoderPosition + skip;
+                }
+                else
+                {
+                    // Keyframe landed at or after the request; deliver the buffer from its start.
+                    achievedPosition = decoderPosition;
+                }
+                break;
+            }
+        }
+
+        position = achievedPosition;
     }
 
     /// <summary>

--- a/tests/NAudio.Windows.Tests/MediaFoundation/MediaFoundationReaderSeekTests.cs
+++ b/tests/NAudio.Windows.Tests/MediaFoundation/MediaFoundationReaderSeekTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using NAudio.MediaFoundation;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using NUnit.Framework;
+
+namespace NAudio.Windows.Tests.MediaFoundation;
+
+/// <summary>
+/// Regression tests for the inexact-seek fix in <see cref="MediaFoundationReader"/> (issue #628).
+/// IMFSourceReader.SetCurrentPosition only seeks to the nearest container keyframe at or before the
+/// requested time, so the reader has to read forward and skip into the decoded buffer to land on the
+/// exact requested position. These tests decode through Media Foundation but need no audio hardware,
+/// so they are intentionally <b>not</b> marked IntegrationTest and run in headless CI.
+/// </summary>
+[TestFixture]
+public class MediaFoundationReaderSeekTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        MediaFoundationApi.Startup();
+    }
+
+    /// <summary>
+    /// For a lossless source (PCM WAV) the bytes returned after a seek must be identical to the bytes
+    /// read sequentially up to the same position, and the reported Position must stay consistent.
+    /// </summary>
+    [Test]
+    public void SeekReadMatchesSequentialReadForLosslessSource()
+    {
+        var path = CreateTempSineWav(seconds: 4);
+        try
+        {
+            int blockAlign;
+            long target;
+            int count;
+            byte[] expected;
+
+            using (var reference = new MediaFoundationReader(path))
+            {
+                blockAlign = reference.WaveFormat.BlockAlign;
+                // a block-aligned position roughly two seconds in
+                target = reference.WaveFormat.AverageBytesPerSecond * 2L;
+                target -= target % blockAlign;
+                count = reference.WaveFormat.AverageBytesPerSecond / 4; // 0.25s
+
+                // read sequentially from the start: discard everything up to target, then capture count bytes
+                var scratch = new byte[(int)target];
+                Assert.That(ReadFull(reference, scratch, scratch.Length), Is.EqualTo(scratch.Length));
+                expected = new byte[count];
+                Assert.That(ReadFull(reference, expected, count), Is.EqualTo(count));
+            }
+
+            using var seeker = new MediaFoundationReader(path);
+            seeker.Position = target;
+            var actual = new byte[count];
+            int got = ReadFull(seeker, actual, count);
+
+            Assert.That(got, Is.EqualTo(count));
+            Assert.That(actual, Is.EqualTo(expected),
+                "PCM read after seeking differs from the bytes read sequentially to the same position");
+            Assert.That(seeker.Position, Is.EqualTo(target + got).Within(blockAlign),
+                "Position accounting drifted after a seek");
+        }
+        finally
+        {
+            TryDelete(path);
+        }
+    }
+
+    /// <summary>
+    /// For a compressed source (MP3) where SetCurrentPosition is inexact, the decoded audio after a
+    /// seek must line up with the same point in a full sequential decode. Before the fix the reader
+    /// returned audio from the preceding frame boundary, shifting the alignment by up to a whole MP3
+    /// frame (~1152 samples). MP3 is lossy so we measure alignment by best-fit lag rather than bytes.
+    /// </summary>
+    [Test]
+    public void SeekAlignsDecodedAudioForCompressedSource()
+    {
+        // only run when an MP3 encoder is actually available on this machine
+        var mp3MediaType = MediaFoundationEncoder.SelectMediaType(
+            AudioSubtypes.MFAudioFormat_MP3, new WaveFormat(44100, 16, 1), 0);
+        if (mp3MediaType == null) Assert.Ignore("No MP3 encoder available");
+
+        var path = Path.Combine(Path.GetTempPath(), $"naudio_mf_seek_{Guid.NewGuid():N}.mp3");
+        try
+        {
+            var signal = new SignalGenerator(44100, 1)
+            {
+                Type = SignalGeneratorType.Sin,
+                Frequency = 440,
+                Gain = 0.5
+            }.Take(TimeSpan.FromSeconds(4));
+            MediaFoundationEncoder.EncodeToMp3(signal.ToWaveProvider(), path, 128000);
+
+            int blockAlign, sampleRate;
+            short[] reference;
+            using (var refReader = new MediaFoundationReader(path))
+            {
+                blockAlign = refReader.WaveFormat.BlockAlign;
+                sampleRate = refReader.WaveFormat.SampleRate;
+                if (refReader.WaveFormat.Channels != 1) Assert.Ignore("Expected a mono MP3 decode");
+                reference = ReadAllSamples(refReader);
+            }
+
+            const int window = 8192;
+            const int maxLag = 2000;
+            int targetSample = sampleRate * 2; // ~2s in
+            if (reference.Length < targetSample + window + maxLag)
+                Assert.Ignore("Decoded MP3 was shorter than expected");
+
+            long targetByte = (long)targetSample * blockAlign;
+            using var seeker = new MediaFoundationReader(path);
+            seeker.Position = targetByte;
+            var raw = new byte[window * blockAlign];
+            Assert.That(ReadFull(seeker, raw, raw.Length), Is.EqualTo(raw.Length),
+                "could not read a full window after seeking");
+            var win = new short[window];
+            Buffer.BlockCopy(raw, 0, win, 0, raw.Length);
+
+            // find the lag (in samples) that best aligns the post-seek window with the reference decode
+            long bestSum = long.MaxValue;
+            int bestLag = int.MaxValue;
+            for (int lag = -maxLag; lag <= maxLag; lag++)
+            {
+                long sum = 0;
+                int baseIdx = targetSample + lag;
+                for (int i = 0; i < window; i++)
+                {
+                    long d = win[i] - reference[baseIdx + i];
+                    sum += d * d;
+                    if (sum >= bestSum) break; // can't beat the current best, abandon early
+                }
+                if (sum < bestSum)
+                {
+                    bestSum = sum;
+                    bestLag = lag;
+                }
+            }
+
+            Assert.That(Math.Abs(bestLag), Is.LessThan(256),
+                $"audio after seeking was misaligned by {bestLag} samples from the requested position");
+        }
+        finally
+        {
+            TryDelete(path);
+        }
+    }
+
+    private static string CreateTempSineWav(int seconds)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"naudio_mf_seek_{Guid.NewGuid():N}.wav");
+        var signal = new SignalGenerator(44100, 1)
+        {
+            Type = SignalGeneratorType.Sin,
+            Frequency = 440,
+            Gain = 0.5
+        }.Take(TimeSpan.FromSeconds(seconds));
+        WaveFileWriter.CreateWaveFile16(path, signal);
+        return path;
+    }
+
+    private static int ReadFull(WaveStream reader, byte[] buffer, int count)
+    {
+        int total = 0;
+        while (total < count)
+        {
+            int read = reader.Read(buffer, total, count - total);
+            if (read == 0) break;
+            total += read;
+        }
+        return total;
+    }
+
+    private static short[] ReadAllSamples(WaveStream reader)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[reader.WaveFormat.AverageBytesPerSecond];
+        int read;
+        while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            ms.Write(buffer, 0, read);
+        }
+        var bytes = ms.ToArray();
+        var samples = new short[bytes.Length / 2];
+        Buffer.BlockCopy(bytes, 0, samples, 0, samples.Length * 2);
+        return samples;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // best-effort temp cleanup
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #628 — seeking in `MediaFoundationReader` was inexact.

`IMFSourceReader.SetCurrentPosition` is documented as a coarse seek: it lands on the nearest container keyframe at or before the requested time, and the caller is expected to read forward and skip into the next decoded buffer to reach the exact position. NAudio didn't do that — `Reposition` set `position = desiredPosition` and let the next `Read` copy the whole post-seek buffer from offset 0, so playback actually resumed from the keyframe. On audio extracted from video containers (webm/Vorbis, mkv/AAC), where keyframes are sparse, this could be seconds off.

This PR makes seeking sample-accurate:

- After `SetCurrentPosition`, `Reposition` now reads forward, discards whole decoded buffers that fall entirely before the target, and skips into the buffer that straddles the requested position. The skip is rounded **down** to a `BlockAlign` boundary (starting mid-sample produces loud static), and it tolerates the duplicate timestamps Media Foundation can emit on consecutive `ReadSample` calls.
- `Position` now reports the byte position actually reached, instead of blindly echoing the requested value. The deferred-reposition behaviour of the `Position` setter (`RepositionInRead = true`, used by GUI sliders) is unchanged.
- The per-sample COM unpacking is factored out of `Read` into a reusable `ReadNextDecoderBuffer` helper so the read loop and the seek skip-ahead share one path (no behavioural change to normal reads).

Also fixes a long-standing usability bug surfaced while testing this: NAudioDemo's `SeekableTrackBar` committed a seek on **both** MouseDown and MouseUp, so a single click repositioned the player twice and the audio at the seek target played back doubled (a short "ca… can" stutter). It now raises `Scroll` once per distinct position.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)

(Bullet added for the `MediaFoundationReader` fix; the NAudioDemo change is sample-only and doesn't need an entry.)

## Testing

- New `NAudio.Windows.Tests` coverage in `MediaFoundationReaderSeekTests` (decode-only, no audio hardware, so it runs in headless CI):
  - **Lossless WAV** — bytes returned after a seek are byte-identical to a sequential read to the same position, plus a `Position` accounting assertion.
  - **Lossy MP3** — best-fit alignment of the post-seek window against a full sequential decode is within a few samples of the requested position. This fails on the old reader (~1152-sample / one-frame offset) and passes with the fix.
- Verified the MP3 test **fails on `main`'s reader and passes with this change** by swapping the single file in/out.
- Built `NAudio.Wasapi`, `NAudio.Windows.Tests` and `NAudioDemo` (0 warnings / 0 errors); full non-skipped test run is green on Windows.
- Manual check in NAudioDemo: seeking m4a/mp3 now lands precisely and the double-click stutter is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKkYQUKLYdyqG9vCbReM15)_