### PR TITLE
Fix Mp3FileReaderBase seeking on files with a Xing/Info header (#1419)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ the NuGet `PackageReleaseNotes` field, which has a hard 35,000-character
 limit and fails the release build if exceeded.
 -->
 
+ * Fixed `Mp3FileReaderBase` seeking silently restarting playback from the beginning of the file on MP3s with a Xing/Info header — the lazy frame index was gated on `IsLengthExact`, which such a header sets without any frame having been scanned. Also fixed seeks landing on the wrong frame when the target fell exactly on a frame boundary, and Xing/Info header frames being indexed as audio (shifting every seek in those files ~26 ms early). A 3.0.0 regression (#1419)
  * Fixed `WdlResamplingSampleProvider` losing samples, and eventually returning 0 permanently, when asked for more output than the source could supply — a 3.0.0 regression that broke the common pattern of reading generously from a `BufferedWaveProvider`-backed capture chain. `WdlResampler.ResampleOut` also no longer drifts in input-driven (feed) mode when handed fewer samples than `ResamplePrepare` requested (#1412)
 
 ### 3.0.1 (18 Aug 2026)

--- a/src/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
@@ -39,6 +39,10 @@ public class Mp3FileReaderBase : WaveStream
 
     private long totalSamples;
     private bool isLengthExact;
+    // Distinct from isLengthExact: a Xing/Info header gives us an exact length without
+    // us having scanned a single frame, so the two must not be conflated. This one is
+    // only ever set when a frame scan actually reaches the end of the stream.
+    private bool tocComplete;
     private long scannedToFilePosition;
     private long scannedToSamplePosition;
     private readonly int bytesPerSample;
@@ -118,6 +122,10 @@ public class Mp3FileReaderBase : WaveStream
             // workaround for a longstanding issue with some files failing to load
             // because they report a spurious sample rate change
             var secondFrame = Mp3Frame.LoadFromStream(mp3Stream);
+            // Decoding starts at dataStartPosition, so the table of contents has to start
+            // there too. When a Xing/Info header is present firstFrame *is* that header —
+            // a valid MPEG frame, but not audio — so the first audio frame is the second one.
+            var firstAudioFrame = xingHeader != null ? secondFrame : firstFrame;
             if (secondFrame != null &&
                 (secondFrame.SampleRate != firstFrame.SampleRate ||
                  secondFrame.ChannelMode != firstFrame.ChannelMode))
@@ -126,6 +134,7 @@ public class Mp3FileReaderBase : WaveStream
                 dataStartPosition = secondFrame.FileOffset;
                 // forget about the first frame, the second one is the first one we really care about
                 firstFrame = secondFrame;
+                firstAudioFrame = secondFrame;
             }
 
             mp3DataLength = mp3Stream.Length - dataStartPosition;
@@ -146,7 +155,7 @@ public class Mp3FileReaderBase : WaveStream
             Mp3WaveFormat = new Mp3WaveFormat(firstFrame.SampleRate,
                 firstFrame.ChannelMode == ChannelMode.Mono ? 1 : 2, firstFrame.FrameLength, firstFrame.BitRate);
 
-            SeedTableOfContents(firstFrame);
+            SeedTableOfContents(firstAudioFrame);
             EstimateTotalSamples(firstFrame);
 
             mp3Stream.Position = dataStartPosition;
@@ -172,20 +181,27 @@ public class Mp3FileReaderBase : WaveStream
     /// <returns>An MP3 Frame decompressor</returns>
     public delegate IMp3FrameDecompressor FrameDecompressorBuilder(WaveFormat mp3Format);
 
-    private void SeedTableOfContents(Mp3Frame firstFrame)
+    private void SeedTableOfContents(Mp3Frame firstAudioFrame)
     {
         tableOfContents = new List<Mp3Index>();
+        tocIndex = 0;
+        if (firstAudioFrame == null)
+        {
+            // A Xing/Info header with nothing after it. Nothing to index; Read returns 0.
+            scannedToFilePosition = dataStartPosition;
+            scannedToSamplePosition = 0;
+            return;
+        }
         var index = new Mp3Index
         {
-            FilePosition = firstFrame.FileOffset,
+            FilePosition = firstAudioFrame.FileOffset,
             SamplePosition = 0,
-            SampleCount = firstFrame.SampleCount,
-            ByteCount = firstFrame.FrameLength,
+            SampleCount = firstAudioFrame.SampleCount,
+            ByteCount = firstAudioFrame.FrameLength,
         };
         tableOfContents.Add(index);
-        scannedToFilePosition = firstFrame.FileOffset + firstFrame.FrameLength;
-        scannedToSamplePosition = firstFrame.SampleCount;
-        tocIndex = 0;
+        scannedToFilePosition = firstAudioFrame.FileOffset + firstAudioFrame.FrameLength;
+        scannedToSamplePosition = firstAudioFrame.SampleCount;
     }
 
     private void EstimateTotalSamples(Mp3Frame firstFrame)
@@ -206,19 +222,21 @@ public class Mp3FileReaderBase : WaveStream
     }
 
     // Caller must hold repositionLock. Saves and restores mp3Stream.Position.
-    // Scans frame headers (no PCM data) appending to TOC until scannedToSamplePosition >=
-    // targetSamplePosition or EOF is reached. On EOF, isLengthExact is set true and
-    // totalSamples is replaced with the exact frame-summed value.
+    // Scans frame headers (no PCM data) appending to TOC until the frame *containing*
+    // targetSamplePosition has been indexed, or EOF is reached. scannedToSamplePosition is
+    // an exclusive upper bound, so covering the target needs it to end up strictly greater.
+    // On EOF, tocComplete is set true, and totalSamples is replaced with the exact
+    // frame-summed value unless a Xing/Info header already gave us an authoritative one.
     private void ExtendTableOfContentsTo(long targetSamplePosition, CancellationToken cancellationToken)
     {
-        if (isLengthExact) return;
-        if (scannedToSamplePosition >= targetSamplePosition) return;
+        if (tocComplete) return;
+        if (scannedToSamplePosition > targetSamplePosition) return;
 
         long savedPosition = mp3Stream.Position;
         try
         {
             mp3Stream.Position = scannedToFilePosition;
-            while (scannedToSamplePosition < targetSamplePosition)
+            while (scannedToSamplePosition <= targetSamplePosition)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 Mp3Frame frame;
@@ -232,8 +250,7 @@ public class Mp3FileReaderBase : WaveStream
                 }
                 if (frame == null)
                 {
-                    isLengthExact = true;
-                    totalSamples = scannedToSamplePosition;
+                    MarkEndOfStreamReached();
                     break;
                 }
                 ValidateFrameFormat(frame);
@@ -243,6 +260,19 @@ public class Mp3FileReaderBase : WaveStream
         finally
         {
             mp3Stream.Position = savedPosition;
+        }
+    }
+
+    // A frame scan hit the end of the stream: the TOC now covers every frame. Only adopt
+    // the frame-summed sample count as the length if we didn't already have an exact one —
+    // a Xing/Info Frames field is authoritative, and overwriting it would make Length jump.
+    private void MarkEndOfStreamReached()
+    {
+        tocComplete = true;
+        if (!isLengthExact)
+        {
+            isLengthExact = true;
+            totalSamples = scannedToSamplePosition;
         }
     }
 
@@ -322,11 +352,10 @@ public class Mp3FileReaderBase : WaveStream
                 AppendIfNewFrame(frame);
                 tocIndex++;
             }
-            else if (!isLengthExact)
+            else
             {
-                // EOF reached during sequential read — we now know the exact length.
-                isLengthExact = true;
-                totalSamples = scannedToSamplePosition;
+                // EOF reached during sequential read — the TOC now covers the whole stream.
+                MarkEndOfStreamReached();
             }
         }
         catch (EndOfStreamException)
@@ -361,10 +390,15 @@ public class Mp3FileReaderBase : WaveStream
     /// <summary>
     /// Forces a full scan of the MP3 frame index so <see cref="Length"/> reports the exact
     /// frame-summed sample count and <see cref="IsLengthExact"/> returns <c>true</c>.
-    /// No-op (returns a completed task) if Length is already exact. Safe to call concurrently
-    /// with Read and <see cref="Position"/> changes; scan is serialised against playback by
-    /// the same internal lock. Restores the current playback position when complete.
+    /// No-op (returns a completed task) if Length is already exact — which it is from the
+    /// constructor for CBR files and for VBR files carrying a Xing/Info header. Safe to call
+    /// concurrently with Read and <see cref="Position"/> changes; scan is serialised against
+    /// playback by the same internal lock. Restores the current playback position when complete.
     /// </summary>
+    /// <remarks>
+    /// This is about <see cref="Length"/> only — it is not a prerequisite for seeking.
+    /// <see cref="Position"/> extends the frame index on demand whatever this reports.
+    /// </remarks>
     /// <param name="cancellationToken">Token observed between frames during the scan.</param>
     public Task EnsureExactLengthAsync(CancellationToken cancellationToken = default)
     {
@@ -430,7 +464,7 @@ public class Mp3FileReaderBase : WaveStream
         target = Math.Max(Math.Min(target, Length), 0);
         var samplePosition = target / bytesPerSample;
 
-        if (samplePosition > scannedToSamplePosition && !isLengthExact)
+        if (samplePosition >= scannedToSamplePosition && !tocComplete)
         {
             ExtendTableOfContentsTo(samplePosition, CancellationToken.None);
             target = Math.Max(Math.Min(target, Length), 0);
@@ -463,6 +497,10 @@ public class Mp3FileReaderBase : WaveStream
         }
         else
         {
+            // At or past the end of the data. tocIndex has to move with it: Read's warm-up
+            // rewind indexes off tocIndex, and leaving it stale would silently restart
+            // playback from wherever it happened to point.
+            tocIndex = tableOfContents.Count;
             mp3Stream.Position = mp3DataLength + dataStartPosition;
         }
 
@@ -520,7 +558,10 @@ public class Mp3FileReaderBase : WaveStream
                 // the data as it would be when reading sequentially from the beginning, because
                 // the decoder is missing the required overlap from the previous frame.
                 tocIndex = Math.Max(0, tocIndex - 3); // no warm-up at the beginning of the stream
-                mp3Stream.Position = tableOfContents[tocIndex].FilePosition;
+                if (tocIndex < tableOfContents.Count)
+                {
+                    mp3Stream.Position = tableOfContents[tocIndex].FilePosition;
+                }
 
                 repositionedFlag = false;
             }

--- a/tests/NAudio.Core.Tests/Mp3/Mp3FileReaderSeekTests.cs
+++ b/tests/NAudio.Core.Tests/Mp3/Mp3FileReaderSeekTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NAudio.Core.Tests.Utils;
+using NAudio.Wave;
+using NUnit.Framework;
+
+namespace NAudio.Core.Tests.Mp3;
+
+/// <summary>
+/// Regression tests for issue #1419: with a Xing/Info header present, every forward seek
+/// past the scanned tail silently rewound to the start of the file. The lazy table of
+/// contents was gated on <c>IsLengthExact</c>, which a Xing <c>Frames</c> field sets true
+/// without a single frame having been scanned.
+/// </summary>
+/// <remarks>
+/// Uses a synthetic in-memory MP3 and a frame-stamping decompressor rather than a real
+/// codec — see the note on <see cref="Mp3FileReaderLazyTocTests"/>. The stamp makes the
+/// frame a seek landed on directly assertable, which an all-silence decompressor cannot.
+/// </remarks>
+[TestFixture]
+[Category("UnitTest")]
+public class Mp3FileReaderSeekTests
+{
+    private const double DurationSeconds = 10;
+    private const int BytesPerSample = 4; // 16-bit stereo
+
+    private static byte[] Mp3Bytes(bool withInfoHeader) =>
+        withInfoHeader
+            ? SyntheticMp3.CreateBytesWithInfoHeader(DurationSeconds)
+            : SyntheticMp3.CreateBytes(DurationSeconds);
+
+    private static int AudioFrameCount => SyntheticMp3.FramesForSeconds(DurationSeconds);
+
+    /// <summary>
+    /// File offset of audio frame <paramref name="audioFrameIndex"/>. With an Info header the
+    /// header itself occupies file frame 0, so the audio is shifted along by one frame.
+    /// </summary>
+    private static long ExpectedFileOffset(bool withInfoHeader, int audioFrameIndex) =>
+        (long)(withInfoHeader ? audioFrameIndex + 1 : audioFrameIndex) * SyntheticMp3.FrameSize;
+
+    private static Mp3FileReaderBase Open(byte[] mp3, out FrameStampingMp3FrameDecompressor decompressor,
+        bool legacyByteArrayOnly = false)
+    {
+        FrameStampingMp3FrameDecompressor created = null;
+        var reader = new Mp3FileReaderBase(new MemoryStream(mp3),
+            fmt => created = new FrameStampingMp3FrameDecompressor(fmt, legacyByteArrayOnly));
+        decompressor = created;
+        return reader;
+    }
+
+    // Note: Mp3FileReaderBase treats two Position writes inside ScrubDetectionWindowMs (30 ms)
+    // as an interactive scrub and deliberately returns silence until the drag settles. Tests
+    // that need to assert on decoded content therefore use one seek per reader, or advance by
+    // reading rather than by writing Position again.
+    private static long ReadStampAt(Mp3FileReaderBase reader, long sampleTarget)
+    {
+        reader.Position = sampleTarget * BytesPerSample;
+        var buf = new byte[BytesPerSample];
+        int read = reader.Read(buf, 0, buf.Length);
+        Assert.That(read, Is.EqualTo(buf.Length), "Seek target should still have data after it");
+        return FrameStampingMp3FrameDecompressor.ReadStamp(buf);
+    }
+
+    // Audio frame 10 exactly on a frame boundary, then the same frame entered part-way
+    // through, then one far past anything the constructor scanned.
+    [TestCase(true, 10, 0)]
+    [TestCase(false, 10, 0)]
+    [TestCase(true, 10, 500)]
+    [TestCase(false, 10, 500)]
+    [TestCase(true, 200, 0)]
+    [TestCase(false, 200, 0)]
+    [TestCase(true, 200, 777)]
+    [TestCase(false, 200, 777)]
+    public void SeekForward_PastScannedTail_LandsOnTargetFrame(bool withInfoHeader, int audioFrame, int sampleWithinFrame)
+    {
+        using var reader = Open(Mp3Bytes(withInfoHeader), out _);
+        long target = (long)audioFrame * SyntheticMp3.SamplesPerFrame + sampleWithinFrame;
+
+        long stamp = ReadStampAt(reader, target);
+
+        Assert.That(stamp, Is.EqualTo(ExpectedFileOffset(withInfoHeader, audioFrame)),
+            $"Seeking to sample {target} should decode audio frame {audioFrame}, " +
+            $"not the frame at file offset {stamp}");
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SeekForward_ToEveryFrameBoundary_LandsOnThatFrame(bool withInfoHeader)
+    {
+        // Frame-boundary targets were the second defect: ExtendTableOfContentsTo stopped one
+        // frame short when the target landed exactly on a boundary, so no TOC entry covered it.
+        var mp3 = Mp3Bytes(withInfoHeader);
+        for (int audioFrame = 1; audioFrame < AudioFrameCount; audioFrame += 37)
+        {
+            using var reader = Open(mp3, out _);
+            long stamp = ReadStampAt(reader, (long)audioFrame * SyntheticMp3.SamplesPerFrame);
+            Assert.That(stamp, Is.EqualTo(ExpectedFileOffset(withInfoHeader, audioFrame)),
+                $"Boundary seek to audio frame {audioFrame} landed on file offset {stamp}");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task SeekThenReadToEnd_DoesNotOverrunLength(bool withInfoHeader)
+    {
+        // The symptom reported in #1419: after seeking, CurrentTime ran past TotalTime because
+        // the seek had quietly rewound and the whole file was decoded again from the start.
+        using var reader = Open(Mp3Bytes(withInfoHeader), out _);
+        await reader.EnsureExactLengthAsync();
+        long length = reader.Length;
+        long target = length / 2 / BytesPerSample * BytesPerSample;
+        reader.Position = target;
+
+        var buf = new byte[16384];
+        long total = 0;
+        int n;
+        do
+        {
+            n = reader.Read(buf, 0, buf.Length);
+            total += n;
+        } while (n > 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(total, Is.EqualTo(length - target),
+                "Reading to EOF after a mid-file seek should yield exactly the remainder");
+            Assert.That(reader.Position, Is.EqualTo(length));
+            Assert.That(reader.CurrentTime, Is.LessThanOrEqualTo(reader.TotalTime),
+                "CurrentTime must not run past TotalTime");
+        });
+    }
+
+    [Test]
+    public void InfoHeaderFrame_IsNeverDecodedAsAudio()
+    {
+        // The Info/Xing frame is a valid MPEG frame but carries no audio, and decoding starts
+        // past it. Indexing it as TOC entry 0 shifted every seek one frame (~26 ms) early.
+        var mp3 = Mp3Bytes(withInfoHeader: true);
+        long firstAudioOffset = SyntheticMp3.FrameSize;
+
+        using (var reader = Open(mp3, out var sequential))
+        {
+            var buf = new byte[BytesPerSample];
+            _ = reader.Read(buf, 0, buf.Length);
+            Assert.That(FrameStampingMp3FrameDecompressor.ReadStamp(buf), Is.EqualTo(firstAudioOffset),
+                "A fresh sequential read should start at the first audio frame");
+            Assert.That(sequential.FramesDecoded, Has.None.Zero,
+                "The Info header frame at file offset 0 should never be handed to the decoder");
+        }
+
+        using (var reader = Open(mp3, out var seekToZero))
+        {
+            Assert.That(ReadStampAt(reader, 0), Is.EqualTo(firstAudioOffset),
+                "Seeking to sample 0 should also land on the first audio frame");
+            Assert.That(seekToZero.FramesDecoded, Has.None.Zero,
+                "The Info header frame should not be decoded as a warm-up frame either");
+        }
+
+        using (var reader = Open(mp3, out _))
+        {
+            Assert.That(ReadStampAt(reader, SyntheticMp3.SamplesPerFrame),
+                Is.EqualTo(firstAudioOffset + SyntheticMp3.FrameSize),
+                "Sample 1152 is the start of the second audio frame");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task SeekToEnd_ReturnsNoDataInsteadOfReplayingFromStart(bool withInfoHeader)
+    {
+        using var reader = Open(Mp3Bytes(withInfoHeader), out _);
+        await reader.EnsureExactLengthAsync();
+        reader.Position = reader.Length;
+
+        var buf = new byte[16384];
+        int n = reader.Read(buf, 0, buf.Length);
+
+        Assert.That(n, Is.Zero, "Seeking to the end should yield no data, not restart playback");
+        Assert.That(reader.Position, Is.EqualTo(reader.Length));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Seek_WorksThroughLegacyByteArrayOnlyDecompressor(bool withInfoHeader)
+    {
+        // The reporter's setup: NLayer's Mp3FrameDecompressor predates Span and reaches the
+        // reader through the default-interface-method fallback. Seeking must behave identically.
+        using var reader = Open(Mp3Bytes(withInfoHeader), out _, legacyByteArrayOnly: true);
+
+        long stamp = ReadStampAt(reader, 200L * SyntheticMp3.SamplesPerFrame);
+
+        Assert.That(stamp, Is.EqualTo(ExpectedFileOffset(withInfoHeader, 200)));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SeekForward_ProducesSamePcmAsSeekBackwardToSamePoint(bool withInfoHeader)
+    {
+        var mp3 = Mp3Bytes(withInfoHeader);
+        long target = 150L * SyntheticMp3.SamplesPerFrame + 64;
+
+        // Forward: straight to the target from a freshly opened reader.
+        using var forward = Open(mp3, out _);
+        forward.Position = target * BytesPerSample;
+        var forwardBuf = new byte[8192];
+        int forwardRead = forward.Read(forwardBuf, 0, forwardBuf.Length);
+
+        // Backward: read sequentially past the target, then come back to it. Advancing by
+        // reading rather than by a second Position write keeps this out of scrub mode.
+        using var backward = Open(mp3, out _);
+        long readPast = 300L * SyntheticMp3.SamplesPerFrame * BytesPerSample;
+        var skipBuf = new byte[8192];
+        while (backward.Position < readPast && backward.Read(skipBuf, 0, skipBuf.Length) > 0)
+        {
+        }
+        backward.Position = target * BytesPerSample;
+        var backwardBuf = new byte[8192];
+        int backwardRead = backward.Read(backwardBuf, 0, backwardBuf.Length);
+
+        Assert.That(forwardRead, Is.EqualTo(backwardRead));
+        Assert.That(forwardBuf, Is.EqualTo(backwardBuf),
+            "Reaching a position by seeking forward or backward should decode the same frames");
+    }
+}

--- a/tests/NAudio.Core.Tests/Utils/FrameStampingMp3FrameDecompressor.cs
+++ b/tests/NAudio.Core.Tests/Utils/FrameStampingMp3FrameDecompressor.cs
@@ -1,0 +1,97 @@
+using System;
+using NAudio.Wave;
+
+namespace NAudio.Core.Tests.Utils;
+
+/// <summary>
+/// Test-only <see cref="IMp3FrameDecompressor"/> that stamps every decoded sample with the
+/// source frame's <see cref="Mp3Frame.FileOffset"/> instead of producing audio. That makes
+/// the frame a seek actually landed on directly readable out of the PCM, which
+/// <see cref="FakeMp3FrameDecompressor"/> (all-silence) cannot distinguish.
+/// </summary>
+/// <remarks>
+/// Requires a stereo 16-bit output format — each 4-byte sample carries the offset as
+/// little-endian low half in the left channel, high half in the right. Decode with
+/// <see cref="ReadStamp"/>.
+/// <para>
+/// Set <paramref name="legacyByteArrayOnly"/> to mimic the shape of a pre-Span third-party
+/// decoder such as NLayer's <c>Mp3FrameDecompressor</c>, which overrides only the byte[]
+/// overload and reaches the reader through the default-interface-method fallback.
+/// </para>
+/// </remarks>
+internal class FrameStampingMp3FrameDecompressor : IMp3FrameDecompressor
+{
+    private const int SamplesPerFrame = 1152;
+    private readonly bool legacyByteArrayOnly;
+
+    public FrameStampingMp3FrameDecompressor(WaveFormat sourceFormat, bool legacyByteArrayOnly = false)
+    {
+        OutputFormat = new WaveFormat(sourceFormat.SampleRate, 16, sourceFormat.Channels);
+        this.legacyByteArrayOnly = legacyByteArrayOnly;
+    }
+
+    public WaveFormat OutputFormat { get; }
+
+    /// <summary>Number of <see cref="Reset"/> calls seen so far.</summary>
+    public int ResetCount { get; private set; }
+
+    /// <summary>File offsets of every frame handed to this decompressor, in order.</summary>
+    public System.Collections.Generic.List<long> FramesDecoded { get; } = new();
+
+    /// <summary>Reads back a stamp written by this decompressor from a PCM buffer.</summary>
+    public static long ReadStamp(ReadOnlySpan<byte> pcm, int sampleIndex = 0)
+    {
+        int o = sampleIndex * 4;
+        return (uint)(pcm[o] | (pcm[o + 1] << 8) | (pcm[o + 2] << 16) | (pcm[o + 3] << 24));
+    }
+
+    public int DecompressFrame(Mp3Frame frame, byte[] dest, int destOffset)
+        => Stamp(frame, dest.AsSpan(destOffset));
+
+    public int DecompressFrame(Mp3Frame frame, Span<byte> dest)
+        => legacyByteArrayOnly
+            // Force the reader down the DIM fallback, exactly as an old NLayer build would.
+            ? this.DecompressFrameViaLegacy(frame, dest)
+            : Stamp(frame, dest);
+
+    private int Stamp(Mp3Frame frame, Span<byte> dest)
+    {
+        FramesDecoded.Add(frame.FileOffset);
+        int bytes = SamplesPerFrame * OutputFormat.Channels * (OutputFormat.BitsPerSample / 8);
+        uint stamp = (uint)frame.FileOffset;
+        for (int o = 0; o < bytes; o += 4)
+        {
+            dest[o] = (byte)stamp;
+            dest[o + 1] = (byte)(stamp >> 8);
+            dest[o + 2] = (byte)(stamp >> 16);
+            dest[o + 3] = (byte)(stamp >> 24);
+        }
+        return bytes;
+    }
+
+    public void Reset() => ResetCount++;
+
+    public void Dispose() { }
+}
+
+internal static class LegacyDecompressorRouting
+{
+    /// <summary>
+    /// Invokes the byte[] overload the way the interface's default Span implementation does,
+    /// so a test double can opt into that path without reimplementing it.
+    /// </summary>
+    public static int DecompressFrameViaLegacy(this IMp3FrameDecompressor decompressor, Mp3Frame frame, Span<byte> dest)
+    {
+        var rented = System.Buffers.ArrayPool<byte>.Shared.Rent(dest.Length);
+        try
+        {
+            int written = decompressor.DecompressFrame(frame, rented, 0);
+            rented.AsSpan(0, written).CopyTo(dest);
+            return written;
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+}

--- a/tests/NAudio.Core.Tests/Utils/SyntheticMp3.cs
+++ b/tests/NAudio.Core.Tests/Utils/SyntheticMp3.cs
@@ -17,8 +17,9 @@ internal static class SyntheticMp3
     //   channel mode 00 (= stereo), mode-ext 00, copyright 0, original 0, emphasis 00 → byte 3 = 0x00
     // Frame size = floor(144 * bitrate / samplerate) = floor(144 * 96000 / 44100) = 313 bytes (no padding).
     // 1152 samples / 44100 Hz ≈ 26.12 ms per frame.
-    private const int FrameSize = 313;
-    private const int SamplesPerFrame = 1152;
+    /// <summary>Bytes per frame in the generated stream — lets tests map file offsets to frame ordinals.</summary>
+    public const int FrameSize = 313;
+    public const int SamplesPerFrame = 1152;
     public const int SampleRate = 44100;
     public const int Channels = 2;
     public const int BitRate = 96000;


### PR DESCRIPTION
## Summary

Fixes #1419. On an MP3 carrying a Xing/Info header, seeking forward past the scanned tail silently rewound to the start of the file: playback restarted from the beginning and `CurrentTime` ran past `TotalTime`. A 3.0.0 regression — NAudio 2.x built the whole table of contents in the constructor, so seeking always worked.

**Root cause.** The lazy TOC introduced in 3.0.0 gated its extension on `isLengthExact`, conflating two different things: *"we know the total length"* and *"the frame index is complete"*. A Xing/Info `Frames` field makes the length exact without a single frame having been scanned, so the TOC stayed at its one seed entry, the lookup in `ApplyPendingReposition` found no covering frame, and `Read`'s warm-up rewind then reset the stream back to the first frame. `EnsureExactLengthAsync` couldn't rescue it either — it no-ops once the length is exact, so there was no workaround.

Split the two concerns with a `tocComplete` flag, set only when a frame scan actually reaches the end of the stream. Two further defects surfaced while confirming the diagnosis:

- **Frame-boundary off-by-one.** `ExtendTableOfContentsTo` stopped one frame short when the target landed exactly on a frame boundary, since `scannedToSamplePosition` is an *exclusive* upper bound. This broke boundary seeks on headerless files too.
- **Xing/Info frame indexed as audio.** The header frame is a valid MPEG frame but carries no audio, and decoding starts past it — yet it was seeded as TOC entry 0, shifting every seek in such files one frame (~26 ms) early.

Plus two hardening fixes the above exposed: seeking at or past the end now moves `tocIndex` with it so the warm-up rewind can't resurrect a stale index, and that rewind tolerates an empty TOC (a Xing header with no audio frames after it).

`MarkEndOfStreamReached` deliberately does **not** overwrite a Xing-derived `totalSamples` — that field is authoritative, and overwriting it mid-playback would make `Length` jump.

Also clarified the `EnsureExactLengthAsync` doc comment, which reads as though a full index scan were a prerequisite for seeking. It isn't — `Position` extends the index on demand.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

New `tests/NAudio.Core.Tests/Mp3/Mp3FileReaderSeekTests.cs`, 19 cases covering forward seeks past the scanned tail, frame-boundary and sub-frame targets, seek-to-end, and forward/backward parity — each across both the Xing/Info and headerless variants.

**15 of the 19 fail without this change**; all 19 pass with it.

The tests use a new `FrameStampingMp3FrameDecompressor` that writes each frame's `FileOffset` into its PCM output, so the frame a seek actually landed on is directly assertable. The existing all-silence `FakeMp3FrameDecompressor` cannot distinguish a correct seek from a rewind, which is part of why this slipped through — the existing `SeekForward_PastScannedTail_LandsOnCorrectSample` test only exercised the headerless variant. One case drives a legacy `byte[]`-only decompressor through the default-interface-method fallback, matching the NLayer setup in the report.

Full cross-platform suite on Linux: **1514 passed, 0 failed, 3 skipped**. `NAudio.Windows.Tests` still builds with `-p:EnableWindowsTargeting=true` (can't be run here).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5rTyEy4PvN8aCVMJyuk8Q)_