### PR TITLE
Read and write cue region lengths via ltxt sub-chunks (#1013)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,7 +85,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `MMDevice.Dispose` now releases the device's property store deterministically (`PropertyStore` is now `IDisposable`), instead of leaving it to be reclaimed by COM finalization (#1145)
  * `AudioEndpointVolume.OnVolumeNotification`: fixed per-channel notifications all returning channel 0's volume (#351)
  * `CueListInterpreter`: WAV files with cue points but no labels now return cues with empty labels instead of null (#549)
- * `CueListInterpreter`: cue region lengths from `ltxt` sub-chunks are now surfaced via a new `Cue.Length` / `CueList.CueLengths` property (#1013)
+ * Cue region lengths (`ltxt` sub-chunks) are now read and written by `CueListInterpreter` / `WaveFileWriter` — new `Cue.Length` / `CueList.CueLengths` and a `WaveFileWriter.AddCue(position, label, length)` overload (#1013)
  * `ResamplerDmoStream`: fixed an infinite loop on `Read` after seeking and the loss of the resampler tail at end-of-stream (#607, #608)
  * `LoopStream.Read`: no longer spins at 100% CPU when the wrapped source can't satisfy a read (#1338)
  * `RawSourceWaveStream`: the `byte[]` constructor now disposes the `MemoryStream` it creates internally when the stream is disposed (it previously leaked); a caller-supplied source stream is still left open

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -85,6 +85,7 @@ extensive correctness work during development — see [Docs/Sampler.md](Docs/Sam
  * `MMDevice.Dispose` now releases the device's property store deterministically (`PropertyStore` is now `IDisposable`), instead of leaving it to be reclaimed by COM finalization (#1145)
  * `AudioEndpointVolume.OnVolumeNotification`: fixed per-channel notifications all returning channel 0's volume (#351)
  * `CueListInterpreter`: WAV files with cue points but no labels now return cues with empty labels instead of null (#549)
+ * `CueListInterpreter`: cue region lengths from `ltxt` sub-chunks are now surfaced via a new `Cue.Length` / `CueList.CueLengths` property (#1013)
  * `ResamplerDmoStream`: fixed an infinite loop on `Read` after seeking and the loss of the resampler tail at end-of-stream (#607, #608)
  * `LoopStream.Read`: no longer spins at 100% CPU when the wrapped source can't satisfy a read (#1338)
  * `RawSourceWaveStream`: the `byte[]` constructor now disposes the `MemoryStream` it creates internally when the stream is disposed (it previously leaked); a caller-supplied source stream is still left open

--- a/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs
@@ -258,6 +258,24 @@ public class WaveFileWriter : Stream
         bufferedCues.Add(new Cue(position, label));
     }
 
+    /// <summary>
+    /// Adds a cue point with a label and a region length in samples. An <c>ltxt</c>
+    /// sub-chunk is emitted alongside the label so the cue reads back as a region rather
+    /// than a point marker.
+    /// </summary>
+    /// <param name="position">Sample position of the cue point.</param>
+    /// <param name="label">Text label (stored as UTF-8).</param>
+    /// <param name="length">Length in samples of the region starting at <paramref name="position"/>.</param>
+    public void AddCue(int position, string label, int length)
+    {
+        ThrowIfDisposed();
+        if (bufferedCues == null)
+        {
+            bufferedCues = new CueList();
+        }
+        bufferedCues.Add(new Cue(position, label, length));
+    }
+
     private void EnsureHeaderFinalized()
     {
         if (headerFinalized) return;

--- a/src/NAudio.Core/Wave/WaveStreams/CueList.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/CueList.cs
@@ -20,16 +20,33 @@ public class Cue
     /// Label of the cue
     /// </summary>
     public string Label { get; }
+    /// <summary>
+    /// Cue length in samples, or <c>null</c> if the cue is a point marker rather than
+    /// a region. Populated from the <c>ltxt</c> sub-chunk of a WAV <c>LIST/adtl</c> chunk.
+    /// </summary>
+    public int? Length { get; }
 
     /// <summary>
-    /// Creates a Cue based on a sample position and label 
+    /// Creates a Cue based on a sample position and label
     /// </summary>
     /// <param name="position"></param>
     /// <param name="label"></param>
-    public Cue(int position, string label)
+    public Cue(int position, string label) : this(position, label, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a Cue based on a sample position, label and region length in samples.
+    /// </summary>
+    /// <param name="position">Sample position of the cue point.</param>
+    /// <param name="label">Text label, or <c>null</c> for an empty label.</param>
+    /// <param name="length">Length in samples of the region starting at <paramref name="position"/>,
+    /// or <c>null</c> for a point marker with no length.</param>
+    public Cue(int position, string label, int? length)
     {
         Position = position;
         Label = label ?? string.Empty;
+        Length = length;
     }
 }
 
@@ -69,13 +86,27 @@ public class Cue
 ///   Int32 typeID;      /* 'adtl' */
 /// } 
 ///
-/// struct LabelChunk 
+/// struct LabelChunk
 /// {
 ///   Int32 chunkID;
 ///   Int32 chunkSize;
 ///   Int32 dwIdentifier;
 ///   Char[] dwText;  /* null-terminated; RIFF does not mandate an encoding — NAudio uses UTF-8 */
 /// } LabelChunk;
+///
+/// struct TextWithDataLengthChunk
+/// {
+///   Int32 chunkID;         /* 'ltxt' */
+///   Int32 chunkSize;
+///   Int32 dwIdentifier;
+///   Int32 dwSampleLength;
+///   Int32 dwPurpose;
+///   Int16 wCountry;
+///   Int16 wLanguage;
+///   Int16 wDialect;
+///   Int16 wCodePage;
+///   /* optional trailing text may follow */
+/// } TextWithDataLengthChunk;
 /// </remarks>
 public class CueList
 {
@@ -132,6 +163,24 @@ public class CueList
     }
 
     /// <summary>
+    /// Gets region lengths in samples for the embedded cues. Entries are <c>null</c>
+    /// for cues that are point markers rather than regions.
+    /// </summary>
+    /// <returns>Array containing the cue lengths.</returns>
+    public int?[] CueLengths
+    {
+        get
+        {
+            int?[] lengths = new int?[cues.Count];
+            for (int i = 0; i < cues.Count; i++)
+            {
+                lengths[i] = cues[i].Length;
+            }
+            return lengths;
+        }
+    }
+
+    /// <summary>
     /// Creates a cue list from the cue RIFF chunk and the list RIFF chunk
     /// </summary>
     /// <param name="cueChunkData">The data contained in the cue chunk</param>
@@ -150,7 +199,9 @@ public class CueList
         }
 
         string[] labels = new string[cueCount];
+        int?[] lengths = new int?[cueCount];
         var labelChunkId = ChunkIdentifier.ChunkIdentifierToInt32("labl");
+        var ltxtChunkId = ChunkIdentifier.ChunkIdentifierToInt32("ltxt");
 
         // Parse list chunk - properly handle all chunk types.
         // listChunkData may be null when the file has cue points but no adtl labels
@@ -175,6 +226,16 @@ public class CueList
                     }
                 }
             }
+            else if (chunkId == ltxtChunkId && chunkSize >= 20 && listChunkData.Length - p >= chunkSize + 8)
+            {
+                // Text-with-data-length: carries a region length (dwSampleLength) for a cue point.
+                // Minimum payload is 20 bytes: dwIdentifier + dwSampleLength + dwPurpose + 4x Int16.
+                var cueId = BitConverter.ToInt32(listChunkData, p + 8);
+                if (cueIndex.TryGetValue(cueId, out var cueIndex_value))
+                {
+                    lengths[cueIndex_value] = BitConverter.ToInt32(listChunkData, p + 12);
+                }
+            }
 
             // Move to next chunk: account for proper word-alignment padding
             // chunkSize is the size of the chunk data, add 8 for chunk ID and size fields
@@ -189,7 +250,7 @@ public class CueList
 
         for (int i = 0; i < cueCount; i++)
         {
-            cues.Add(new Cue(positions[i], labels[i]));
+            cues.Add(new Cue(positions[i], labels[i], lengths[i]));
         }
     }
 

--- a/src/NAudio.Core/Wave/WaveStreams/CueList.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/CueList.cs
@@ -278,12 +278,15 @@ public class CueList
     }
 
     /// <summary>
-    /// Serialises the cue labels into the body of a <c>LIST</c> chunk of type <c>adtl</c>
-    /// (no chunk id / size header — starts with the <c>adtl</c> type marker).
+    /// Serialises the cue labels (and optional region lengths) into the body of a <c>LIST</c>
+    /// chunk of type <c>adtl</c> (no chunk id / size header — starts with the <c>adtl</c>
+    /// type marker). A cue whose <see cref="Cue.Length"/> is non-null gets a companion
+    /// <c>ltxt</c> sub-chunk emitted alongside its <c>labl</c>.
     /// </summary>
     internal byte[] SerializeAdtlListChunkData()
     {
         int labelChunkId = ChunkIdentifier.ChunkIdentifierToInt32("labl");
+        int ltxtChunkId = ChunkIdentifier.ChunkIdentifierToInt32("ltxt");
         using var ms = new MemoryStream();
         using var w = new BinaryWriter(ms);
         w.Write(Encoding.UTF8.GetBytes("adtl"));
@@ -298,6 +301,22 @@ public class CueList
             if ((labelArray.Length + 1) % 2 == 1)
             {
                 w.Write((byte)0);               // word-alignment padding
+            }
+
+            if (this[i].Length.HasValue)
+            {
+                // ltxt minimum payload: dwIdentifier + dwSampleLength + dwPurpose + 4x Int16 = 20 bytes.
+                // dwPurpose and the four language fields are left at 0 — consumers that only care
+                // about region length ignore them, and there's no widely-honoured semantic default.
+                w.Write(ltxtChunkId);
+                w.Write(20);
+                w.Write(i);                     // dwIdentifier (cue id)
+                w.Write(this[i].Length.Value);  // dwSampleLength
+                w.Write(0);                     // dwPurpose
+                w.Write((short)0);              // wCountry
+                w.Write((short)0);              // wLanguage
+                w.Write((short)0);              // wDialect
+                w.Write((short)0);              // wCodePage
             }
         }
         return ms.ToArray();

--- a/tests/NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using NAudio.Utils;
 using NAudio.Wave;
 using NUnit.Framework;
@@ -174,6 +175,65 @@ public class CueListInterpreterTests
         Assert.That(cues[1].Label, Is.EqualTo("Beta"));
     }
 
+    [Test]
+    public void ReadsCueLengthFromLtxtChunk()
+    {
+        // Hand-built WAV: two cue points, one carrying a region length via an ltxt sub-chunk
+        // in the LIST/adtl. The writer doesn't emit ltxt itself, so we compose the chunks
+        // and let the interpreter parse them back.
+        var cueBytes = BuildCueChunkBody(
+            (cueId: 1, samplePosition: 100),
+            (cueId: 2, samplePosition: 200));
+        var adtlBytes = BuildAdtlListChunkBody(
+            (cueId: 1, label: "Point", sampleLength: null),
+            (cueId: 2, label: "Region", sampleLength: 50));
+
+        var ms = new MemoryStream();
+        using (var w = new WaveFileWriter(new IgnoreDisposeStream(ms), Format))
+        {
+            w.AddChunk("cue ", cueBytes, ChunkPosition.AfterData);
+            w.AddChunk("LIST", adtlBytes, ChunkPosition.AfterData);
+            w.WriteSamples(new short[] { 1, 2 }, 0, 2);
+        }
+        ms.Position = 0;
+        using var reader = new WaveFileReader(ms);
+        var cues = reader.Chunks.Read(CueListInterpreter.Instance);
+        Assert.That(cues, Is.Not.Null);
+        Assert.That(cues.Count, Is.EqualTo(2));
+        Assert.That(cues[0].Position, Is.EqualTo(100));
+        Assert.That(cues[0].Label, Is.EqualTo("Point"));
+        Assert.That(cues[0].Length, Is.Null);
+        Assert.That(cues[1].Position, Is.EqualTo(200));
+        Assert.That(cues[1].Label, Is.EqualTo("Region"));
+        Assert.That(cues[1].Length, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void IgnoresLtxtChunkReferencingUnknownCueId()
+    {
+        // An ltxt referring to a cue id that isn't in the cue chunk should be silently
+        // dropped rather than throwing or corrupting a neighbouring cue.
+        var cueBytes = BuildCueChunkBody((cueId: 1, samplePosition: 100));
+        var adtlBytes = BuildAdtlListChunkBody(
+            (cueId: 1, label: "Real", sampleLength: null),
+            (cueId: 999, label: null, sampleLength: 12345));
+
+        var ms = new MemoryStream();
+        using (var w = new WaveFileWriter(new IgnoreDisposeStream(ms), Format))
+        {
+            w.AddChunk("cue ", cueBytes, ChunkPosition.AfterData);
+            w.AddChunk("LIST", adtlBytes, ChunkPosition.AfterData);
+            w.WriteSamples(new short[] { 1, 2 }, 0, 2);
+        }
+        ms.Position = 0;
+        using var reader = new WaveFileReader(ms);
+        var cues = reader.Chunks.Read(CueListInterpreter.Instance);
+        Assert.That(cues, Is.Not.Null);
+        Assert.That(cues.Count, Is.EqualTo(1));
+        Assert.That(cues[0].Label, Is.EqualTo("Real"));
+        Assert.That(cues[0].Length, Is.Null);
+    }
+
     // ---- helpers ------------------------------------------------------------
 
     /// <summary>
@@ -191,6 +251,66 @@ public class CueListInterpreterTests
         w.Write(0);                                 // dwChunkStart
         w.Write(0);                                 // dwBlockStart
         w.Write(samplePosition);                    // dwSampleOffset
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a <c>cue </c> chunk body with the given cue points. Uses the sample position
+    /// as both <c>dwPosition</c> and <c>dwSampleOffset</c>, and points at the <c>data</c> chunk.
+    /// </summary>
+    private static byte[] BuildCueChunkBody(params (int cueId, int samplePosition)[] points)
+    {
+        using var ms = new MemoryStream();
+        using var w = new BinaryWriter(ms);
+        w.Write(points.Length);
+        foreach (var (cueId, samplePosition) in points)
+        {
+            w.Write(cueId);
+            w.Write(samplePosition);
+            w.Write(ChunkIdentifier.ChunkIdentifierToInt32("data"));
+            w.Write(0);
+            w.Write(0);
+            w.Write(samplePosition);
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a <c>LIST</c> chunk body of type <c>adtl</c> containing a <c>labl</c> sub-chunk
+    /// for each entry, and an <c>ltxt</c> sub-chunk when <paramref name="entries"/> supplies
+    /// a <c>sampleLength</c>. The writer only emits <c>labl</c>, so we build these by hand
+    /// to exercise the reader's <c>ltxt</c> path.
+    /// </summary>
+    private static byte[] BuildAdtlListChunkBody(params (int cueId, string label, int? sampleLength)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using var w = new BinaryWriter(ms);
+        w.Write(Encoding.UTF8.GetBytes("adtl"));
+        foreach (var (cueId, label, sampleLength) in entries)
+        {
+            if (label != null)
+            {
+                var labelBytes = Encoding.UTF8.GetBytes(label);
+                w.Write(ChunkIdentifier.ChunkIdentifierToInt32("labl"));
+                w.Write(labelBytes.Length + 1 + 4); // dwIdentifier + text + NUL
+                w.Write(cueId);
+                w.Write(labelBytes);
+                w.Write((byte)0);
+                if ((labelBytes.Length + 1) % 2 == 1) w.Write((byte)0); // word-align
+            }
+            if (sampleLength.HasValue)
+            {
+                w.Write(ChunkIdentifier.ChunkIdentifierToInt32("ltxt"));
+                w.Write(20); // dwIdentifier + dwSampleLength + dwPurpose + 4x Int16
+                w.Write(cueId);
+                w.Write(sampleLength.Value);
+                w.Write(0);       // dwPurpose
+                w.Write((short)0); // wCountry
+                w.Write((short)0); // wLanguage
+                w.Write((short)0); // wDialect
+                w.Write((short)0); // wCodePage
+            }
+        }
         return ms.ToArray();
     }
 

--- a/tests/NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/CueListInterpreterTests.cs
@@ -209,6 +209,29 @@ public class CueListInterpreterTests
     }
 
     [Test]
+    public void RoundTripsCueLengthViaWaveFileWriter()
+    {
+        var ms = new MemoryStream();
+        using (var w = new WaveFileWriter(new IgnoreDisposeStream(ms), Format))
+        {
+            w.AddCue(100, "Point");
+            w.AddCue(200, "Region", 50);
+            w.WriteSamples(new short[] { 1, 2 }, 0, 2);
+        }
+        ms.Position = 0;
+        using var reader = new WaveFileReader(ms);
+        var cues = reader.Chunks.ReadCueList();
+        Assert.That(cues, Is.Not.Null);
+        Assert.That(cues.Count, Is.EqualTo(2));
+        Assert.That(cues[0].Position, Is.EqualTo(100));
+        Assert.That(cues[0].Label, Is.EqualTo("Point"));
+        Assert.That(cues[0].Length, Is.Null);
+        Assert.That(cues[1].Position, Is.EqualTo(200));
+        Assert.That(cues[1].Label, Is.EqualTo("Region"));
+        Assert.That(cues[1].Length, Is.EqualTo(50));
+    }
+
+    [Test]
     public void IgnoresLtxtChunkReferencingUnknownCueId()
     {
         // An ltxt referring to a cue id that isn't in the cue chunk should be silently

--- a/tests/NAudio.Core.Tests/WaveStreams/CueListTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/CueListTests.cs
@@ -102,6 +102,41 @@ public class CueListTests
 
     [Test]
     [Category("UnitTest")]
+    public void CueLengthDefaultsToNull()
+    {
+        var cue = new Cue(1000, "Label");
+        Assert.That(cue.Length, Is.Null);
+    }
+
+    [Test]
+    [Category("UnitTest")]
+    public void CueLengthConstructorRoundTrips()
+    {
+        var cue = new Cue(1000, "Region", 500);
+        Assert.That(cue.Position, Is.EqualTo(1000));
+        Assert.That(cue.Label, Is.EqualTo("Region"));
+        Assert.That(cue.Length, Is.EqualTo(500));
+    }
+
+    [Test]
+    [Category("UnitTest")]
+    public void CueLengthsReturnsCorrectArray()
+    {
+        var cueList = new CueList();
+        cueList.Add(new Cue(100, "Point"));
+        cueList.Add(new Cue(200, "Region", 50));
+        cueList.Add(new Cue(300, "AnotherRegion", 25));
+
+        var lengths = cueList.CueLengths;
+
+        Assert.That(lengths, Has.Length.EqualTo(3));
+        Assert.That(lengths[0], Is.Null);
+        Assert.That(lengths[1], Is.EqualTo(50));
+        Assert.That(lengths[2], Is.EqualTo(25));
+    }
+
+    [Test]
+    [Category("UnitTest")]
     public void CueLabelIsReadOnly()
     {
         // arrange


### PR DESCRIPTION
## Summary

Re-implements the intent of #1013 on `main`, and rounds it out so cue region lengths are both read and written (the original PR was read-only).

WAV files store cue region lengths in an `ltxt` sub-chunk of the `LIST/adtl` list, sitting alongside the `labl` sub-chunks that carry cue labels. NAudio's cue-list interpreter previously recognised `labl` but not `ltxt`, so cue regions loaded from WAVs (loop points, sampler regions, marker regions from Audacity/Reaper/Adobe Audition, etc.) were surfaced as bare point markers — the length information was dropped on the floor.

Changes:

- **`Cue`** — new nullable `int? Length` property. A new `Cue(int position, string label, int? length)` constructor sits alongside the existing `Cue(int position, string label)`; the two-arg constructor now forwards to the three-arg with `length: null`, so source-compat is preserved for callers using positional args.
- **`CueList`** — new `CueLengths` property mirroring `CuePositions` / `CueLabels`; internal parser extended to recognise the `ltxt` chunk id and populate `Length`. `SerializeAdtlListChunkData` now emits an `ltxt` sub-chunk (20-byte minimum payload, `dwPurpose = 0` and the four language-code Int16s zeroed) whenever a cue has a non-null `Length`. `<remarks>` on the class now documents the `ltxt` struct alongside the existing cue-point and label structs.
- **`WaveFileWriter`** — new `AddCue(int position, string label, int length)` overload that stores the region length. The existing two-arg `AddCue` is unchanged.

Files without regions read back exactly as before (empty `ltxt`-less `adtl` lists still produce cues with `Length == null`). Unknown cue ids in a stray `ltxt` are silently dropped rather than throwing, matching the existing tolerance for stray `labl` entries.

Design deltas from the original PR:

- Kept `Cue`'s existing constructor signature and added a new overload rather than editing the parameter order (the original PR changed `Cue(int, string)` to `Cue(int, int?, string)`, a source-breaking change).
- The parser uses `cueIndex.TryGetValue(cueId, ...)` to map ids to indices, matching the existing `labl` path. The original PR indexed a stale `cue` variable left over from the preceding cue-point loop, which would misattribute the length to the wrong entry.
- Added a write path so cues built via `AddCue(position, label, length)` round-trip correctly, instead of the length being silently ignored on save.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

- New `CueListTests`: `CueLengthDefaultsToNull`, `CueLengthConstructorRoundTrips`, `CueLengthsReturnsCorrectArray`.
- New `CueListInterpreterTests`: `ReadsCueLengthFromLtxtChunk` (hand-built `cue `/`LIST/adtl` bytes with `ltxt`), `IgnoresLtxtChunkReferencingUnknownCueId`, `RoundTripsCueLengthViaWaveFileWriter` (writer → reader end-to-end).
- `dotnet test tests/NAudio.Core.Tests` (`TestCategory!=IntegrationTest`) on .NET 10 locally: 1451 passed, 0 failed, 3 skipped (unchanged from `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRoXqEPiaPk3KXTQqThSPK)_