### PR TITLE
Let sample apps roll forward onto newer .NET runtimes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,15 @@
          apps with their own <Version> in the csproj override this. -->
     <VersionPrefix>3.0.1</VersionPrefix>
 
+    <!-- The sample/tool apps target net9.0 so they still build on the .NET 9
+         SDK, but the default roll-forward policy (Minor) refuses to cross a
+         major version — so with only the .NET 10 SDK installed they fail to
+         launch with "You must install .NET 9.0". LatestMajor lets the host
+         run them on the newest installed runtime instead. This only feeds
+         runtimeconfig.json generation, which class libraries don't emit, so
+         it's inert for the NAudio packages themselves. -->
+    <RollForward>LatestMajor</RollForward>
+
     <!-- Common NuGet package metadata. Per-package csprojs override
          individual properties when needed (e.g. the NAudio meta-package
          sets its own <Authors>Mark Heath &amp; Contributors</Authors>). -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@ the NuGet `PackageReleaseNotes` field, which has a hard 35,000-character
 limit and fails the release build if exceeded.
 -->
 
+- Sample and tool apps now roll forward onto newer .NET runtimes, so running them no longer requires the .NET 9 runtime to be installed
+
 ### 3.0.0 (15 Aug 2026)
 
 NAudio 3 is a major release. The single `NAudio` assembly is now split into


### PR DESCRIPTION
## Summary

The sample and tool apps target `net9.0`, and the default roll-forward policy (`Minor`) will not cross a major version boundary. With only the .NET 10 SDK installed, they build fine but fail to launch with *"You must install .NET 9.0"* — so anyone wanting to run `NAudioConsoleTest`, `NAudioDemo`, `NAudioWpfDemo` etc. was forced to install the .NET 9 runtime alongside their newer SDK.

This sets `<RollForward>LatestMajor</RollForward>` once in `Directory.Build.props`, so the host runs these apps on the newest installed runtime instead.

Notes on the approach:

- **TFMs are untouched.** Keeping the apps on `net9.0` means anyone on the .NET 9 SDK can still build and run them exactly as before — bumping them to `net10.0` would have fixed this at their expense, and `net9.0` remains the repo's stated floor.
- **One property covers everything.** `RollForward` only feeds `runtimeconfig.json` generation, and class libraries don't emit one, so it's inert for the shipping NAudio packages — nothing lands in the nupkgs. It also sits above the `frameworks` array, so a single line covers `Microsoft.WindowsDesktop.App` as well as `Microsoft.NETCore.App` for the WinForms/WPF samples.
- Picked up by `NAudio.Benchmarks` and `MfStressTest` too, which had the same problem. `NAudioAotSmokeTest` inherits it harmlessly but doesn't need it (AOT-published, self-contained).

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

Verified on Linux with the .NET 10 SDK installed and **no** .NET 9 runtime present:

- **Mechanism proven end-to-end** with a minimal `net9.0` console app. Without the property: `You must install or update .NET to run this application.` With it: `ran on 10.0.10`.
- `NAudioConsoleTest.runtimeconfig.json` now carries `"rollForward": "LatestMajor"`.
- `NAudioWpfDemo.runtimeconfig.json` gets it at the top level, above both the `Microsoft.NETCore.App` and `Microsoft.WindowsDesktop.App` entries.
- `src/NAudio.Core/bin/.../net9.0/` emits no `runtimeconfig.json`, confirming the property is inert for the packaged libraries.
- All six sample apps plus `NAudio.Benchmarks` and `MfStressTest` build clean (0 warnings, 0 errors).
- `NAudio.Core.Tests`: 1461 passed, 0 failed, 3 skipped.

The samples themselves are Windows-only, so actually launching them wasn't possible in this environment — the runtime-selection behaviour was verified via the generated `runtimeconfig.json` files and the equivalent cross-platform repro above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDnGVD6tWPhxa8a6xgqiJs)_