### PR TITLE
Allow output-only ASIO duplex sessions (empty InputChannels)

### DIFF
--- a/Docs/AsioDuplex.md
+++ b/Docs/AsioDuplex.md
@@ -126,6 +126,36 @@ device.InitDuplex(new AsioDuplexOptions
 
 (Note that `mix` starts zeroed — the library zeros output buffers before each call.)
 
+## Output-only (no input channels)
+
+Leaving `InputChannels` empty (or null) configures an **output-only** session: the same processor callback runs, but there's no capture side. This is the way to drive each output channel *independently* — writing a separate `Span<float>` per channel — without collapsing everything into a single interleaved `IWaveProvider` the way playback mode requires. It's the natural fit for routing different channel pairs to different speakers.
+
+```c#
+device.InitDuplex(new AsioDuplexOptions
+{
+    OutputChannels = [0, 1, 2, 3],   // two independent speaker pairs
+    SampleRate     = 48000,
+    Processor      = (in AsioProcessBuffers b) =>
+    {
+        var frontL = b.GetOutput(0);
+        var frontR = b.GetOutput(1);
+        var rearL  = b.GetOutput(2);
+        var rearR  = b.GetOutput(3);
+        for (int i = 0; i < b.Frames; i++)
+        {
+            // fill each channel from whatever source you like — no interleaving
+        }
+    }
+});
+device.Start();
+```
+
+In this mode `b.InputChannelCount` is `0` and calling `b.GetInput(i)` / `b.RawInput(i)` throws — there's nothing to capture. Everything else works exactly as in full duplex: outputs are zero-filled before your callback, and unwritten channels stay silent.
+
+`OutputChannels` and `Processor` are still required; only the input side is optional.
+
+> Duplex is the general "processor callback over per-channel `Span<float>`" mode; output-only is simply that mode with the input side empty, rather than a separate API to learn.
+
 ## The raw escape hatch
 
 For zero-copy passthrough — say you want to memcpy native bytes from one channel to another without the float round-trip — call `RawInput` / `RawOutput`:

--- a/Docs/AsioPlayback.md
+++ b/Docs/AsioPlayback.md
@@ -55,6 +55,8 @@ OutputChannels = device.Capabilities.AllOutputChannels
 
 See [AsioChannelMapping](AsioChannelMapping.md) for more channel-routing patterns.
 
+> Need to write each output channel independently — a different source per channel, rather than one interleaved `IWaveProvider` fanned out — for example to route separate channel pairs to separate speakers? Use [duplex mode with no input channels](AsioDuplex.md#output-only-no-input-channels).
+
 ## Start and stop
 
 ```c#

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+- Allowed `AsioDevice.InitDuplex` to be called with no input channels (empty or null `AsioDuplexOptions.InputChannels`), configuring an output-only processor session — the way to write each ASIO output channel independently without feeding a single interleaved `IWaveProvider` (#1389)
 - Changed `NAudio.Wasapi` to target `net9.0` instead of `net9.0-windows10.0.19041.0`; it stays Windows-only at runtime via `[SupportedOSPlatform("windows")]`, so cross-platform apps can now reference it and build on Linux/macOS without `EnableWindowsTargeting` (#1384)
 - Moved the WinRT MIDI backend (`WinRTMidiIn`, `WinRTMidiOut`, `MidiMessageConverter`) from `NAudio.Wasapi` into `NAudio.Midi`, which now dual-targets `net9.0;net9.0-windows10.0.19041.0`. The types keep the `NAudio.Midi` namespace; they ship only in the Windows build (#1384)
 - Annotated the process-loopback APIs (`AudioClient.ActivateProcessLoopbackAsync`, `WasapiRecorderBuilder.WithProcessLoopback`) with `[SupportedOSPlatform("windows10.0.19041.0")]` so the platform-compatibility analyzer flags the Windows 10 2004 floor precisely on those members, instead of the whole assembly carrying it via the old TFM (#1384)

--- a/src/NAudio.Asio/AsioDevice.cs
+++ b/src/NAudio.Asio/AsioDevice.cs
@@ -391,15 +391,23 @@ public sealed class AsioDevice : IDisposable
     /// Configures the device for duplex operation: a single user-supplied callback receives input and writes output
     /// in the same buffer-switch. Used for low-latency real-time DSP (passthrough monitoring, effects, level metering with playback).
     /// </summary>
+    /// <remarks>
+    /// <see cref="AsioDuplexOptions.InputChannels"/> may be empty (or null), which configures an <em>output-only</em>
+    /// processor session: the callback writes independent per-channel <see cref="Span{Single}"/> output via
+    /// <see cref="AsioProcessBuffers.GetOutput"/> with no capture side. This is the route to driving each output channel
+    /// individually (e.g. routing different channel pairs to different speakers) without feeding a single interleaved
+    /// <see cref="IWaveProvider"/> as <see cref="InitPlayback"/> requires. <see cref="AsioDuplexOptions.OutputChannels"/>
+    /// and <see cref="AsioDuplexOptions.Processor"/> are always required.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown if the device has already been configured.</exception>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown if the input or output channel selection is invalid, or the processor is missing.</exception>
+    /// <exception cref="ArgumentException">Thrown if the output channel selection is invalid or empty, the (optional) input channel selection is invalid, or the processor is missing.</exception>
     /// <exception cref="NotSupportedException">Thrown if the selected channels use a native format outside Int16LSB/Int24LSB/Int32LSB/Float32LSB, or mix formats.</exception>
     public void InitDuplex(AsioDuplexOptions options)
     {
         if (options is null) throw new ArgumentNullException(nameof(options));
-        if (options.InputChannels is null || options.InputChannels.Length == 0)
-            throw new ArgumentException($"{nameof(AsioDuplexOptions)}.{nameof(options.InputChannels)} is required and must contain at least one channel.", nameof(options));
+        // Input channels are optional: an empty/null selection configures an output-only processor session
+        // (independent per-channel Span<float> writes with no capture). Outputs and a processor are always required.
         if (options.OutputChannels is null || options.OutputChannels.Length == 0)
             throw new ArgumentException($"{nameof(AsioDuplexOptions)}.{nameof(options.OutputChannels)} is required and must contain at least one channel.", nameof(options));
         if (options.Processor is null)
@@ -407,15 +415,22 @@ public sealed class AsioDevice : IDisposable
         ThrowIfDisposed();
         ThrowIfNotUnconfigured();
 
-        int[] inputChannels = options.InputChannels;
+        int[] inputChannels = options.InputChannels ?? Array.Empty<int>();
         int[] outputChannels = options.OutputChannels;
-        ValidateChannelIndices(inputChannels, driver.Capabilities.NbInputChannels, nameof(options) + "." + nameof(options.InputChannels), isInput: true);
+        bool hasInputs = inputChannels.Length > 0;
+        if (hasInputs)
+            ValidateChannelIndices(inputChannels, driver.Capabilities.NbInputChannels, nameof(options) + "." + nameof(options.InputChannels), isInput: true);
         ValidateChannelIndices(outputChannels, driver.Capabilities.NbOutputChannels, nameof(options) + "." + nameof(options.OutputChannels), isInput: false);
 
         // Phase 0 finding F3 — every selected channel on each side must share a single supported native format.
-        var inputFormat = ValidateUniformInputFormat(inputChannels);
+        // With no inputs there is nothing to validate or convert on the capture side.
+        var inputFormat = default(AsioSampleType);
+        if (hasInputs)
+        {
+            inputFormat = ValidateUniformInputFormat(inputChannels);
+            duplexInputConverter = AsioNativeToFloatConverter.Select(inputFormat);
+        }
         var outputFormat = ValidateUniformOutputFormat(outputChannels);
-        duplexInputConverter = AsioNativeToFloatConverter.Select(inputFormat);
         duplexOutputConverter = AsioFloatToNativeConverter.Select(outputFormat);
 
         int sampleRate = options.SampleRate ?? (int)driver.Capabilities.SampleRate;
@@ -451,7 +466,8 @@ public sealed class AsioDevice : IDisposable
             OutputFloatBuffers = outputFloatBuffers,
             InputNativeBuffers = new IntPtr[inputChannels.Length],
             OutputNativeBuffers = new IntPtr[outputChannels.Length],
-            InputNativeBytesPerChannel = framesPerBuffer * AsioNativeToFloatConverter.BytesPerSample(inputFormat),
+            // BytesPerSample throws on the default (unset) format, so only compute it when there are inputs.
+            InputNativeBytesPerChannel = hasInputs ? framesPerBuffer * AsioNativeToFloatConverter.BytesPerSample(inputFormat) : 0,
             OutputNativeBytesPerChannel = framesPerBuffer * AsioNativeToFloatConverter.BytesPerSample(outputFormat),
             OutputRawAccessed = new bool[outputChannels.Length],
             Valid = false
@@ -856,7 +872,7 @@ public sealed class AsioDevice : IDisposable
 
     private static AsioDuplexOptions Snapshot(AsioDuplexOptions o) => new()
     {
-        InputChannels = (int[])o.InputChannels.Clone(),
+        InputChannels = o.InputChannels is null ? null : (int[])o.InputChannels.Clone(),
         OutputChannels = (int[])o.OutputChannels.Clone(),
         SampleRate = o.SampleRate,
         BufferSize = o.BufferSize,

--- a/src/NAudio.Asio/AsioDuplexOptions.cs
+++ b/src/NAudio.Asio/AsioDuplexOptions.cs
@@ -10,6 +10,8 @@ public sealed class AsioDuplexOptions
     /// <summary>
     /// Physical input channel indices. May be non-contiguous. The processor callback addresses them via
     /// <see cref="AsioProcessBuffers.GetInput"/> using zero-based indices into this array.
+    /// Optional — leave null or empty for an output-only session, where the callback writes per-channel output
+    /// via <see cref="AsioProcessBuffers.GetOutput"/> with no capture side and <see cref="AsioProcessBuffers.InputChannelCount"/> is 0.
     /// </summary>
     public int[] InputChannels { get; init; }
 

--- a/src/NAudio.Asio/AsioProcessBuffers.cs
+++ b/src/NAudio.Asio/AsioProcessBuffers.cs
@@ -75,7 +75,10 @@ public readonly ref struct AsioProcessBuffers
     public ReadOnlySpan<float> GetInput(int channelIndex)
     {
         if ((uint)channelIndex >= (uint)context.InputChannelCount)
-            throw new ArgumentOutOfRangeException(nameof(channelIndex), $"Expected index in [0, {context.InputChannelCount - 1}].");
+            throw new ArgumentOutOfRangeException(nameof(channelIndex),
+                context.InputChannelCount == 0
+                    ? "This is an output-only session (no input channels were selected), so there is no input to read."
+                    : $"Expected index in [0, {context.InputChannelCount - 1}].");
         return context.InputFloatBuffers[channelIndex].AsSpan(0, context.Frames);
     }
 

--- a/tests/NAudio.Windows.Tests/Asio/AsioDuplexOptionsTests.cs
+++ b/tests/NAudio.Windows.Tests/Asio/AsioDuplexOptionsTests.cs
@@ -43,4 +43,19 @@ public class AsioDuplexOptionsTests
         Assert.That(options.BufferSize, Is.EqualTo(256));
         Assert.That(options.Processor, Is.SameAs(processor));
     }
+
+    [Test]
+    public void OutputOnly_LeavesInputChannelsUnset()
+    {
+        // Output-only configuration: no input channels, just outputs and a processor.
+        var options = new AsioDuplexOptions
+        {
+            OutputChannels = [0, 1, 2, 3],
+            Processor = (in AsioProcessBuffers _) => { }
+        };
+
+        Assert.That(options.InputChannels, Is.Null, "output-only leaves InputChannels null");
+        Assert.That(options.OutputChannels, Has.Length.EqualTo(4));
+        Assert.That(options.Processor, Is.Not.Null);
+    }
 }

--- a/tests/NAudio.Windows.Tests/Asio/AsioOutputOnlyDuplexTests.cs
+++ b/tests/NAudio.Windows.Tests/Asio/AsioOutputOnlyDuplexTests.cs
@@ -1,0 +1,111 @@
+using System;
+using NAudio.Wave;
+using NAudio.Wave.Asio;
+using NUnit.Framework;
+
+namespace NAudio.Windows.Tests.Asio;
+
+/// <summary>
+/// Unit coverage for output-only duplex sessions (empty <see cref="AsioDuplexOptions.InputChannels"/>).
+/// The full <see cref="AsioDevice.InitDuplex"/> path needs real ASIO hardware, so these tests exercise the
+/// per-callback view (<see cref="AsioProcessBuffers"/>) directly against a hand-built <c>AsioCallbackContext</c>
+/// shaped exactly as <c>InitDuplex</c> shapes it when no inputs are selected: zero input channels, populated outputs.
+/// </summary>
+[TestFixture]
+[Category("UnitTest")]
+public class AsioOutputOnlyDuplexTests
+{
+    private const int Frames = 4;
+
+    // Mirrors the context InitDuplex builds for OutputChannels = [0, 1] with no inputs.
+    private static AsioCallbackContext OutputOnlyContext(int outputChannels = 2) => new()
+    {
+        Frames = Frames,
+        SampleRate = 48000,
+        InputChannelCount = 0,
+        OutputChannelCount = outputChannels,
+        InputFormat = default,               // unset — no input side
+        OutputFormat = AsioSampleType.Float32LSB,
+        InputFloatBuffers = Array.Empty<float[]>(),
+        OutputFloatBuffers = AllocChannels(outputChannels),
+        InputNativeBuffers = Array.Empty<IntPtr>(),
+        OutputNativeBuffers = new IntPtr[outputChannels],
+        InputNativeBytesPerChannel = 0,
+        OutputRawAccessed = new bool[outputChannels],
+        Valid = true,
+    };
+
+    private static float[][] AllocChannels(int count)
+    {
+        var buffers = new float[count][];
+        for (int i = 0; i < count; i++) buffers[i] = new float[Frames];
+        return buffers;
+    }
+
+    [Test]
+    public void OutputOnly_ReportsZeroInputsAndCorrectOutputCount()
+    {
+        var ctx = OutputOnlyContext(outputChannels: 4);
+        var buffers = new AsioProcessBuffers(ctx);
+        // Read the ref-struct properties into plain locals — a ref struct can't be captured in the Assert.Multiple lambda.
+        int inputCount = buffers.InputChannelCount;
+        int outputCount = buffers.OutputChannelCount;
+        int frames = buffers.Frames;
+        Assert.Multiple(() =>
+        {
+            Assert.That(inputCount, Is.EqualTo(0));
+            Assert.That(outputCount, Is.EqualTo(4));
+            Assert.That(frames, Is.EqualTo(Frames));
+        });
+    }
+
+    [Test]
+    public void OutputOnly_GetOutput_ReturnsWritablePerChannelSpans()
+    {
+        var ctx = OutputOnlyContext();
+        var buffers = new AsioProcessBuffers(ctx);
+
+        var ch0 = buffers.GetOutput(0);
+        var ch1 = buffers.GetOutput(1);
+        Assert.That(ch0.Length, Is.EqualTo(Frames));
+        Assert.That(ch1.Length, Is.EqualTo(Frames));
+
+        // Writes land in the library-owned buffers, independently per channel.
+        ch0[0] = 0.25f;
+        ch1[3] = -0.5f;
+        Assert.That(ctx.OutputFloatBuffers[0][0], Is.EqualTo(0.25f));
+        Assert.That(ctx.OutputFloatBuffers[1][3], Is.EqualTo(-0.5f));
+        Assert.That(ctx.OutputFloatBuffers[1][0], Is.EqualTo(0f), "writing channel 0 must not touch channel 1");
+    }
+
+    [Test]
+    public void OutputOnly_GetInput_ThrowsWithOutputOnlyExplanation()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var buffers = new AsioProcessBuffers(OutputOnlyContext());
+            buffers.GetInput(0);
+        });
+        Assert.That(ex!.Message, Does.Contain("output-only"));
+    }
+
+    [Test]
+    public void OutputOnly_RawInput_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var buffers = new AsioProcessBuffers(OutputOnlyContext());
+            buffers.RawInput(0);
+        });
+    }
+
+    [Test]
+    public void OutputOnly_GetOutput_RejectsOutOfRangeChannel()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var buffers = new AsioProcessBuffers(OutputOnlyContext(outputChannels: 2));
+            buffers.GetOutput(2);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

`AsioDevice.InitDuplex` previously required at least one input channel. This PR relaxes that so `AsioDuplexOptions.InputChannels` may be **empty or null**, configuring an **output-only** processor session: the callback writes an independent per-channel `Span<float>` to each output via `GetOutput(i)`, with no capture side.

This is the route to driving each ASIO output channel *separately* — e.g. routing different channel pairs to different speakers — without collapsing everything into a single interleaved `IWaveProvider` the way `InitPlayback` requires. It's the scenario raised in discussion #1389.

Design choice: duplex stays the one flexible "processor callback over per-channel `Span<float>`" mode, and output-only is simply that mode with the input side empty — avoiding a separate `Init*` method, options class, and its own tutorial.

### Changes

- **`InitDuplex`** accepts null/empty `InputChannels`. `OutputChannels` and `Processor` remain required. Input-side validation, uniform-format check, converter selection, and `InputNativeBytesPerChannel` sizing are skipped when there are no inputs (`BytesPerSample`/`ValidateUniformInputFormat` throw or index `[0]` on an unset input side). The buffer-switch callback's input loop already runs zero times, so no change there.
- **`AsioProcessBuffers.GetInput`** returns a clear "output-only session" message instead of `Expected index in [0, -1]` when no inputs were selected.
- **`Snapshot(AsioDuplexOptions)`** tolerates a null `InputChannels` so the `Reinitialize` recovery path survives.
- **`AsioDuplexOptions.InputChannels`** XML doc marks it optional.
- **Docs:** new "Output-only (no input channels)" section in `AsioDuplex.md`; cross-link from `AsioPlayback.md` for readers who want independent per-channel output.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

- Built `NAudio.Asio` and `NAudio.Windows.Tests` with `-p:EnableWindowsTargeting=true` on the .NET 10 SDK — both compile clean (0 warnings / 0 errors).
- Added `AsioOutputOnlyDuplexTests` (hardware-free, `UnitTest` category) covering the output-only invariants at the `AsioProcessBuffers` level: zero input count / correct output count, per-channel writable spans that don't cross-contaminate, `GetInput`/`RawInput` throwing with the output-only explanation, and output-channel bounds. Plus an output-only options-shape test in `AsioDuplexOptionsTests`.
- The full `InitDuplex` success path needs a real ASIO driver, so — consistent with the existing `AsioDeviceValidationTests` approach — these tests exercise the resulting per-callback behaviour directly rather than opening hardware. The unit tests run headless on the `windows-latest` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xeycf79kqnQpPZEVCtFTDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xeycf79kqnQpPZEVCtFTDp)_