### PR TITLE
Use the Lock class

### DIFF
--- a/samples/NAudioWpfDemo/WasapiRecorderDemo/WasapiRecorderViewModel.cs
+++ b/samples/NAudioWpfDemo/WasapiRecorderDemo/WasapiRecorderViewModel.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
@@ -45,7 +46,7 @@ internal class WasapiRecorderViewModel : ViewModelBase, IDisposable
     // field — which the UI thread may null out from under it during teardown.
     private WaveFormat captureFormat;
     private WaveFileWriter writer;
-    private readonly object writerLock = new();
+    private readonly Lock writerLock = new();
     private readonly DispatcherTimer meterTimer = new();
 
     // Written by the capture thread, read and reset by the meter timer on the UI thread. Float

--- a/src/NAudio.Alsa/AlsaOut.cs
+++ b/src/NAudio.Alsa/AlsaOut.cs
@@ -24,7 +24,7 @@ public sealed class AlsaOut : IWavePlayer, IWaveLatency
         PCMFormat.SND_PCM_FORMAT_S24_3LE,
     };
 
-    private readonly object sync = new();
+    private readonly Lock sync = new();
     private readonly ManualResetEventSlim resumeGate = new(initialState: true);
     private readonly AlsaPcm pcm;
     private SampleChannel channel;

--- a/src/NAudio.Alsa/AlsaPcm.cs
+++ b/src/NAudio.Alsa/AlsaPcm.cs
@@ -28,7 +28,7 @@ internal sealed class AlsaPcm : IDisposable
     /// <summary>Number of periods in the device ring buffer.</summary>
     internal const uint Periods = 4;
 
-    private readonly object gate = new();
+    private readonly Lock gate = new();
     private readonly SafePcmHandle handle;
     private bool disposed;
     private Thread worker;

--- a/src/NAudio.Asio/AsioDevice.cs
+++ b/src/NAudio.Asio/AsioDevice.cs
@@ -24,7 +24,7 @@ namespace NAudio.Wave;
 public sealed class AsioDevice : IDisposable
 {
     private readonly SynchronizationContext syncContext;
-    private readonly object stateLock = new();
+    private readonly Lock stateLock = new();
     private AsioDriverExt driver;
     private AsioDeviceState state;
 

--- a/src/NAudio.Core/Effects/EffectChain.cs
+++ b/src/NAudio.Core/Effects/EffectChain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using NAudio.Wave;
 
 namespace NAudio.Effects;
@@ -21,7 +22,7 @@ namespace NAudio.Effects;
 public sealed class EffectChain : ISampleProvider
 {
     private readonly ISampleProvider source;
-    private readonly object gate = new(); // serializes edits; never held during Read
+    private readonly Lock gate = new(); // serializes edits; never held during Read
     private volatile IAudioEffect[] effects = Array.Empty<IAudioEffect>();
 
     /// <summary>

--- a/src/NAudio.Core/Sequencing/EventTimeline.cs
+++ b/src/NAudio.Core/Sequencing/EventTimeline.cs
@@ -17,7 +17,7 @@ namespace NAudio.Sequencing;
 /// <typeparam name="T">Payload type. See <see cref="SequencerEvent{T}"/>.</typeparam>
 public sealed class EventTimeline<T>
 {
-    private readonly object writeLock = new();
+    private readonly Lock writeLock = new();
     private SequencerEvent<T>[] snapshot = Array.Empty<SequencerEvent<T>>();
 
     /// <summary>The number of events currently in the timeline.</summary>

--- a/src/NAudio.Core/Sequencing/LiveTempoMap.cs
+++ b/src/NAudio.Core/Sequencing/LiveTempoMap.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace NAudio.Sequencing;
 
@@ -10,7 +11,7 @@ namespace NAudio.Sequencing;
 /// </summary>
 public sealed class LiveTempoMap : ITempoMap
 {
-    private readonly object writerLock = new();
+    private readonly Lock writerLock = new();
     private volatile Segment[] segments;
 
     /// <summary>Creates a tempo map starting at the given BPM from tick 0.</summary>

--- a/src/NAudio.Core/Sequencing/Transport.cs
+++ b/src/NAudio.Core/Sequencing/Transport.cs
@@ -15,7 +15,7 @@ public sealed class Transport
 {
     private readonly ITempoMap tempoMap;
     private readonly int sampleRate;
-    private readonly object mutationLock = new();
+    private readonly Lock mutationLock = new();
     private long currentFrames;
     private long currentTicks;
     private int isPlaying;

--- a/src/NAudio.Core/Utils/CircularBuffer.cs
+++ b/src/NAudio.Core/Utils/CircularBuffer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace NAudio.Utils;
 
@@ -9,7 +10,7 @@ namespace NAudio.Utils;
 public class CircularBuffer
 {
     private readonly byte[] buffer;
-    private readonly object lockObject;
+    private readonly Lock lockObject;
     private int writePosition;
     private int readPosition;
     private int byteCount;
@@ -21,7 +22,7 @@ public class CircularBuffer
     public CircularBuffer(int size)
     {
         buffer = new byte[size];
-        lockObject = new object();
+        lockObject = new Lock();
     }
 
     /// <summary>

--- a/src/NAudio.Core/Wave/SampleProviders/FadeInOutSampleProvider.cs
+++ b/src/NAudio.Core/Wave/SampleProviders/FadeInOutSampleProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace NAudio.Wave.SampleProviders;
 
@@ -15,7 +16,7 @@ public class FadeInOutSampleProvider : ISampleProvider
         FadingOut,
     }
 
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
     private readonly ISampleProvider source;
     private int fadeSamplePosition;
     private int fadeSampleCount;

--- a/src/NAudio.Core/Wave/WaveStreams/AiffFileReader.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/AiffFileReader.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Collections.Generic;
 using NAudio.Utils;
+using System.Threading;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
@@ -18,7 +19,7 @@ public class AiffFileReader : WaveStream
     private readonly int dataChunkLength;
     private readonly List<AiffChunk> chunks = new();
     private Stream waveStream;
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
 
     /// <summary>Supports opening a AIF file</summary>
     /// <remarks>The AIF is of similar nastiness to the WAV format.

--- a/src/NAudio.Core/Wave/WaveStreams/BlockAlignReductionStream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/BlockAlignReductionStream.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using NAudio.Utils;
 
 // ReSharper disable once CheckNamespace
@@ -15,7 +16,7 @@ public class BlockAlignReductionStream : WaveStream
     private readonly CircularBuffer circularBuffer;
     private long bufferStartPosition;
     private byte[] sourceBuffer;
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
 
     /// <summary>
     /// Creates a new BlockAlignReductionStream

--- a/src/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/Mp3FileReaderBase.cs
@@ -65,7 +65,7 @@ public class Mp3FileReaderBase : WaveStream
     private const int ScrubDetectionWindowMs = 30;
     private const int SettleWindowMs = 50;
 
-    private readonly object repositionLock = new();
+    private readonly Lock repositionLock = new();
 
 
     /// <summary>Supports opening a MP3 file</summary>

--- a/src/NAudio.Core/Wave/WaveStreams/Wave32To16Stream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/Wave32To16Stream.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NAudio.Utils;
 
 // ReSharper disable once CheckNamespace
@@ -16,7 +17,7 @@ public class Wave32To16Stream : WaveStream
     private long position;
     private bool clip;
     private float volume;
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
 
     /// <summary>
     /// Reused between <c>Read</c> calls to avoid per-read allocations.

--- a/src/NAudio.Core/Wave/WaveStreams/WaveChannel32.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveChannel32.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NAudio.Wave.SampleProviders;
 
 namespace NAudio.Wave;
@@ -21,7 +22,7 @@ public class WaveChannel32 : WaveStream, ISampleNotifier
     private volatile float pan;
     private long position;
     private readonly ISampleChunkConverter sampleProvider;
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
 
     /// <summary>
     /// Creates a new WaveChannel32

--- a/src/NAudio.Core/Wave/WaveStreams/WaveFileReader.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveFileReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 
 namespace NAudio.Wave;
 
@@ -13,7 +14,7 @@ public class WaveFileReader : WaveStream
     private readonly bool ownInput;
     private readonly long dataPosition;
     private readonly long dataChunkLength;
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
     private Stream waveStream;
 
     /// <summary>Supports opening a WAV file</summary>

--- a/src/NAudio.Core/Wave/WaveStreams/WaveMixerStream32.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveMixerStream32.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Numerics.Tensors;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NAudio.Utils;
 
 namespace NAudio.Wave;
@@ -14,7 +15,7 @@ namespace NAudio.Wave;
 public class WaveMixerStream32 : WaveStream
 {
     private readonly List<WaveStream> inputStreams;
-    private readonly object inputsLock;
+    private readonly Lock inputsLock;
     private WaveFormat waveFormat;
     private long length;
     private long position;
@@ -30,7 +31,7 @@ public class WaveMixerStream32 : WaveStream
         waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(44100, 2);
         bytesPerSample = 4;
         inputStreams = new List<WaveStream>();
-        inputsLock = new object();
+        inputsLock = new Lock();
     }
 
     /// <summary>

--- a/src/NAudio.Core/Wave/WaveStreams/WaveOffsetStream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveOffsetStream.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
@@ -20,7 +21,7 @@ public class WaveOffsetStream : WaveStream
     private TimeSpan startTime;
     private TimeSpan sourceOffset;
     private TimeSpan sourceLength;
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
 
     /// <summary>
     /// Creates a new WaveOffsetStream

--- a/src/NAudio.SoundFile/SoundFileReader.cs
+++ b/src/NAudio.SoundFile/SoundFileReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NAudio.Wave;
 
 namespace NAudio.SoundFile;
@@ -18,7 +19,7 @@ namespace NAudio.SoundFile;
 /// </remarks>
 public sealed class SoundFileReader : WaveStream, ISampleProvider
 {
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
     private readonly WaveFormat waveFormat;
     private readonly SafeSndFileHandle handle;
     private readonly StreamVirtualIo virtualIo;

--- a/src/NAudio.SoundFile/SoundFileWriter.cs
+++ b/src/NAudio.SoundFile/SoundFileWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 
@@ -24,7 +25,7 @@ public sealed class SoundFileWriter : Stream
 {
     private enum ItemType { Short, Float }
 
-    private readonly object lockObject = new();
+    private readonly Lock lockObject = new();
     private readonly WaveFormat sourceFormat;
     private readonly ItemType itemType;
     private readonly int channels;

--- a/src/NAudio.Vst3/Vst3Plugin.cs
+++ b/src/NAudio.Vst3/Vst3Plugin.cs
@@ -133,7 +133,7 @@ public sealed unsafe class Vst3Plugin : IDisposable
     // Updated at the top of every Process call (audio thread). Read under the lock by producers
     // computing target samples in Send* methods. Lock contention is microsecond-scale (two stores
     // on each side) and only happens when a MIDI event arrives — fine for the audio thread.
-    private readonly object _clockLock = new();
+    private readonly Lock _clockLock = new();
     private long _blockStartSample;
     private long _blockStartTimestampTicks;
 

--- a/src/NAudio.Wasapi/CoreAudioApi/AudioSessionControl.cs
+++ b/src/NAudio.Wasapi/CoreAudioApi/AudioSessionControl.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
+using System.Threading;
 using NAudio.CoreAudioApi.Interfaces;
 
 namespace NAudio.CoreAudioApi;
@@ -23,7 +24,7 @@ public class AudioSessionControl : IDisposable
     private IAudioSessionControl2 audioSessionControlInterface2;
     private readonly bool ownsInterface;
     private readonly Dictionary<IAudioSessionEventsHandler, AudioSessionEventsCallback> audioSessionEventCallbacks = new();
-    private readonly object eventCallbackLock = new();
+    private readonly Lock eventCallbackLock = new();
 
     // ComWrappers CCWs return a distinct IntPtr per interface (and a separate vtable
     // for IUnknown). Registration APIs that expect IAudioSessionEvents* must receive

--- a/src/NAudio.WinForms/WaveOutWindow.cs
+++ b/src/NAudio.WinForms/WaveOutWindow.cs
@@ -15,7 +15,7 @@ namespace NAudio.Wave;
 /// </summary>
 public class WaveOutWindow : IWavePlayer, IWavePosition, IWaveLatency
 {
-    private readonly object waveOutLock = new();
+    private readonly Lock waveOutLock = new();
     private readonly SynchronizationContext syncContext;
     private readonly WaveInterop.WaveCallback callback;
     private readonly WaveCallbackHost callbackHost;

--- a/src/NAudio.WinMM/WaveOut.cs
+++ b/src/NAudio.WinMM/WaveOut.cs
@@ -11,7 +11,7 @@ namespace NAudio.Wave;
 /// </summary>
 public class WaveOut : IWavePlayer, IWavePosition, IWaveLatency
 {
-    private readonly object waveOutLock;
+    private readonly Lock waveOutLock;
     private readonly SynchronizationContext syncContext;
     private IntPtr hWaveOut; // WaveOut handle
     private WaveOutBuffer[] buffers;
@@ -71,7 +71,7 @@ public class WaveOut : IWavePlayer, IWavePosition, IWaveLatency
         syncContext = SynchronizationContext.Current;
         BufferMilliseconds = 100;
         NumberOfBuffers = 2;
-        waveOutLock = new object();
+        waveOutLock = new Lock();
     }
 
     /// <summary>

--- a/src/NAudio.WinMM/WaveOutBuffer.cs
+++ b/src/NAudio.WinMM/WaveOutBuffer.cs
@@ -14,8 +14,8 @@ internal class WaveOutBuffer : IDisposable
     private readonly Int32 bufferSize; // allocated bytes, may not be the same as bytes read
     private readonly byte[] buffer;
     private readonly IWaveProvider waveStream;
-    private readonly object waveOutLock;
-    private readonly object waveStreamLock;
+    private readonly Lock waveOutLock;
+    private readonly Lock waveStreamLock;
     private GCHandle hBuffer;
     private IntPtr hWaveOut;
     private GCHandle hHeader; // we need to pin the header structure
@@ -31,7 +31,7 @@ internal class WaveOutBuffer : IDisposable
     /// <param name="bufferSize">Buffer size in bytes</param>
     /// <param name="bufferFillStream">Stream to provide more data</param>
     /// <param name="waveOutLock">Lock to protect WaveOut API's from being called on >1 thread</param>
-    public WaveOutBuffer(IntPtr hWaveOut, Int32 bufferSize, IWaveProvider bufferFillStream, object waveOutLock)
+    public WaveOutBuffer(IntPtr hWaveOut, Int32 bufferSize, IWaveProvider bufferFillStream, Lock waveOutLock)
     {
         this.bufferSize = bufferSize;
         buffer = new byte[bufferSize];
@@ -39,7 +39,7 @@ internal class WaveOutBuffer : IDisposable
         this.hWaveOut = hWaveOut;
         waveStream = bufferFillStream;
         this.waveOutLock = waveOutLock;
-        waveStreamLock = new object();
+        waveStreamLock = new Lock();
 
         header = new WaveHeader();
         hHeader = GCHandle.Alloc(header, GCHandleType.Pinned);

--- a/src/NAudio.WinMM/WaveOutUtils.cs
+++ b/src/NAudio.WinMM/WaveOutUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
@@ -12,7 +13,7 @@ internal static class WaveOutUtils
     /// <summary>
     /// Get WaveOut Volume
     /// </summary>
-    public static float GetWaveOutVolume(IntPtr hWaveOut, object lockObject)
+    public static float GetWaveOutVolume(IntPtr hWaveOut, Lock lockObject)
     {
         int stereoVolume;
         MmResult result;
@@ -27,7 +28,7 @@ internal static class WaveOutUtils
     /// <summary>
     /// Set WaveOut Volume
     /// </summary>
-    public static void SetWaveOutVolume(float value, IntPtr hWaveOut, object lockObject)
+    public static void SetWaveOutVolume(float value, IntPtr hWaveOut, Lock lockObject)
     {
         if (value < 0) throw new ArgumentOutOfRangeException(nameof(value), "Volume must be between 0.0 and 1.0");
         if (value > 1) throw new ArgumentOutOfRangeException(nameof(value), "Volume must be between 0.0 and 1.0");
@@ -46,7 +47,7 @@ internal static class WaveOutUtils
     /// <summary>
     /// Get position in bytes
     /// </summary>
-    public static long GetPositionBytes(IntPtr hWaveOut, object lockObject)
+    public static long GetPositionBytes(IntPtr hWaveOut, Lock lockObject)
     {
         lock (lockObject)
         {

--- a/src/NAudio/AudioFileReader.cs
+++ b/src/NAudio/AudioFileReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NAudio.Wave.SampleProviders;
 
 // ReSharper disable once CheckNamespace
@@ -22,7 +23,7 @@ public class AudioFileReader : WaveStream, ISampleProvider
     private int destBytesPerSample;
     private int sourceBytesPerSample;
     private long length;
-    private readonly object lockObject;
+    private readonly Lock lockObject;
 
     /// <summary>
     /// Initializes a new instance of AudioFileReader
@@ -33,7 +34,7 @@ public class AudioFileReader : WaveStream, ISampleProvider
     /// NAudio.SoundFile package.</exception>
     public AudioFileReader(string fileName)
     {
-        lockObject = new object();
+        lockObject = new Lock();
         FileName = fileName;
         CreateReaderStream(fileName);
         Init();
@@ -56,7 +57,7 @@ public class AudioFileReader : WaveStream, ISampleProvider
     public AudioFileReader(Stream inputStream)
     {
         ArgumentNullException.ThrowIfNull(inputStream);
-        lockObject = new object();
+        lockObject = new Lock();
         CreateReaderStream(inputStream);
         Init();
     }


### PR DESCRIPTION
## Summary

This PR replaces private and internal lock `object`s with the [Lock class](https://learn.microsoft.com/en-us/dotnet/api/system.threading.lock?view=net-10.0) which offers [better performance](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/lock#guidelines).

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [X] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

Unit tests pass the same as on the master branch.