### PR TITLE
Bump VersionPrefix to 3.0.1 for post-3.0.0 development

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- Lockstep version for all NAudio NuGet packages. CI overrides
          <VersionSuffix> on pre-release builds (e.g. preview.NN). Sample/tool
          apps with their own <Version> in the csproj override this. -->
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
 
     <!-- Common NuGet package metadata. Per-package csprojs override
          individual properties when needed (e.g. the NAudio meta-package


### PR DESCRIPTION
## Summary

Post-release version bump following 3.0.0, which shipped from tag `v3.0.0` on 15 Aug 2026. This is step 3c of [ReleaseInstructions.md](../ReleaseInstructions.md).

One line: `<VersionPrefix>` in `Directory.Build.props`, `3.0.0` → `3.0.1`.

**Why it matters.** Preview builds are versioned `<VersionPrefix>-preview.<run_number>`. Leaving the prefix at `3.0.0` would make the next `gh workflow run release.yml` dispatch produce `3.0.0-preview.<N>`, which under SemVer 2 sorts *below* the `3.0.0` already on NuGet — invisible to anyone on a prerelease feed, and confusing to anyone who did find it. At `3.0.1` the next preview is `3.0.1-preview.<N>`, which sorts above the released `3.0.0` as intended.

Patch rather than minor because it only has to be greater than what shipped. Raise it later if the next release turns out to carry features — the release workflow validates the tag against this value at that point, so a mismatch fails fast rather than shipping something wrong.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

Development-version housekeeping with no observable effect for consumers.

## Testing

- `dotnet build src/NAudio.Core/NAudio.Core.csproj -c Release` — 0 warnings, 0 errors
- `dotnet pack src/NAudio.Core/NAudio.Core.csproj -c Release` produces `NAudio.Core.3.0.1.nupkg`, confirming the new prefix flows through
- Confirmed no NAudio package csproj carries its own `<Version>`, so all 13 stay in lockstep off this single value

Verified alongside this that the 3.0.0 release itself is sound: the tag-driven `release.yml` run succeeded (run 21, the first ever tag-triggered run), the GitHub Release **NAudio 3.0.0** exists on `v3.0.0`, and `NAudio`, `NAudio.Sampler` and `NAudio.Vst3` are live on NuGet at 3.0.0 with READMEs rendering and the package pages showing Project Website → the docs site and Source Repository → GitHub.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TpvyNK3E3Qv5Gogx4NKENh)_