### PR TITLE
[v2 branch] ci: add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,15 @@ jobs:
 
       # NAudioTests is the only test project. IntegrationTest needs real audio
       # hardware, so it is filtered out of the headless run.
+      #
+      # The project path is positional and the trx report comes from --logger,
+      # because this branch has no global.json opting into Microsoft.Testing
+      # .Platform - so dotnet test runs in VSTest mode. Do not copy main's
+      # `--project` / `--solution` / `--report-trx` spelling here: those are
+      # MTP-mode switches and MSBuild rejects them (MSB1001) in VSTest mode.
       - name: Test
         run: >
-          dotnet test --project NAudioTests/NAudioTests.csproj
+          dotnet test NAudioTests/NAudioTests.csproj
           --configuration Release
           --no-build
           --filter "TestCategory!=IntegrationTest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: build
+
+# Build & test the NAudio 2 maintenance branch.
+#
+# windows-latest ships the .NET 8/9/10 SDKs, Windows SDK 10.0.26100 and the
+# .NET Framework 4.7.2 targeting pack, which between them cover every TFM in
+# NAudio.sln - so no setup-dotnet step and no Windows SDK install is needed.
+# (The Azure pipeline this replaces installed Windows SDK 10.1.18362 via
+# chocolatey, dating from when NAudio.Uap was a UWP project. It now targets
+# net9.0-windows10.0.26100 and gets its Windows projections from the
+# Microsoft.Windows.SDK.NET.Ref NuGet package instead.)
+
+on:
+  pull_request:
+  push:
+    branches: [release/2.x]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore
+        run: dotnet restore NAudio.sln
+
+      # Any CPU matches what the Azure pipeline built. Note that
+      # NAudioUniversalDemo (WinUI 3) has no Release|Any CPU Build entry in
+      # NAudio.sln - it has no AnyCPU platform - so it is restored but not
+      # built, exactly as before.
+      - name: Build
+        run: dotnet build NAudio.sln --configuration Release --no-restore
+
+      # NAudioTests is the only test project. IntegrationTest needs real audio
+      # hardware, so it is filtered out of the headless run.
+      - name: Test
+        run: >
+          dotnet test --project NAudioTests/NAudioTests.csproj
+          --configuration Release
+          --no-build
+          --filter "TestCategory!=IntegrationTest"
+          --logger "trx;LogFileName=NAudioTests.trx"
+          --results-directory ${{ runner.temp }}/TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ${{ runner.temp }}/TestResults/*.trx
+          if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,21 @@ jobs:
           --logger "trx;LogFileName=NAudioTests.trx"
           --results-directory ${{ runner.temp }}/TestResults
 
+      # All nine package projects set GeneratePackageOnBuild, so the Release
+      # build above already produced the .nupkg files. Uploading them lets a
+      # release be pushed from a CI-built artifact instead of a local build.
+      #
+      # The glob wildcards start at the repo root, so upload-artifact roots the
+      # zip there and preserves <Package>/bin/Release/<Package>.<version>.nupkg
+      # - the exact layout publish.ps1 globs for. Extract into an empty
+      # directory, drop publish.ps1 alongside, and it runs unchanged.
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: '**/bin/Release/*.nupkg'
+          if-no-files-found: error
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

`release/2.x` has no `.github` directory and depends entirely on the legacy Azure DevOps pipeline, which **does not build pull requests from forks** — it posts an instant `neutral` check and nothing else. PR #1414 (from `anatawa12/NAudio`, changing P/Invoke marshalling attributes across five files) was merged with no CI having run on it at all.

This adds `.github/workflows/build.yml` giving the same coverage as `azure-pipelines.yml` using the dotnet CLI, and — because GitHub Actions builds fork PRs by default — closes that gap.

### What changed relative to the Azure pipeline

| Azure step | Here |
| --- | --- |
| `choco install windows-sdk-10.1 --version=10.1.18362.1` | **Dropped.** It dated from when `NAudio.Uap` was `uap10.0.18362`. It now targets `net9.0-windows10.0.26100` and gets its Windows projections from the `Microsoft.Windows.SDK.NET.Ref` NuGet package. `windows-latest` also has Windows SDK 10.0.26100.0 preinstalled. |
| `NuGetToolInstaller` + `NuGetCommand` restore | `dotnet restore` — every project in `NAudio.sln` is SDK-style. |
| `VSBuild@1` (sln, Any CPU, Release) | `dotnet build --configuration Release`. No non-SDK csproj or `packages.config` anywhere in the solution, so full MSBuild isn't required. |
| `VSTest@2`, `TestCategory!=IntegrationTest` | `dotnet test NAudioTests/NAudioTests.csproj --filter "TestCategory!=IntegrationTest"`, plus a `.trx` artifact. |

No `setup-dotnet` step: `windows-latest` ships the .NET 8/9/10 SDKs, the .NET Framework 4.7.2 targeting pack and Windows SDK 10.0.26100, which covers every TFM in the solution.

The job is named `build` to match the status check the "Protected branches" ruleset expects on `release/*`.

`azure-pipelines.yml` is deliberately left in place so both can run in parallel; removing it should be a follow-up.

### Result

Green on eea9747 — [run 32948536846](https://github.com/naudio/NAudio/actions/runs/32948536846):

```
Build succeeded.  0 Warning(s)  0 Error(s)   — 34.59s
Passed!  - Failed: 0, Passed: 738, Skipped: 3, Total: 741 - NAudioTests.dll (net8.0)
```

Whole job 1m49s, against 5m36s for the Azure build of the same commit. Every TFM compiled — `net472`, `netcoreapp3.1`, `net6.0`, `net8.0-windows`, `netstandard2.0`, `net9.0-windows10.0.26100` — and `TreatWarningsAsErrors` produced nothing under the SDK's Roslyn, so none of the risks flagged before the first run materialised.

### Note on NAudioUniversalDemo

`NAudioUniversalDemo` (WinUI 3) has a `Release|Any CPU.ActiveCfg` entry in `NAudio.sln` but no matching `Build.0`, so it is restored but not built under `Release|Any CPU` — the same as under Azure. That entry has never existed in the repo's history; the project has no `AnyCPU` platform (`x86;x64;arm64`), which is why Visual Studio never wrote one. Left as-is here so this PR measures one thing only.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

The workflow run on this PR is the test — see **Result** above.