### PR TITLE
Builds on GNU/Linux

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <!-- Lockstep version for all NAudio NuGet packages. CI overrides
          <VersionSuffix> on pre-release builds (e.g. preview.NN). Sample/tool
@@ -16,6 +16,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>naudio-icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Strong naming. The .snk lives at the repo root, anchored via
          $(MSBuildThisFileDirectory) so csprojs at any depth resolve it.


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? -->

## Release notes

<!--
Tick one. The maintainer may rewrite or remove your entry at release time;
the goal here is to ensure user-visible changes don't slip through.
-->

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

I did run the compilation, with success,
I use Debian 13,
do not care about timings, It was during a big copy on hard disk in parallel
 :

````bash
paul@mercure:~/Workspace/NAudio$ dotnet build 
Restauration terminée (21,5s)
  NAudio.Core net9.0 a réussi (33,2s) → src/NAudio.Core/bin/Debug/net9.0/NAudio.Core.dll
  NAudio.Alsa net9.0 a réussi (3,4s) → src/NAudio.Alsa/bin/Debug/net9.0/NAudio.Alsa.dll
  NAudio.SoundFile net9.0 a réussi (7,8s) → src/NAudio.SoundFile/bin/Debug/net9.0/NAudio.SoundFile.dll
  NAudio.Midi net9.0 a réussi (3,2s) → src/NAudio.Midi/bin/Debug/net9.0/NAudio.Midi.dll
  NAudio.Dmo net9.0-windows a réussi (11,1s) → src/NAudio.Dmo/bin/Debug/net9.0-windows/NAudio.Dmo.dll
  NAudio.Midi net9.0-windows10.0.19041.0 a réussi (9,9s) → src/NAudio.Midi/bin/Debug/net9.0-windows10.0.19041.0/NAudio.Midi.dll
  NAudio.Asio net9.0-windows a réussi (1,6s) → src/NAudio.Asio/bin/Debug/net9.0-windows/NAudio.Asio.dll
  NAudio.Wasapi net9.0 a réussi (12,5s) → src/NAudio.Wasapi/bin/Debug/net9.0/NAudio.Wasapi.dll
  NAudio.Alsa.Tests net10.0 a réussi (2,2s) → tests/NAudio.Alsa.Tests/bin/Debug/net10.0/NAudio.Alsa.Tests.dll
  NAudio.Benchmarks net9.0-windows a réussi (22,4s) → tests/NAudio.Benchmarks/bin/Release/net9.0-windows/NAudio.Benchmarks.dll
  MfStressTest net9.0-windows10.0.19041.0 win-x64 a réussi (4,1 s) → tests/MfStressTest/bin/Release/net9.0-windows10.0.19041.0/win-x64/MfStressTest.dll
  NAudio.Core.Tests net10.0 a réussi (9,0s) → tests/NAudio.Core.Tests/bin/Debug/net10.0/NAudio.Core.Tests.dll
  NAudio.SoundFile.Tests net10.0 a réussi (1,0s) → tests/NAudio.SoundFile.Tests/bin/Debug/net10.0/NAudio.SoundFile.Tests.dll
  NAudio.Sampler net9.0 a réussi (1,8s) → src/NAudio.Sampler/bin/Debug/net9.0/NAudio.Sampler.dll
  NAudio.WinMM net9.0-windows a réussi (1,7s) → src/NAudio.WinMM/bin/Debug/net9.0-windows/NAudio.WinMM.dll
  NAudio net9.0 a réussi (0,8s) → src/NAudio/bin/Debug/net9.0/NAudio.dll
  NAudio.Sampler.Tests net10.0 a réussi (6,2s) → tests/NAudio.Sampler.Tests/bin/Debug/net10.0/NAudio.Sampler.Tests.dll
  NAudio.Vst3 net9.0-windows a réussi (6,9s) → src/NAudio.Vst3/bin/Debug/net9.0-windows/NAudio.Vst3.dll
  NAudio.WinForms net9.0-windows a réussi (8,6s) → src/NAudio.WinForms/bin/Debug/net9.0-windows/NAudio.WinForms.dll
  NAudio.Extras net9.0 a réussi (0,2s) → src/NAudio.Extras/bin/Debug/net9.0/NAudio.Extras.dll
  NAudioAotSmokeTest net9.0-windows10.0.19041.0 win-x64 a réussi (9,2 s) → tests/NAudioAotSmokeTest/bin/Debug/net9.0-windows10.0.19041.0/win-x64/NAudioAotSmokeTest.dll
  NAudioConsoleTest net9.0-windows10.0.26100 a réussi (15,5s) → samples/NAudioConsoleTest/bin/Debug/net9.0-windows10.0.26100/NAudioConsoleTest.dll
  NAudio net9.0-windows10.0.19041.0 a réussi (0,2s) → src/NAudio/bin/Debug/net9.0-windows10.0.19041.0/NAudio.dll
  NAudio.Extras net9.0-windows10.0.19041.0 a réussi (0,3s) → src/NAudio.Extras/bin/Debug/net9.0-windows10.0.19041.0/NAudio.Extras.dll
  AudioFileInspector net9.0-windows10.0.19041.0 a réussi (3,4s) → samples/AudioFileInspector/bin/Debug/net9.0-windows10.0.19041.0/AudioFileInspector.dll
  MidiFileConverter net9.0-windows10.0.19041.0 a réussi (3,2s) → samples/MidiFileConverter/bin/Debug/net9.0-windows10.0.19041.0/MIDI File Converter.dll
  MixDiff net9.0-windows10.0.19041.0 a réussi (3,3s) → samples/MixDiff/bin/Debug/net9.0-windows10.0.19041.0/MixDiff.dll
  NAudio.Windows.Tests net10.0-windows10.0.19041.0 a réussi (63,1s) → tests/NAudio.Windows.Tests/bin/Debug/net10.0-windows10.0.19041.0/NAudio.Windows.Tests.dll
  NAudioDemo net9.0-windows10.0.19041.0 a réussi (0,8s) → samples/NAudioDemo/bin/Debug/net9.0-windows10.0.19041.0/NAudioDemo.dll
  NAudioWpfDemo net9.0-windows10.0.19041.0 a réussi (65,5s) → samples/NAudioWpfDemo/bin/Debug/net9.0-windows10.0.19041.0/NAudioWpfDemo.dll

Générer a réussi dans 248,2s
````
