### PR TITLE
[v2 branch] chore: add [MarshalAs(UnmanagedType.LPStruct)] for better Unity/mono compatibility

### DIFF
--- a/NAudio.Core/Wave/WaveOutputs/DirectSoundOut.cs
+++ b/NAudio.Core/Wave/WaveOutputs/DirectSoundOut.cs
@@ -779,7 +779,7 @@ namespace NAudio.Wave
         internal interface IDirectSound
         {
             //STDMETHOD(CreateSoundBuffer)    (THIS_ LPCDSBUFFERDESC pcDSBufferDesc, LPDIRECTSOUNDBUFFER *ppDSBuffer, LPUNKNOWN pUnkOuter) PURE;
-            void CreateSoundBuffer([In] BufferDescription desc, [Out, MarshalAs(UnmanagedType.Interface)] out object dsDSoundBuffer, IntPtr pUnkOuter);
+            void CreateSoundBuffer([In, MarshalAs(UnmanagedType.LPStruct)] BufferDescription desc, [Out, MarshalAs(UnmanagedType.Interface)] out object dsDSoundBuffer, IntPtr pUnkOuter);
             //STDMETHOD(GetCaps)              (THIS_ LPDSCAPS pDSCaps) PURE;
             void GetCaps(IntPtr caps);
             //STDMETHOD(DuplicateSoundBuffer) (THIS_ LPDIRECTSOUNDBUFFER pDSBufferOriginal, LPDIRECTSOUNDBUFFER *ppDSBufferDuplicate) PURE;

--- a/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioClient.cs
+++ b/NAudio.Wasapi/CoreAudioApi/Interfaces/IAudioClient.cs
@@ -28,7 +28,7 @@ namespace NAudio.CoreAudioApi.Interfaces
             AudioClientStreamFlags streamFlags,
             long hnsBufferDuration, // REFERENCE_TIME
             long hnsPeriodicity, // REFERENCE_TIME
-            [In] WaveFormat pFormat,
+            [In, MarshalAs(UnmanagedType.LPStruct)] WaveFormat pFormat,
             [In] ref Guid audioSessionGuid);
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace NAudio.CoreAudioApi.Interfaces
         [PreserveSig]
         int IsFormatSupported(
             AudioClientShareMode shareMode,
-            [In] WaveFormat pFormat,
+            [In, MarshalAs(UnmanagedType.LPStruct)] WaveFormat pFormat,
             IntPtr closestMatchFormat); // or outIntPtr??
 
         /// <summary>

--- a/NAudio.Wasapi/MediaFoundation/IMFSinkWriter.cs
+++ b/NAudio.Wasapi/MediaFoundation/IMFSinkWriter.cs
@@ -54,6 +54,6 @@ namespace NAudio.MediaFoundation
         /// <summary>
         /// Gets statistics about the performance of the sink writer.
         /// </summary>
-        void GetStatistics([In] int dwStreamIndex, [In, Out] MF_SINK_WRITER_STATISTICS pStats);
+        void GetStatistics([In] int dwStreamIndex, [In, Out, MarshalAs(UnmanagedType.LPStruct)] MF_SINK_WRITER_STATISTICS pStats);
     }
 }

--- a/NAudio.Wasapi/MediaFoundation/MediaFoundationInterop.cs
+++ b/NAudio.Wasapi/MediaFoundation/MediaFoundationInterop.cs
@@ -82,7 +82,7 @@ namespace NAudio.MediaFoundation
         /// Gets a list of Microsoft Media Foundation transforms (MFTs) that match specified search criteria. 
         /// </summary>
         [DllImport("mfplat.dll", ExactSpelling = true, PreserveSig = false)]
-        public static extern void MFTEnumEx([In] Guid guidCategory, [In] _MFT_ENUM_FLAG flags, [In] MFT_REGISTER_TYPE_INFO pInputType, [In] MFT_REGISTER_TYPE_INFO pOutputType,
+        public static extern void MFTEnumEx([In] Guid guidCategory, [In] _MFT_ENUM_FLAG flags, [In, MarshalAs(UnmanagedType.LPStruct)] MFT_REGISTER_TYPE_INFO pInputType, [In, MarshalAs(UnmanagedType.LPStruct)] MFT_REGISTER_TYPE_INFO pOutputType,
                                             [Out] out IntPtr pppMFTActivate, [Out] out int pcMFTActivate);
 
         /// <summary>

--- a/NAudio.WinMM/Compression/AcmInterop.cs
+++ b/NAudio.WinMM/Compression/AcmInterop.cs
@@ -158,7 +158,7 @@ namespace NAudio.Wave.Compression
             IntPtr hAcmDriver,
             IntPtr sourceFormatPointer,
             IntPtr destFormatPointer,
-            [In] WaveFilter waveFilter,
+            [In, MarshalAs(UnmanagedType.LPStruct)] WaveFilter waveFilter,
             IntPtr callback,
             IntPtr instance,
             AcmStreamOpenFlags openFlags);
@@ -169,11 +169,11 @@ namespace NAudio.Wave.Compression
 
         // http://msdn.microsoft.com/en-us/library/dd742924%28VS.85%29.aspx
         [DllImport("Msacm32.dll")]
-        public static extern MmResult acmStreamConvert(IntPtr hAcmStream, [In, Out] AcmStreamHeaderStruct streamHeader, AcmStreamConvertFlags streamConvertFlags);
+        public static extern MmResult acmStreamConvert(IntPtr hAcmStream, [In, Out, MarshalAs(UnmanagedType.LPStruct)] AcmStreamHeaderStruct streamHeader, AcmStreamConvertFlags streamConvertFlags);
 
         // http://msdn.microsoft.com/en-us/library/dd742929%28VS.85%29.aspx
         [DllImport("Msacm32.dll")]
-        public static extern MmResult acmStreamPrepareHeader(IntPtr hAcmStream, [In, Out] AcmStreamHeaderStruct streamHeader, int prepareFlags);
+        public static extern MmResult acmStreamPrepareHeader(IntPtr hAcmStream, [In, Out, MarshalAs(UnmanagedType.LPStruct)] AcmStreamHeaderStruct streamHeader, int prepareFlags);
 
         // http://msdn.microsoft.com/en-us/library/dd742929%28VS.85%29.aspx
         [DllImport("Msacm32.dll")]
@@ -185,6 +185,6 @@ namespace NAudio.Wave.Compression
 
         // http://msdn.microsoft.com/en-us/library/dd742932%28VS.85%29.aspx
         [DllImport("Msacm32.dll")]
-        public static extern MmResult acmStreamUnprepareHeader(IntPtr hAcmStream, [In, Out] AcmStreamHeaderStruct streamHeader, int flags);
+        public static extern MmResult acmStreamUnprepareHeader(IntPtr hAcmStream, [In, Out, MarshalAs(UnmanagedType.LPStruct)] AcmStreamHeaderStruct streamHeader, int flags);
     }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? -->
This PR adds `[MarshalAs(UnmanagedType.LPStruct)]` to each functions to workaround unity's mono runtime bug.

https://github.com/mono/mono/pull/20895

## Release notes

<!--
Tick one. The maintainer may rewrite or remove your entry at release time;
the goal here is to ensure user-visible changes don't slip through.
-->

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [x] Leave the release-notes entry for the maintainer to write

## Testing

<!-- How did you verify this works? -->

I confirmed audio recording is not working in unity with `NAudio.Wasapi.dll` 2.3.0, and replacing with my build of `NAudio.Wasapi.dll` would fix the problem.

## Additional Note

The bug in Unity has been sent to unity but not tracked publicly yet.