### PR TITLE
[v2 branch] Bump versions to 2.4.0 and prepare release notes

### DIFF
--- a/NAudio.Asio/NAudio.Asio.csproj
+++ b/NAudio.Asio/NAudio.Asio.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0-windows</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Core/NAudio.Core.csproj
+++ b/NAudio.Core/NAudio.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Mark Heath</Authors>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/NAudio.Extras/NAudio.Extras.csproj
+++ b/NAudio.Extras/NAudio.Extras.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/naudio/NAudio</RepositoryUrl>
     <Copyright>© Mark Heath 2026</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <PackageIcon>naudio-icon.png</PackageIcon>
   </PropertyGroup>
 

--- a/NAudio.Midi/NAudio.Midi.csproj
+++ b/NAudio.Midi/NAudio.Midi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Uap/NAudio.Uap.csproj
+++ b/NAudio.Uap/NAudio.Uap.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- https://docs.microsoft.com/en-us/windows/uwp/updates-and-versions/choose-a-uwp-version -->
     <TargetFramework>net9.0-windows10.0.26100</TargetFramework>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.Wasapi/NAudio.Wasapi.csproj
+++ b/NAudio.Wasapi/NAudio.Wasapi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net9.0-windows10.0.26100</TargetFrameworks>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.WinForms/NAudio.WinForms.csproj
+++ b/NAudio.WinForms/NAudio.WinForms.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Mark Heath</Authors>

--- a/NAudio.WinMM/NAudio.WinMM.csproj
+++ b/NAudio.WinMM/NAudio.WinMM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/NAudio/NAudio.csproj
+++ b/NAudio/NAudio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net6.0</TargetFrameworks>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <Authors>Mark Heath &amp; Contributors</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>NAudio, an audio library for .NET</Description>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 ### Unreleased
 
+### 2.4.0 (26 Aug 2026)
+
  * Added `DeviceCount` and `GetCapabilities` static methods to `WaveOutEvent` so output devices can be enumerated without referencing `NAudio.WinForms` (#1331, #777)
+ * Fixed WASAPI and Media Foundation interop under Unity's Mono runtime, which marshalled formatted class parameters as COM interfaces; they are now explicitly marked `[MarshalAs(UnmanagedType.LPStruct)]` (#1414)
 
 ### 2.3.0 (12 Mar 2026)
 


### PR DESCRIPTION
## Summary

Pre-flight for a 2.4.0 release off `release/2.x`.

**Versions** — `<Version>` bumped from `2.3.0` to `2.4.0` in all nine package projects: `NAudio.Core`, `NAudio.Midi`, `NAudio.WinMM`, `NAudio.Wasapi`, `NAudio.Asio`, `NAudio.WinForms`, `NAudio.Uap`, `NAudio.Extras` and the `NAudio` meta-package.

They have to move in lockstep. Every inter-package dependency on this branch is a `ProjectReference`, so `pack` writes the *referenced project's* `<Version>` into the nuspec — bump only some and the meta-package would still resolve the old ones. (`release/2.x` has no centralised `<VersionPrefix>`; that only exists on `main`.)

Nothing else on the branch carries a version string, and the sample/tool projects keep their own independent versions.

**Release notes** — `### Unreleased` renamed to `### 2.4.0 (26 Aug 2026)`, with a fresh empty `### Unreleased` above it for post-release contributions. #1414 had no entry because the contributor ticked "leave it for the maintainer", so it's written up here; reword freely.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

CI covers the build. Locally I packed `NAudio.WinMM` and checked the generated nuspec to confirm the version flows into inter-package dependencies as intended:

```xml
<id>NAudio.WinMM</id>
<version>2.4.0</version>
  <group targetFramework=".NETStandard2.0">
    <dependency id="NAudio.Core" version="2.4.0" exclude="Build,Analyzers" />
```

`AssemblyVersion` isn't set explicitly anywhere, so it derives from `<Version>` and becomes `2.4.0.0`. Assemblies are strong-named via the committed `NAudioStrongNameKey.snk`, so .NET Framework consumers will need the usual binding redirects for a minor version bump — same as every previous 2.x release.

## After merging

The push to `release/2.x` produces a `packages` artifact containing the nine `.nupkg` files, laid out as `<Package>/bin/Release/<Package>.2.4.0.nupkg` — extract into an empty directory, drop `publish.ps1` alongside, and it runs unchanged. Then tag `v2.4.0` and write the GitHub release.

Tagging is safe: `main`'s `release.yml` triggers on `push: tags: ['v*']`, but workflow files are read from the ref that was pushed, and `release/2.x` contains only `build.yml`. Nothing publishes to NuGet without `publish.ps1` being run by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7fG3Gpn1ho2o5eTCJ1Hpi)_