### PR TITLE
Fix WINDOWS/WASAPI constants dropped from meta-package Windows build

### DIFF
--- a/src/NAudio.Extras/NAudio.Extras.csproj
+++ b/src/NAudio.Extras/NAudio.Extras.csproj
@@ -11,7 +11,10 @@
     <Description>Optional extras (extra demo/sample providers and helpers) for the NAudio audio library.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
+  <!-- Use $(TargetFramework), not $(TargetPlatformIdentifier): the latter isn't set
+       until an SDK import that runs after this body, so it would drop WINDOWS from the
+       Windows build. See the matching note in NAudio.csproj. -->
+  <PropertyGroup Condition=" $(TargetFramework.Contains('-windows')) ">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 

--- a/src/NAudio/NAudio.csproj
+++ b/src/NAudio/NAudio.csproj
@@ -12,7 +12,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
+  <!-- Derive the platform from $(TargetFramework) rather than $(TargetPlatformIdentifier):
+       the latter is set by an SDK import that runs *after* this project body, so a
+       PropertyGroup condition on it silently sees an empty value and drops the constant
+       from the Windows build. (ItemGroup conditions below evaluate later and are safe.) -->
+  <PropertyGroup Condition=" $(TargetFramework.Contains('-windows')) ">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
@@ -34,7 +38,7 @@
   <!-- WASAPI marks "Media Foundation codecs available" for AudioFileReader. It now
        lights up with the Windows leg (same as WINDOWS). The 19041 floor on the
        Windows TFM is retained because NAudio.Midi's WinRT MIDI asset requires it. -->
-  <PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
+  <PropertyGroup Condition=" $(TargetFramework.Contains('-windows')) ">
     <DefineConstants>$(DefineConstants);WASAPI</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem

Playing `.mp3`/`.mp4`/`.m4a`/`.aac`/`.wma` (and non-PCM `.wav`) through the `NAudio` meta-package threw **"Unsupported file format. Media Foundation reader requires the NAudio.Wasapi package"** — even on Windows with `NAudio.Wasapi.dll` present in the output.

## Root cause

The `DefineConstants` gates in `NAudio.csproj` and `NAudio.Extras.csproj` were keyed off `$(TargetPlatformIdentifier)`:

```xml
<PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
  <DefineConstants>$(DefineConstants);WASAPI</DefineConstants>
</PropertyGroup>
```

The SDK doesn't populate `$(TargetPlatformIdentifier)` until an import that runs **after** the project body, so these `PropertyGroup` conditions evaluated against an *empty* value and silently dropped both `WINDOWS` and `WASAPI` from the `net9.0-windows` leg. Confirmed via `--getProperty:DefineConstants`, which returned just `TRACE;DEBUG` for the Windows leg.

That compiled out `AudioFileReader`'s `#if WASAPI` Media Foundation fallback, leaving the `#else` throw. `NAudio.Wasapi.dll` was still copied to output because the `ItemGroup` `ProjectReference` uses the *same* condition but evaluates in a later phase (after `TargetPlatformIdentifier` is set) — so the package shipped while the code that uses it did not.

A second latent effect: with `WINDOWS` also dropped, `AudioFileReader`'s `#if !WINDOWS` non-PCM WAV path ("requires Windows for ACM codec conversion") was wrongly compiled into the Windows build too.

Regression from `fcd1105c` (which changed these conditions from `'$(TargetFramework)' != 'net9.0'`).

## Fix

Switch the three `PropertyGroup` conditions to test `$(TargetFramework)`, which *is* available during body evaluation:

```xml
<PropertyGroup Condition=" $(TargetFramework.Contains('-windows')) ">
```

## Verification

- `DefineConstants` for `net9.0-windows10.0.19041.0` now resolves to `TRACE;WINDOWS;WASAPI;DEBUG`; the plain `net9.0` leg correctly stays `TRACE;DEBUG`.
- After a clean rebuild, the meta-package `NAudio.dll` in the demo output references `MediaFoundationReader` and no longer contains the throw string.
- `.m4a` playback works in NAudioDemo's Audio File Playback tab.

No release-notes entry: this fixes an unreleased NAudio 3 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)