### PR TITLE
Reject duplicate sources in MixingSampleProvider.AddMixerInput (#662)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -98,6 +98,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * Hardened Media Foundation and DMO interop against COM ref leaks on error paths (`MediaFoundationReader`, `MediaFoundationEncoder`, `MediaFoundationTransform`, `MediaBuffer`, `Mf*` wrappers) (#1293)
  * `MediaFoundationReader`: seeking is now sample-accurate — since `IMFSourceReader.SetCurrentPosition` only seeks to the nearest container keyframe, the reader now reads forward and skips into the decoded buffer to reach the exact requested position, instead of restarting playback from the keyframe (audible on audio extracted from video, e.g. Vorbis/AAC). `Position` now reflects the byte position actually reached (#628)
  * Removed dead `naudio.codeplex.com` links from the README, MixDiff and source comments (#985)
+ * `MixingSampleProvider.AddMixerInput` now throws `ArgumentException` if the same source is added twice, instead of silently consuming it at 2× rate and aliasing it against itself (#662)
 
 #### Performance
 

--- a/src/NAudio.Core/Wave/SampleProviders/MixingSampleProvider.cs
+++ b/src/NAudio.Core/Wave/SampleProviders/MixingSampleProvider.cs
@@ -74,6 +74,12 @@ public class MixingSampleProvider : ISampleProvider
             {
                 throw new InvalidOperationException("Too many mixer inputs");
             }
+            // Adding the same source twice would consume it at 2× its natural rate and alias
+            // it against itself — almost always a caller bug. Reject rather than silently mix.
+            if (sources.Contains(mixerInput))
+            {
+                throw new ArgumentException("Mixer input has already been added", nameof(mixerInput));
+            }
             sources.Add(mixerInput);
         }
         if (WaveFormat == null)

--- a/tests/NAudio.Core.Tests/WaveStreams/MixingSampleProviderTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/MixingSampleProviderTests.cs
@@ -66,6 +66,16 @@ public class MixingSampleProviderTests
     }
 
     [Test]
+    public void AddingSameMixerInputTwiceThrows()
+    {
+        var input = new TestSampleProvider(44100, 2, 2000);
+        var msp = new MixingSampleProvider(WaveFormat.CreateIeeeFloatWaveFormat(44100, 2));
+        msp.AddMixerInput(input);
+        Assert.Throws<ArgumentException>(() => msp.AddMixerInput(input));
+        Assert.That(msp.MixerInputs.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
     public void MixerInputEndedInvoked()
     {
         var input1 = new TestSampleProvider(44100, 2, 8000);


### PR DESCRIPTION
## Summary

Adds a duplicate-input guard to `MixingSampleProvider.AddMixerInput` — the same design intent as #662 (originally against the now-removed `MixingWaveProvider32`), applied to the class that replaced it.

Adding the same `ISampleProvider` twice previously succeeded silently, and produced surprising behaviour on `Read`: the loop calls `source.Read(...)` once per entry, so the source is consumed at 2× its natural rate, and the two reads land into the same output buffer offset — aliasing the source against itself. `MixerInputEnded` also fires twice when it eventually reports fewer samples than requested. Almost always a caller bug, and hard to diagnose because playback just sounds wrong rather than failing.

The check now throws `ArgumentException("Mixer input has already been added", nameof(mixerInput))` inside the existing `lock (sources)`, matching the tone of the neighbouring `WaveFormat`-mismatch guard.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

- Added `AddingSameMixerInputTwiceThrows` in `MixingSampleProviderTests`.
- `dotnet test tests/NAudio.Core.Tests` (`TestCategory!=IntegrationTest`) on .NET 10 locally: 1445 passed, 0 failed, 3 skipped (unchanged from `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRoXqEPiaPk3KXTQqThSPK)_