### PR TITLE
ci: attach the .nupkg files to the GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,13 +238,31 @@ jobs:
       # ship to NuGet — no GitHub Release noise for every preview. The
       # release-body.md file was already produced by the earlier
       # "Extract RELEASE_NOTES.md section" step.
+      #
+      # The .nupkg files are attached as release assets. artifacts/ is still
+      # on disk from the Pack step, so there is no artifact round-trip. This
+      # also gives a permanent copy of exactly what shipped: Actions artifacts
+      # expire (90 days by default), release assets do not. Symbol packages
+      # are deliberately left off — they go to NuGet's symbol server and would
+      # only double the asset list here.
+      #
+      # gh does not expand globs, and PowerShell does not expand wildcards in
+      # arguments to external commands, so the file list is built explicitly —
+      # same reason as the Push step above.
       - name: Create GitHub Release (final only)
         if: steps.version.outputs.is_final == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
+          $assets = @(Get-ChildItem -Path "artifacts\*.nupkg" | ForEach-Object { $_.FullName })
+          if ($assets.Count -eq 0) {
+            Write-Error "No .nupkg files found in artifacts/ to attach to the release"
+            exit 1
+          }
+          Write-Host "Attaching $($assets.Count) package(s) to the release"
           gh release create "v${{ steps.version.outputs.version }}" `
             --title "NAudio ${{ steps.version.outputs.version }}" `
             --notes-file release-body.md `
-            --verify-tag
+            --verify-tag `
+            @assets

--- a/ReleaseInstructions.md
+++ b/ReleaseInstructions.md
@@ -52,7 +52,7 @@ The tag push triggers `release.yml`, which:
 - Validates `RELEASE_NOTES.md` has a matching `### 3.0.0` section, and that it fits NuGet's 35,000-character `PackageReleaseNotes` limit.
 - Packs all 13 NAudio packages (+ matching `.snupkg` symbol packages).
 - Pushes everything to NuGet via trusted publishing.
-- Creates a GitHub Release titled `NAudio 3.0.0` with body extracted from the `RELEASE_NOTES.md` section.
+- Creates a GitHub Release titled `NAudio 3.0.0` with body extracted from the `RELEASE_NOTES.md` section, with the 13 `.nupkg` files attached as release assets (symbol packages are not attached — they go to NuGet's symbol server).
 
 No further action required for the publish itself. Both validations are fail-fast — if `VersionPrefix` or release notes don't match the tag, the workflow errors before packing.
 


### PR DESCRIPTION
## Summary

The release job already packs all 13 packages into `artifacts/` and uploads them as an Actions artifact, but the GitHub Release itself carried no assets. So the only ways to obtain a released package were NuGet, or an Actions artifact that expires after 90 days.

`gh release create` runs in the same job with `artifacts/` still on disk, so attaching them needs no artifact download round-trip — just an explicit file list on the existing command. The release then holds a permanent copy of exactly what shipped, which is useful for provenance and for anyone who wants a package without going through NuGet.

Two deliberate choices:

- **Explicit expansion rather than a glob.** `gh` doesn't expand globs and PowerShell doesn't expand wildcards in arguments to external commands — the same reason the `Push to NuGet` step loops instead of globbing. `--verify-tag artifacts\*.nupkg` would be passed through literally and fail.
- **Symbol packages not attached.** `.snupkg` files are already pushed to NuGet's symbol server, and including them would double the asset list for no benefit to someone reading the release page. Easy to add later if you'd rather have them.

The step fails fast if `artifacts/` somehow contains no packages, rather than silently creating an assetless release.

`ReleaseInstructions.md` §3b is updated so the description of what the tag push does stays accurate.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

YAML validated locally; the changed step only runs on a final tag-driven release, so it can't be exercised until the next `v*` tag. The `build` workflow doesn't touch `release.yml`, so CI here only confirms nothing else regressed.

Worth knowing before the next release: if the splat doesn't behave as expected on the runner's PowerShell, the failure surfaces *after* `Push to NuGet` has already succeeded — packages would be live on NuGet with the GitHub Release step failed. Recovery is just `gh release create` re-run by hand, but if you'd rather not find out during a real release, dispatching a preview won't help (previews skip this step) — the alternative is a throwaway tag on a scratch branch.

## Related

Partly addresses #1229, though not the substance of it: that request is for compiled **DLLs** for users unfamiliar with NuGet, and a `.nupkg` attached to a release still asks them to know it's a renamed zip. It's also worth noting NAudio 3 is `net9.0`-only, so the .NET Framework audience in that thread can't use these packages at all — the useful binaries bundle for them belongs on the 2.x line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7fG3Gpn1ho2o5eTCJ1Hpi)_