### PR TITLE
Tidy up repo-wide EnableWindowsTargeting (follow-up to #1388)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <!-- Lockstep version for all NAudio NuGet packages. CI overrides
          <VersionSuffix> on pre-release builds (e.g. preview.NN). Sample/tool

--- a/src/NAudio.Midi/NAudio.Midi.csproj
+++ b/src/NAudio.Midi/NAudio.Midi.csproj
@@ -5,14 +5,9 @@
          and file reader/writer (builds and runs everywhere). The Windows leg
          additionally exposes WinRT (Windows.Devices.Midi) live MIDI I/O, which
          needs the Windows SDK projections and therefore the versioned TFM. -->
+    <!-- EnableWindowsTargeting (needed so this package's Windows leg builds on
+         non-Windows hosts) is set repo-wide in Directory.Build.props. -->
     <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0</TargetFrameworks>
-    <!-- Now that this package has a Windows leg, allow its source to build on
-         non-Windows hosts (the SDK NuGet-restores the Windows reference packs).
-         This keeps the documented Linux/macOS dev+test workflow working — e.g.
-         NAudio.Core.Tests project-references this package. It affects source
-         builds only; NuGet consumers resolve the net9.0 asset and never build
-         the Windows leg, so cross-platform apps still need no such flag. -->
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cross-platform MIDI file reading and writing, MIDI message types, and SMPTE timing for the NAudio audio library. On Windows, also provides WinRT (Windows.Devices.Midi) live MIDI input and output.</Description>


### PR DESCRIPTION
## Summary

Small follow-up to #1388, which added repo-wide `EnableWindowsTargeting=true` in `Directory.Build.props`:

- **Removed the UTF-8 BOM** that #1388 introduced on `Directory.Build.props` (the file was otherwise BOM-free).
- **Dropped the now-redundant per-project `<EnableWindowsTargeting>` from `NAudio.Midi.csproj`.** It was added in #1385 so `NAudio.Midi`'s Windows leg would build on non-Windows hosts; the repo-wide setting now covers that, so this leaves a single source of truth. Replaced the verbose per-project comment with a one-liner pointing at `Directory.Build.props`.

## Release notes

- [x] This PR doesn't need a release-notes entry (internal build-config cleanup)

## Testing

Built `NAudio.Midi` (both legs) on Linux with **no** `-p:EnableWindowsTargeting` flag — the `net9.0-windows10.0.19041.0` leg builds cleanly, confirming the setting now flows from `Directory.Build.props` and the per-project line was safe to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKitVe3w24krFyGJNsQV48)_