### PR TITLE
Use Regex source generators

### DIFF
--- a/src/NAudio.Core/FileFormats/Sfz/SfzParser.cs
+++ b/src/NAudio.Core/FileFormats/Sfz/SfzParser.cs
@@ -27,13 +27,13 @@ public static partial class SfzParser
 {
     private const int MaxIncludeDepth = 32;
 
-    [GeneratedRegex(@"^\s*#define\s+(\$[A-Za-z0-9_]+)\s+(.+?)\s*$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^\s*#define\s+(\$[A-Za-z0-9_]+)\s+(.+?)\s*$")]
     private static partial Regex DefineRegex { get; }
-    [GeneratedRegex(@"^\s*#include\s+""([^""]+)""\s*$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^\s*#include\s+""([^""]+)""\s*$")]
     private static partial Regex IncludeRegex { get; }
-    [GeneratedRegex(@"\$[A-Za-z0-9_]+", RegexOptions.Compiled)]
+    [GeneratedRegex(@"\$[A-Za-z0-9_]+")]
     private static partial Regex VariableRegex { get; }
-    [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline)]
+    [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Singleline)]
     private static partial Regex BlockCommentRegex { get; }
 
     /// <summary>

--- a/src/NAudio.Core/FileFormats/Sfz/SfzParser.cs
+++ b/src/NAudio.Core/FileFormats/Sfz/SfzParser.cs
@@ -23,18 +23,18 @@ namespace NAudio.Sfz;
 /// ranges, tuning, envelopes…) and external sample loading are applied by
 /// later layers on top of the parsed model.
 /// </summary>
-public static class SfzParser
+public static partial class SfzParser
 {
     private const int MaxIncludeDepth = 32;
 
-    private static readonly Regex DefineRegex =
-        new(@"^\s*#define\s+(\$[A-Za-z0-9_]+)\s+(.+?)\s*$", RegexOptions.Compiled);
-    private static readonly Regex IncludeRegex =
-        new(@"^\s*#include\s+""([^""]+)""\s*$", RegexOptions.Compiled);
-    private static readonly Regex VariableRegex =
-        new(@"\$[A-Za-z0-9_]+", RegexOptions.Compiled);
-    private static readonly Regex BlockCommentRegex =
-        new(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline);
+    [GeneratedRegex(@"^\s*#define\s+(\$[A-Za-z0-9_]+)\s+(.+?)\s*$", RegexOptions.Compiled)]
+    private static partial Regex DefineRegex { get; }
+    [GeneratedRegex(@"^\s*#include\s+""([^""]+)""\s*$", RegexOptions.Compiled)]
+    private static partial Regex IncludeRegex { get; }
+    [GeneratedRegex(@"\$[A-Za-z0-9_]+", RegexOptions.Compiled)]
+    private static partial Regex VariableRegex { get; }
+    [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline)]
+    private static partial Regex BlockCommentRegex { get; }
 
     /// <summary>
     /// Parses SFZ text. <paramref name="includeResolver"/> supplies the text


### PR DESCRIPTION
## Summary

Replace Regex constructors with source generators for [better performance](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators).

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [X] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

SFZ unit tests are green.
