### PR TITLE
Fix WdlResampler losing samples when the source under-feeds (#1412)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@ the NuGet `PackageReleaseNotes` field, which has a hard 35,000-character
 limit and fails the release build if exceeded.
 -->
 
+ * Fixed `WdlResamplingSampleProvider` losing samples, and eventually returning 0 permanently, when asked for more output than the source could supply — a 3.0.0 regression that broke the common pattern of reading generously from a `BufferedWaveProvider`-backed capture chain. `WdlResampler.ResampleOut` also no longer drifts in input-driven (feed) mode when handed fewer samples than `ResamplePrepare` requested (#1412)
+
 ### 3.0.1 (18 Aug 2026)
 
 A patch release. The headline fix is packaging: the `NAudio` and `NAudio.Extras`

--- a/src/NAudio.Core/Dsp/WdlResampler.cs
+++ b/src/NAudio.Core/Dsp/WdlResampler.cs
@@ -465,12 +465,25 @@ public class WdlResampler
             double adj = (srcpos - m_samples_in_rsinbuf + outlatadj) / drspos;
             if (adj > 0)
             {
-                ret -= (int)(adj + 0.5);
-                if (ret < 0) ret = 0;
+                // NAudio deviates from upstream WDL here. Upstream drops the discarded output
+                // samples but leaves srcpos where the padded run left it, so the overshoot past
+                // the real input is carried into m_fracpos by the isrcpos clamp below. That
+                // overshoot was consumption of the zero padding, not of real input, so carrying
+                // it forward makes the next call skip input that has not been supplied yet: the
+                // resampler loses samples on every short read and eventually returns 0 forever
+                // (see issue #1412). Rewinding srcpos alongside ret keeps the fractional source
+                // position aligned with the samples actually delivered.
+                int trimmed = (int)(adj + 0.5);
+                if (trimmed > ret) trimmed = ret;
+                ret -= trimmed;
+                srcpos -= trimmed * drspos;
+                if (srcpos < 0) srcpos = 0;
             }
         }
 
         int isrcpos = (int)srcpos;
+        // Upstream WDL 2016 feed-mode accounting fix: when srcpos runs past the buffered input the
+        // overshoot has to stay in m_fracpos so the next feed skips it, rather than being lost.
         if (isrcpos > m_samples_in_rsinbuf) isrcpos = m_samples_in_rsinbuf;
         m_fracpos = srcpos - isrcpos;
         m_samples_in_rsinbuf -= isrcpos;

--- a/tests/NAudio.Core.Tests/WaveStreams/WdlResamplingSampleProviderTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WdlResamplingSampleProviderTests.cs
@@ -236,6 +236,226 @@ public class WdlResamplingSampleProviderTests
             Assert.That(float.IsNaN(outBuf[i]) || float.IsInfinity(outBuf[i]), Is.False);
     }
 
+    // --- Under-fed source (issue #1412) -------------------------------------------------------
+    // WdlResamplingSampleProvider is output-driven: ResamplePrepare asks for however much input the
+    // requested output needs, and a pull-based source (a BufferedWaveProvider fed by a capture
+    // callback, say) routinely has less than that. ResampleOut then pads with zeros, produces the
+    // output it can, and trims the padding-derived samples off the count. These tests pin that the
+    // padding is not also charged against the caller's next read.
+
+    [TestCase(160)]
+    [TestCase(161)]
+    [TestCase(192)]
+    [TestCase(320)]
+    [TestCase(2048)]
+    public void OverRequestingFromAnUnderfedSourceStillReturnsAllAvailableOutput(int framesRequested)
+    {
+        // Reported repro: 48 kHz mono float in, 16 kHz out, 480 input frames (10 ms) handed over
+        // per round, which is exactly 160 output frames. Every request size must keep yielding 160
+        // -- before the fix, anything above 160 decayed and >= ~2x collapsed to 0 permanently.
+        const int from = 48000;
+        const int to = 16000;
+        const int inputFramesPerRound = 480;
+        const int expectedPerRound = 160;
+        const int rounds = 6;
+
+        var source = new ChunkedSampleProvider(GenerateSine(from, 1, 1, 1000, 0.5), from, 1, inputFramesPerRound);
+        var resampler = new WdlResamplingSampleProvider(source, to);
+        var buffer = new float[framesRequested];
+
+        for (int round = 0; round < rounds; round++)
+        {
+            source.ReleaseChunk();
+            int read = resampler.Read(buffer);
+            Assert.That(read, Is.EqualTo(expectedPerRound),
+                $"round {round}: asked for {framesRequested} frames with {expectedPerRound} available");
+        }
+    }
+
+    [TestCase(48000, 16000, 1)]
+    [TestCase(44100, 16000, 1)]
+    [TestCase(44100, 48000, 1)]
+    [TestCase(22050, 44100, 1)]
+    [TestCase(8000, 48000, 1)]
+    [TestCase(44100, 44100, 1)]
+    [TestCase(48000, 44100, 2)]
+    [TestCase(96000, 8000, 2)]
+    public void UnderfedSourceDoesNotLoseSamplesOverManyReads(int from, int to, int channels)
+    {
+        // Same shape as above but generalised: 10 ms of input released per round while the caller
+        // always asks for far more than that. Total output must track total input by the rate
+        // ratio; any per-call leakage compounds and shows up here.
+        const int rounds = 200;
+        int chunkFrames = from / 100;
+        var input = GenerateSine(from, channels, 3, 1000, 0.5);
+        var source = new ChunkedSampleProvider(input, from, channels, chunkFrames);
+        var resampler = new WdlResamplingSampleProvider(source, to);
+        var buffer = new float[8192 * channels];
+
+        int totalSamples = 0;
+        for (int round = 0; round < rounds; round++)
+        {
+            source.ReleaseChunk();
+            totalSamples += resampler.Read(buffer);
+        }
+
+        int inFrames = Math.Min(rounds * chunkFrames, input.Length / channels);
+        int expected = (int)((long)inFrames * to / from);
+        Assert.That(totalSamples / channels, Is.EqualTo(expected).Within(2),
+            $"{from} -> {to} ({channels}ch): expected ~{expected} output frames, got {totalSamples / channels}");
+    }
+
+    [TestCase(48000, 16000, 1)]
+    [TestCase(48000, 24000, 2)]
+    [TestCase(44100, 44100, 1)]
+    public void ChunkedOverRequestedReadsMatchAWellFedRead(int from, int to, int channels)
+    {
+        // Restoring the sample count is not enough on its own: the fractional source position has
+        // to stay aligned too, or the output drifts in phase at every short read. At integer rate
+        // ratios a starved chunked read should be sample-for-sample identical to reading the same
+        // signal from a source that can always fill the request.
+        var input = GenerateSine(from, channels, 1, 1000, 0.5);
+
+        var wellFed = ReadAll(new WdlResamplingSampleProvider(new ArraySampleProvider(input, from, channels), to), 4096 * channels);
+
+        int chunkFrames = from / 100;
+        var source = new ChunkedSampleProvider(input, from, channels, chunkFrames);
+        var starved = new WdlResamplingSampleProvider(source, to);
+        var accumulated = new System.Collections.Generic.List<float>();
+        var buffer = new float[8192 * channels];
+        for (int round = 0; round < 120; round++)
+        {
+            source.ReleaseChunk();
+            int read = starved.Read(buffer);
+            for (int i = 0; i < read; i++) accumulated.Add(buffer[i]);
+        }
+
+        Assert.That(accumulated.Count, Is.EqualTo(wellFed.Length),
+            $"{from} -> {to}: starved read produced {accumulated.Count} samples, well-fed produced {wellFed.Length}");
+        for (int i = 0; i < wellFed.Length; i++)
+            Assert.That(accumulated[i], Is.EqualTo(wellFed[i]).Within(1e-6f),
+                $"{from} -> {to}: sample {i} differs between starved and well-fed reads");
+    }
+
+    [TestCase(48000, 16000)]
+    [TestCase(44100, 48000)]
+    public void SincModeUnderfedSourceDoesNotLoseSamples(int from, int to)
+    {
+        // The flush path behaves differently in sinc mode: m_sincsize widens the zero padding and
+        // outlatadj shifts the trim point, so cover it separately from the interpolating modes.
+        var resampler = new WdlResampler();
+        resampler.SetMode(false, 0, true, 64, 32);
+        resampler.SetFeedMode(false);
+        resampler.SetRates(from, to);
+
+        var input = GenerateSine(from, 1, 2, 1000, 0.5);
+        var outBuf = new float[4096];
+        int chunkFrames = from / 100;
+        int inPos = 0;
+        int totalOut = 0;
+
+        for (int round = 0; round < 150 && inPos < input.Length; round++)
+        {
+            int needed = resampler.ResamplePrepare(outBuf.Length, 1, out Span<float> inSpan);
+            int give = Math.Min(Math.Min(needed, chunkFrames), input.Length - inPos);
+            input.AsSpan(inPos, give).CopyTo(inSpan);
+            inPos += give;
+            totalOut += resampler.ResampleOut(outBuf, give, outBuf.Length, 1);
+        }
+
+        int expected = (int)((long)inPos * to / from);
+        Assert.That(totalOut, Is.EqualTo(expected).Within(2),
+            $"sinc {from} -> {to}: consumed {inPos} input frames, expected ~{expected} output frames, got {totalOut}");
+    }
+
+    [TestCase(48000, 44100)]
+    [TestCase(44100, 48000)]
+    [TestCase(48000, 16000)]
+    public void FeedModeWithFewerSamplesThanPreparedDoesNotDrift(int from, int to)
+    {
+        // ResampleOut is documented as accepting fewer samples than ResamplePrepare returned ("it
+        // will be flushed to produce all remaining valid samples"), which drives the same padding
+        // path in input-driven mode. Supply short feeds deliberately and check the totals.
+        var resampler = new WdlResampler();
+        resampler.SetMode(true, 2, false);
+        resampler.SetFilterParms();
+        resampler.SetFeedMode(true);
+        resampler.SetRates(from, to);
+
+        var input = GenerateSine(from, 1, 2, 440, 0.5);
+        var outBuf = new float[to * 4];
+        var rng = new Random(7);
+        int totalIn = 0;
+        int totalOut = 0;
+
+        while (totalIn < input.Length)
+        {
+            int prepared = Math.Min(rng.Next(64, 512), input.Length - totalIn);
+            int supplied = Math.Max(1, prepared - rng.Next(0, 32));
+            resampler.ResamplePrepare(prepared, 1, out Span<float> inSpan);
+            input.AsSpan(totalIn, supplied).CopyTo(inSpan);
+            totalOut += resampler.ResampleOut(outBuf.AsSpan(totalOut), supplied, outBuf.Length - totalOut, 1);
+            totalIn += supplied;
+        }
+
+        int expected = (int)((long)totalIn * to / from);
+        Assert.That(totalOut, Is.EqualTo(expected).Within(2),
+            $"feed mode {from} -> {to}: supplied {totalIn} input frames, expected ~{expected} output frames, got {totalOut}");
+    }
+
+    [Test]
+    public void ResamplePrepareWithoutResampleOutIsSafe()
+    {
+        // Documented on ResamplePrepare: "it is safe to call ResamplePrepare without calling
+        // ResampleOut (the next call of ResamplePrepare will function as normal)".
+        const int from = 48000;
+        const int to = 16000;
+
+        var resampler = new WdlResampler();
+        resampler.SetMode(true, 2, false);
+        resampler.SetFilterParms();
+        resampler.SetFeedMode(false);
+        resampler.SetRates(from, to);
+
+        var input = GenerateSine(from, 1, 1, 1000, 0.5);
+        var outBuf = new float[1024];
+
+        for (int i = 0; i < 3; i++)
+            resampler.ResamplePrepare(outBuf.Length, 1, out _);
+
+        int needed = resampler.ResamplePrepare(outBuf.Length, 1, out Span<float> inSpan);
+        int give = Math.Min(needed, input.Length);
+        input.AsSpan(0, give).CopyTo(inSpan);
+        int produced = resampler.ResampleOut(outBuf, give, outBuf.Length, 1);
+
+        Assert.That(produced, Is.EqualTo(outBuf.Length).Within(2),
+            "abandoned ResamplePrepare calls should not affect the next full cycle");
+    }
+
+    [Test]
+    public void ResetRestoresStartOfStreamBehaviour()
+    {
+        // Reset is the documented way to reuse a resampler for a new stream; after it, the same
+        // input must give the same output as a freshly constructed instance.
+        const int from = 48000;
+        const int to = 44100;
+        var input = GenerateSine(from, 1, 1, 1000, 0.5);
+
+        var first = new WdlResampler();
+        first.SetMode(true, 2, false);
+        first.SetFilterParms();
+        first.SetFeedMode(false);
+        first.SetRates(from, to);
+
+        var reference = RunOutputDriven(first, input, 1024);
+        first.Reset();
+        var afterReset = RunOutputDriven(first, input, 1024);
+
+        Assert.That(afterReset.Length, Is.EqualTo(reference.Length), "output length changed after Reset");
+        for (int i = 0; i < reference.Length; i++)
+            Assert.That(afterReset[i], Is.EqualTo(reference[i]).Within(1e-6f), $"sample {i} differs after Reset");
+    }
+
     [Test]
     public void GetCurrentLatencyReportsSubSamplePrecision()
     {
@@ -380,6 +600,23 @@ public class WdlResamplingSampleProviderTests
         return buf;
     }
 
+    private static float[] RunOutputDriven(WdlResampler resampler, float[] input, int outFrames)
+    {
+        var output = new System.Collections.Generic.List<float>();
+        var outBuf = new float[outFrames];
+        int inPos = 0;
+        while (inPos < input.Length)
+        {
+            int needed = resampler.ResamplePrepare(outFrames, 1, out Span<float> inSpan);
+            int give = Math.Min(needed, input.Length - inPos);
+            input.AsSpan(inPos, give).CopyTo(inSpan);
+            inPos += give;
+            int produced = resampler.ResampleOut(outBuf, give, outFrames, 1);
+            for (int i = 0; i < produced; i++) output.Add(outBuf[i]);
+        }
+        return output.ToArray();
+    }
+
     private static float[] ReadAll(ISampleProvider source, int chunkSize)
     {
         var output = new System.Collections.Generic.List<float>();
@@ -434,6 +671,40 @@ public class WdlResamplingSampleProviderTests
         var trimmed = new float[outPos];
         Array.Copy(output, trimmed, outPos);
         return trimmed;
+    }
+
+    /// <summary>
+    /// A source that only ever hands out the frames explicitly released to it, simulating a
+    /// pull-based capture pipeline where the resampler routinely asks for more than has arrived.
+    /// </summary>
+    private sealed class ChunkedSampleProvider : ISampleProvider
+    {
+        private readonly float[] data;
+        private readonly int chunkFrames;
+        private int pos;
+        private int releasedFrames;
+
+        public ChunkedSampleProvider(float[] data, int sampleRate, int channels, int chunkFrames)
+        {
+            this.data = data;
+            this.chunkFrames = chunkFrames;
+            WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public void ReleaseChunk() => releasedFrames += chunkFrames;
+
+        public int Read(Span<float> buffer)
+        {
+            int limit = Math.Min(data.Length, releasedFrames * WaveFormat.Channels);
+            int take = Math.Min(buffer.Length, limit - pos);
+            if (take <= 0) return 0;
+            take -= take % WaveFormat.Channels;
+            data.AsSpan(pos, take).CopyTo(buffer);
+            pos += take;
+            return take;
+        }
     }
 
     private sealed class ArraySampleProvider : ISampleProvider

--- a/tests/NAudio.Core.Tests/WaveStreams/WdlResamplingSampleProviderTests.cs
+++ b/tests/NAudio.Core.Tests/WaveStreams/WdlResamplingSampleProviderTests.cs
@@ -194,15 +194,19 @@ public class WdlResamplingSampleProviderTests
             $"In-band sine in sinc mode lost too much amplitude: in={inRms:F4} out={outRms:F4}");
     }
 
-    [Test]
-    public void FeedModeWithSmallInputChunksProducesExpectedOutput()
+    [TestCase(48000, 44100, 1)]
+    [TestCase(48000, 44100, 2)]
+    [TestCase(48000, 44100, 3)]
+    [TestCase(44100, 48000, 2)]
+    public void FeedModeWithSmallInputChunksProducesExpectedOutput(int from, int to, int channels)
     {
         // Exercises the 2016 feed-mode accounting fix. In feed (input-driven) mode we hand
         // ResamplePrepare an input count and ResampleOut produces however many output samples that
         // input maps to. Without the clamp on isrcpos, m_fracpos drifts and output count is wrong.
-        const int from = 48000;
-        const int to = 44100;
-        const int totalInputSamples = from * 2; // 2 seconds
+        // Run at several channel counts: ResampleOut has separate 1-channel, 2-channel and general
+        // interpolation loops, and every buffer index around the accounting is scaled by nch.
+        const int seconds = 2;
+        int totalInputFrames = from * seconds;
 
         var resampler = new WdlResampler();
         resampler.SetMode(true, 2, false);
@@ -210,29 +214,31 @@ public class WdlResamplingSampleProviderTests
         resampler.SetFeedMode(true); // input-driven
         resampler.SetRates(from, to);
 
-        var input = GenerateSine(from, channels: 1, seconds: 2, frequency: 440, gain: 0.5);
-        var outBuf = new float[to * 4];
-        int totalOut = 0;
-        int totalIn = 0;
+        var input = GenerateSine(from, channels, seconds, frequency: 440, gain: 0.5);
+        var outBuf = new float[to * 4 * channels];
+        int outCapacityFrames = outBuf.Length / channels;
+        int totalOutFrames = 0;
+        int totalInFrames = 0;
         var rng = new Random(42);
 
-        while (totalIn < totalInputSamples)
+        while (totalInFrames < totalInputFrames)
         {
-            int chunk = Math.Min(rng.Next(1, 257), totalInputSamples - totalIn);
-            int needed = resampler.ResamplePrepare(chunk, 1, out Span<float> inSpan);
+            int chunk = Math.Min(rng.Next(1, 257), totalInputFrames - totalInFrames);
+            int needed = resampler.ResamplePrepare(chunk, channels, out Span<float> inSpan);
             Assert.That(needed, Is.EqualTo(chunk),
                 $"In feed mode ResamplePrepare must return the input count we supplied (got {needed}, expected {chunk})");
-            input.AsSpan(totalIn, chunk).CopyTo(inSpan);
-            int produced = resampler.ResampleOut(outBuf.AsSpan(totalOut), chunk, outBuf.Length - totalOut, 1);
-            totalOut += produced;
-            totalIn += chunk;
+            input.AsSpan(totalInFrames * channels, chunk * channels).CopyTo(inSpan);
+            int produced = resampler.ResampleOut(outBuf.AsSpan(totalOutFrames * channels), chunk,
+                outCapacityFrames - totalOutFrames, channels);
+            totalOutFrames += produced;
+            totalInFrames += chunk;
         }
 
-        int expected = (int)((double)totalInputSamples * to / from);
+        int expected = (int)((double)totalInputFrames * to / from);
         // Feed-mode count should be near-exact, not drifting.
-        Assert.That(totalOut, Is.EqualTo(expected).Within(2),
-            $"feed-mode output count drift: expected ~{expected}, got {totalOut}");
-        for (int i = 0; i < totalOut; i++)
+        Assert.That(totalOutFrames, Is.EqualTo(expected).Within(2),
+            $"feed-mode output frame count drift at {channels}ch: expected ~{expected}, got {totalOutFrames}");
+        for (int i = 0; i < totalOutFrames * channels; i++)
             Assert.That(float.IsNaN(outBuf[i]) || float.IsInfinity(outBuf[i]), Is.False);
     }
 
@@ -368,10 +374,13 @@ public class WdlResamplingSampleProviderTests
             $"sinc {from} -> {to}: consumed {inPos} input frames, expected ~{expected} output frames, got {totalOut}");
     }
 
-    [TestCase(48000, 44100)]
-    [TestCase(44100, 48000)]
-    [TestCase(48000, 16000)]
-    public void FeedModeWithFewerSamplesThanPreparedDoesNotDrift(int from, int to)
+    [TestCase(48000, 44100, 1)]
+    [TestCase(44100, 48000, 1)]
+    [TestCase(48000, 16000, 1)]
+    [TestCase(48000, 44100, 2)]
+    [TestCase(48000, 16000, 2)]
+    [TestCase(44100, 48000, 3)]
+    public void FeedModeWithFewerSamplesThanPreparedDoesNotDrift(int from, int to, int channels)
     {
         // ResampleOut is documented as accepting fewer samples than ResamplePrepare returned ("it
         // will be flushed to produce all remaining valid samples"), which drives the same padding
@@ -382,25 +391,30 @@ public class WdlResamplingSampleProviderTests
         resampler.SetFeedMode(true);
         resampler.SetRates(from, to);
 
-        var input = GenerateSine(from, 1, 2, 440, 0.5);
-        var outBuf = new float[to * 4];
+        const int seconds = 2;
+        int totalInputFrames = from * seconds;
+        var input = GenerateSine(from, channels, seconds, 440, 0.5);
+        var outBuf = new float[to * 4 * channels];
+        int outCapacityFrames = outBuf.Length / channels;
         var rng = new Random(7);
-        int totalIn = 0;
-        int totalOut = 0;
+        int totalInFrames = 0;
+        int totalOutFrames = 0;
 
-        while (totalIn < input.Length)
+        while (totalInFrames < totalInputFrames)
         {
-            int prepared = Math.Min(rng.Next(64, 512), input.Length - totalIn);
+            int prepared = Math.Min(rng.Next(64, 512), totalInputFrames - totalInFrames);
             int supplied = Math.Max(1, prepared - rng.Next(0, 32));
-            resampler.ResamplePrepare(prepared, 1, out Span<float> inSpan);
-            input.AsSpan(totalIn, supplied).CopyTo(inSpan);
-            totalOut += resampler.ResampleOut(outBuf.AsSpan(totalOut), supplied, outBuf.Length - totalOut, 1);
-            totalIn += supplied;
+            resampler.ResamplePrepare(prepared, channels, out Span<float> inSpan);
+            input.AsSpan(totalInFrames * channels, supplied * channels).CopyTo(inSpan);
+            totalOutFrames += resampler.ResampleOut(outBuf.AsSpan(totalOutFrames * channels), supplied,
+                outCapacityFrames - totalOutFrames, channels);
+            totalInFrames += supplied;
         }
 
-        int expected = (int)((long)totalIn * to / from);
-        Assert.That(totalOut, Is.EqualTo(expected).Within(2),
-            $"feed mode {from} -> {to}: supplied {totalIn} input frames, expected ~{expected} output frames, got {totalOut}");
+        int expected = (int)((long)totalInFrames * to / from);
+        Assert.That(totalOutFrames, Is.EqualTo(expected).Within(2),
+            $"feed mode {from} -> {to} ({channels}ch): supplied {totalInFrames} input frames, " +
+            $"expected ~{expected} output frames, got {totalOutFrames}");
     }
 
     [Test]
@@ -540,6 +554,39 @@ public class WdlResamplingSampleProviderTests
         AssertTailDc(three, 3, new[] { 0.1f, 0.2f, 0.3f });
     }
 
+    [Test]
+    public void FeedModeChannelCountChangeMidStreamKeepsChannelsAligned()
+    {
+        // Same reinterleave check as above, but input-driven. Feed mode takes a different route
+        // through ResamplePrepare (sreq is the supplied input count rather than one derived from
+        // the output request), so the buffered frames left between calls — the ones the
+        // reinterleave has to repack — are sized differently.
+        const int from = 8000;
+        const int to = 48000; // upsample so a few input frames stay buffered between calls
+
+        var resampler = new WdlResampler();
+        resampler.SetMode(false, 0, false); // point sampling
+        resampler.SetFeedMode(true);
+        resampler.SetRates(from, to);
+
+        // Phase 1: stereo, L = +0.5 DC, R = -0.5 DC. Leaves a few stereo frames buffered.
+        PumpDcFeedMode(resampler, nch: 2, dc: new[] { 0.5f, -0.5f }, cycles: 6, inFramesPerCycle: 64, outFramesPerCycle: 256);
+
+        // Phase 2: switch to mono (decreasing) — the buffered right channel must not leak out.
+        var mono = PumpDcFeedMode(resampler, nch: 1, dc: new[] { 0.25f }, cycles: 16, inFramesPerCycle: 64, outFramesPerCycle: 256);
+        foreach (var v in mono)
+        {
+            Assert.That(float.IsFinite(v), Is.True, "non-finite mono output");
+            Assert.That(v, Is.GreaterThanOrEqualTo(0.2f),
+                $"mono output dipped to {v}: the buffered right channel (-0.5) leaked through a missing reinterleave");
+        }
+        AssertTailDc(mono, 1, new[] { 0.25f });
+
+        // Phase 3: switch to 3 channels (increasing).
+        var three = PumpDcFeedMode(resampler, nch: 3, dc: new[] { 0.1f, 0.2f, 0.3f }, cycles: 16, inFramesPerCycle: 64, outFramesPerCycle: 256);
+        AssertTailDc(three, 3, new[] { 0.1f, 0.2f, 0.3f });
+    }
+
     // ---- helpers ----
 
     private static float[] PumpDc(WdlResampler resampler, int nch, float[] dc, int cycles, int outFramesPerCycle)
@@ -552,6 +599,27 @@ public class WdlResamplingSampleProviderTests
                 for (int ch = 0; ch < nch; ch++)
                     inSpan[f * nch + ch] = dc[ch];
             var outBuf = new float[outFramesPerCycle * nch];
+            int produced = resampler.ResampleOut(outBuf, needed, outFramesPerCycle, nch);
+            for (int i = 0; i < produced * nch; i++) outAll.Add(outBuf[i]);
+        }
+        return outAll.ToArray();
+    }
+
+    private static float[] PumpDcFeedMode(WdlResampler resampler, int nch, float[] dc, int cycles,
+        int inFramesPerCycle, int outFramesPerCycle)
+    {
+        var outAll = new System.Collections.Generic.List<float>();
+        // outFramesPerCycle is deliberately less than the supplied input maps to, so input stays
+        // buffered between calls — the frames a channel-count change has to reinterleave.
+        var outBuf = new float[outFramesPerCycle * nch];
+        for (int c = 0; c < cycles; c++)
+        {
+            int needed = resampler.ResamplePrepare(inFramesPerCycle, nch, out Span<float> inSpan);
+            Assert.That(needed, Is.EqualTo(inFramesPerCycle),
+                $"feed mode should hand back the supplied input count (got {needed})");
+            for (int f = 0; f < needed; f++)
+                for (int ch = 0; ch < nch; ch++)
+                    inSpan[f * nch + ch] = dc[ch];
             int produced = resampler.ResampleOut(outBuf, needed, outFramesPerCycle, nch);
             for (int i = 0; i < produced * nch; i++) outAll.Add(outBuf[i]);
         }


### PR DESCRIPTION
## Summary

Fixes #1412. `WdlResamplingSampleProvider` is output-driven: `ResamplePrepare` asks for however much input the requested output needs, and a pull-based source (a `BufferedWaveProvider` fed by a capture callback, say) routinely has less than that. `ResampleOut` pads the input buffer with zeros, resamples, and trims the padding-derived samples back off the returned count.

Since 3.0.0 it also carried the padding *consumption* forward. The 2016 upstream feed-mode fix backported in 0da9863 clamps `isrcpos` to `m_samples_in_rsinbuf`, which parks the overshoot past the real input in `m_fracpos`. In feed mode that overshoot is genuine input to skip on the next feed. In output-driven mode it is consumption of the zero padding, so the next call skips input that was never supplied. At 48 kHz → 16 kHz with 160 output frames available:

```
asked for   160 samples (160 available): 160, 160, 160, 160, 160, 160
asked for   161 samples (160 available): 160, 159, 158, 157, 156, 155
asked for   192 samples (160 available): 160, 128, 96, 93, 93, 93
asked for   320 samples (160 available): 160, 0, 0, 0, 0, 0
asked for  2048 samples (160 available): 160, 0, 0, 0, 0, 0
```

Input keeps being drained, no output is ever produced again, and correctly sized reads afterwards do not bring it back. Upsampling chains fail the same way (`8000 → 48000` yields 480 samples and then nothing). `release/2.x` does not have the clamp, hence 2.3.0 being correct.

The fix rewinds `srcpos` by the same amount `ret` is trimmed, so the fractional source position stays aligned with the samples actually delivered. The clamp stays for the feed-mode case it was added for. This deviates from upstream WDL, which has the same latent bug but isn't usually driven this way; the reasoning is recorded in a comment so a future upstream sync doesn't silently undo it.

Two things worth flagging:

- **Feed mode was broken too**, unreported. `ResampleOut` is documented as accepting fewer samples than `ResamplePrepare` returned, and that path lost around 10% of the output (48 k → 44.1 k: 78573 samples instead of 88200). Same root cause, fixed by the same change.
- **Nothing changes when the source can fill the request.** The block only runs when padding was actually used, so file conversion and `ReadFully = true` chains are untouched. In-tree, `NAudio.Extras/CaptureMixerInput` sets `ReadFully = true` and was never affected.

A separate, pre-existing limitation is deliberately left alone: when *upsampling* from a starved source, a few samples per short read are still contaminated by the zero padding (44100 → 48000: ~198 over 120 reads; 8000 → 48000: ~1881). This is identical in 2.3.0 and in upstream WDL, has never been reported, and fixing it properly means reworking what the interpolator is allowed to read across all four interpolation paths.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

`dotnet test tests/NAudio.Core.Tests` — 1498 tests, 0 failures, no new build warnings.

Existing resampler coverage was entirely well-fed, which is how this got through: every test used a source that could always fill the request, and feed mode had a single mono exact-feed test. Added:

| test | covers |
|---|---|
| `OverRequestingFromAnUnderfedSourceStillReturnsAllAvailableOutput` | the reported repro matrix (160/161/192/320/2048) |
| `UnderfedSourceDoesNotLoseSamplesOverManyReads` | 8 rate/channel combos over 200 reads — up, down, non-integer, 1:1, stereo |
| `ChunkedOverRequestedReadsMatchAWellFedRead` | starved read is sample-identical to a well-fed read, so phase alignment is pinned and not just the count |
| `SincModeUnderfedSourceDoesNotLoseSamples` | the flush path with `m_sincsize` / `outlatadj` in play |
| `FeedModeWithFewerSamplesThanPreparedDoesNotDrift` | short feeds in input-driven mode, 1/2/3 channels |

20 of those cases fail against the unfixed resampler; I checked rather than trusting a green run.

The second commit closes a coverage gap found while writing the first: both feed-mode tests were mono, so `ResampleOut`'s separate 1-channel, 2-channel and general interpolation loops, the per-channel IIR history stride, and the `nch`-scaled buffer indexing were only ever exercised input-driven at one channel. Both feed-mode tests are now parameterised over 1, 2 and 3 channels, and there's a feed-mode counterpart to `ChannelCountChangeMidStreamKeepsChannelsAligned`. That new test needed the per-cycle output capped to leave input buffered across the channel switch — without that the reinterleave never runs and the test passes vacuously. Verified it fails with `ReinterleaveBuffer` stubbed out.

Also added coverage for two documented behaviours that had no tests at all: `ResamplePrepare` without a matching `ResampleOut`, and `Reset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USio6r6ASSFxbqUaCzS1L3)_