### PR TITLE
Finish the System.Threading.Lock sweep (follow-up to #1421)

### DIFF
--- a/samples/NAudioConsoleTest/Asio/Tests/AsioValidateSamplePositionTest.cs
+++ b/samples/NAudioConsoleTest/Asio/Tests/AsioValidateSamplePositionTest.cs
@@ -44,7 +44,7 @@ internal sealed class AsioValidateSamplePositionTest : IConsoleTest
         });
 
         var samples = new List<Sample>(capacity: 8192);
-        var lockObj = new object();
+        var lockObj = new Lock();
         device.AudioCaptured += (_, e) =>
         {
             lock (lockObj)

--- a/samples/NAudioConsoleTest/Wasapi/Tests/WasapiVolumeCallbackStressTest.cs
+++ b/samples/NAudioConsoleTest/Wasapi/Tests/WasapiVolumeCallbackStressTest.cs
@@ -61,7 +61,7 @@ internal sealed class WasapiVolumeCallbackStressTest : IConsoleTest
                                $"settleTime={settleTime.TotalMilliseconds:F0}ms[/]\n");
 
         var notifyCount = 0;
-        var sync = new object();
+        var sync = new Lock();
         float[] latestChannelVolumes = [];
         void OnNotify(AudioVolumeNotificationData data)
         {

--- a/samples/NAudioWpfDemo/Vst3HostDemo/Vst3EditorHost.cs
+++ b/samples/NAudioWpfDemo/Vst3HostDemo/Vst3EditorHost.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Interop;
 using NAudio.Vst3;
 
@@ -21,7 +22,7 @@ internal class Vst3EditorHost : HwndHost
     // probably other parent-snooping plug-ins) embed cleanly — STATIC has subtle differences
     // a few editors trip over, e.g. cbWndExtra/cbClsExtra defaults and the absence of CS_DBLCLKS.
     private const string ContainerClassName = "NAudio.Vst3.EditorHostContainer";
-    private static readonly object classRegLock = new();
+    private static readonly Lock classRegLock = new();
     private static bool classRegistered;
     private static WndProcDelegate containerWndProc; // rooted so the JIT can't GC the delegate while Win32 holds the fn ptr
 

--- a/samples/NAudioWpfDemo/Vst3Shared/Vst3InstalledPlugins.cs
+++ b/samples/NAudioWpfDemo/Vst3Shared/Vst3InstalledPlugins.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using NAudio.Vst3;
 
@@ -50,7 +51,7 @@ internal static class Vst3InstalledPlugins
 {
     private const int CacheVersion = 1;
 
-    private static readonly object syncRoot = new();
+    private static readonly Lock syncRoot = new();
     private static IReadOnlyList<Vst3InstalledPlugin> cached;
     private static Task<IReadOnlyList<Vst3InstalledPlugin>> inflight;
 

--- a/src/NAudio.Core/Wave/SampleProviders/MixingSampleProvider.cs
+++ b/src/NAudio.Core/Wave/SampleProviders/MixingSampleProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics.Tensors;
+using System.Threading;
 using NAudio.Utils;
 
 namespace NAudio.Wave.SampleProviders;
@@ -11,6 +12,10 @@ namespace NAudio.Wave.SampleProviders;
 public class MixingSampleProvider : ISampleProvider
 {
     private readonly List<ISampleProvider> sources;
+    // A dedicated lock rather than lock(sources): the list itself is handed out
+    // publicly by MixerInputs, so locking on it means anyone holding that
+    // reference shares the mixer's own lock.
+    private readonly Lock inputsLock = new();
     private float[] sourceBuffer;
     private const int MaxInputs = 1024; // protect ourselves against doing something silly
 
@@ -68,7 +73,7 @@ public class MixingSampleProvider : ISampleProvider
     {
         // we'll just call the lock around add since we are protecting against an AddMixerInput at
         // the same time as a Read, rather than two AddMixerInput calls at the same time
-        lock (sources)
+        lock (inputsLock)
         {
             if (sources.Count >= MaxInputs)
             {
@@ -107,7 +112,7 @@ public class MixingSampleProvider : ISampleProvider
     /// <param name="mixerInput">Mixer input to remove</param>
     public void RemoveMixerInput(ISampleProvider mixerInput)
     {
-        lock (sources)
+        lock (inputsLock)
         {
             sources.Remove(mixerInput);
         }
@@ -118,7 +123,7 @@ public class MixingSampleProvider : ISampleProvider
     /// </summary>
     public void RemoveAllMixerInputs()
     {
-        lock (sources)
+        lock (inputsLock)
         {
             sources.Clear();
         }
@@ -136,7 +141,7 @@ public class MixingSampleProvider : ISampleProvider
     {
         int outputSamples = 0;
         sourceBuffer = BufferHelpers.Ensure(sourceBuffer, buffer.Length);
-        lock (sources)
+        lock (inputsLock)
         {
             int index = sources.Count - 1;
             while (index >= 0)

--- a/src/NAudio.Dmo/DirectSound/DirectSoundOut.cs
+++ b/src/NAudio.Dmo/DirectSound/DirectSoundOut.cs
@@ -40,8 +40,13 @@ public partial class DirectSoundOut : IWavePlayer
     private readonly SynchronizationContext syncContext;
     private long bytesPlayed;
 
-    // Used purely for locking
-    private readonly Object m_LockObject = new();
+    // Used purely for locking. Deliberately a plain object rather than a
+    // System.Threading.Lock: Stop() needs the bounded Monitor.TryEnter(obj, 50)
+    // below, and Monitor.Enter/TryEnter on a Lock takes that instance's object
+    // header instead of the Lock itself — a different mutex from the one the
+    // lock statements here use, silently losing mutual exclusion. Switch this
+    // to Lock only together with Stop(), using Lock.TryEnter(TimeSpan).
+    private readonly object m_LockObject = new();
 
     /// <summary>
     /// Gets the DirectSound output devices in the system

--- a/src/NAudio.WinMM/Compression/AcmInterop.cs
+++ b/src/NAudio.WinMM/Compression/AcmInterop.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace NAudio.Wave.Compression;
 
@@ -22,7 +23,7 @@ namespace NAudio.Wave.Compression;
 /// <see cref="AcmLock"/> and forwards to it.
 /// </para>
 /// <para>
-/// The lock is reentrant (<see cref="System.Threading.Monitor"/>), so
+/// The lock is reentrant (<see cref="System.Threading.Lock"/>), so
 /// msacm32 callbacks such as <see cref="AcmDriverEnumCallback"/>,
 /// <see cref="AcmFormatEnumCallback"/> and
 /// <see cref="AcmFormatTagEnumCallback"/> are free to call back into this
@@ -35,7 +36,7 @@ internal class AcmInterop
     /// Process-wide lock guarding every msacm32 P/Invoke. See the class
     /// remarks on <see cref="AcmInterop"/> for why this exists.
     /// </summary>
-    internal static readonly object AcmLock = new();
+    internal static readonly Lock AcmLock = new();
 
     // http://msdn.microsoft.com/en-us/library/dd742891%28VS.85%29.aspx
     public delegate bool AcmDriverEnumCallback(IntPtr hAcmDriverId, IntPtr instance, AcmDriverDetailsSupportFlags flags);


### PR DESCRIPTION
## Summary

Follow-up to #1421, which converted most private lock objects to `System.Threading.Lock` but left a few behind.

**Converted (6):**

- `AcmInterop.AcmLock` — the process-wide lock serialising every msacm32 P/Invoke (~20 `lock` sites, taken per buffer during ACM conversion). Its class remarks documented the reentrancy guarantee via `<see cref="System.Threading.Monitor"/>`; `Lock` is equally reentrant, so the cref is updated rather than the claim.
- `Vst3InstalledPlugins.syncRoot` and `Vst3EditorHost.classRegLock` — statics in NAudioWpfDemo.
- `AsioValidateSamplePositionTest.lockObj` and `WasapiVolumeCallbackStressTest.sync` — locals in NAudioConsoleTest, captured by a lambda and a local function respectively.
- `MixingSampleProvider` — this one is not a straight type swap. The four sites locked on `sources`, but `MixerInputs => sources` hands that same `List<ISampleProvider>` instance to callers, so the mixer's lock was reachable from outside the assembly. It now uses a private `Lock inputsLock`, named to match `WaveMixerStream32`.

**Documented, not converted (1):**

`DirectSoundOut.m_LockObject` deliberately stays a plain `object`. `Stop()` uses the bounded `Monitor.TryEnter(obj, 50)`, and `Monitor.Enter`/`TryEnter` on a `Lock` takes that instance's object header rather than the `Lock` itself — a different mutex from the one the `lock` statements use, silently losing mutual exclusion with no compiler error. A comment now records this and names the migration path (`Lock.TryEnter(TimeSpan)`, changed together with `Stop()`). It was declared `Object` rather than `object`, which is why #1421's search skipped it.

After this, `DirectSoundOut` is the only object-based lock left in `src/` or `samples/`.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

No public or internal signature changes; all six are private or internal fields/locals.

The `MixingSampleProvider` change is source- and binary-compatible but technically behavioural: a caller doing `lock (mixer.MixerInputs)` currently gets real mutual exclusion with `Read`/`AddMixerInput`, and after this will not. That is obscure enough not to warrant an entry — flagging it here rather than in the release notes.

## Testing

- Full solution, Release, `-p:EnableWindowsTargeting=true`: **0 warnings, 0 errors**. Relevant because CS9216 fires on any `Lock`→`object` conversion and `TreatWarningsAsErrors` is on, so a clean build is positive evidence that none of these is being handed to `Monitor` or an `object` parameter.
- `NAudio.Core.Tests`: 1517 total, 0 failed, in both Debug and Release. `origin/main` measured as a baseline first (also 1517/0), so the delta is clean.
- Built and tested on Linux, so `AcmInterop` and the WPF/console samples are compile-verified only here — CI on `windows-latest` covers the rest.


---
_Generated by [Claude Code](https://claude.ai/code/session_014WCRUp6W6PDsG7FnDyxxfd)_