### PR TITLE
Bump workflow actions to their Node 24 majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore
         run: dotnet restore NAudio.slnx
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: ${{ runner.temp }}/TestResults/*.trx
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Publish Native AOT smoke test
         # The csproj already sets PublishAot and RuntimeIdentifier=win-x64, so

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,14 +32,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check every tutorial is in the TOC
         shell: bash
         run: ./.github/scripts/check-docs-toc.sh
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '9.0.x'
 
@@ -52,9 +52,12 @@ jobs:
       - name: Upload Pages artifact
         # Only needed for the deploy job, which only runs on main.
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docfx/_site
+          # v3 archived dotfiles; v5 drops them unless asked. DocFX doesn't
+          # emit any today, but keep the old behaviour rather than find out.
+          include-hidden-files: true
 
   deploy:
     # Publish to GitHub Pages only from main.
@@ -70,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0   # full history so gh release --generate-notes can diff against the previous tag
 
@@ -190,7 +190,7 @@ jobs:
           }
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nupkg-${{ steps.version.outputs.version }}
           path: |


### PR DESCRIPTION
## Summary

GitHub has deprecated Node 20 on Actions runners — every Node20-based action now runs under Node 24 anyway and logs a deprecation warning on each job. This bumps the five actions we use to the majors that declare `node24`, so the warnings go away and the pinned runtime matches what the runner actually uses.

| Action | Was | Now | Used in |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | build.yml (×2), docs.yml, release.yml |
| `actions/setup-dotnet` | v4 | **v6** | docs.yml |
| `actions/upload-artifact` | v4 | **v7** | build.yml, release.yml |
| `actions/upload-pages-artifact` | v3 | **v5** | docs.yml |
| `actions/deploy-pages` | v4 | **v5** | docs.yml |

`NuGet/login@v1` already resolves to a `node24` build, so it is left alone.

This is a warning cleanup, not a fix for anything currently broken. (The `id-token` timeout that failed the Docs deploy in run 211 was an unrelated transient OIDC service timeout, which succeeded on re-run.)

### Compatibility checked before bumping

- **No input we pass was removed or renamed** across the intervening majors — they are Node-runtime bumps and CommonJS→ESM migrations. Our call sites only use `name`, `path`, `if-no-files-found`, `dotnet-version` and `fetch-depth`, all still current. Nothing in the repo uses `download-artifact`, which is where the artifact v3→v4 breakage normally bites.
- **Minimum runner 2.327.1** is required by the new majors. Every job runs on `windows-latest` or `ubuntu-latest`, so this is satisfied automatically; it would only matter if self-hosted runners were ever added.
- **One behaviour change reaches us:** `upload-pages-artifact` v3 archived dotfiles unconditionally, while v5 excludes them unless `include-hidden-files` is set. DocFX doesn't emit any today (resources are two PNGs and one template CSS, no `.nojekyll`, and Pages-via-Actions doesn't run Jekyll), so this is almost certainly a no-op — but the input is set explicitly rather than finding out the hard way. Happy to drop that line if you'd rather keep the bump pure.

Each new major tag was verified by reading its `action.yml` and confirming `runs.using: node24`, rather than inferring it from the version number.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

CI-only change with no user-visible effect, so no changelog entry — labelled `release-notes-skip`.

## Testing

All three workflow files re-parse as valid YAML.

The `build` workflow runs on this PR and exercises `checkout@v7` and `upload-artifact@v7` directly. `docs.yml`'s build job (including `setup-dotnet@v6`) also runs on PRs since the workflow watches `.github/workflows/docs.yml`. The two Pages actions can't be proven until merge — `upload-pages-artifact` is gated on `github.ref == 'refs/heads/main'` and the `deploy` job only runs on `main` — so worth a glance at the first Docs run after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqRTtXHq6bXX2n1xTVjVV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqRTtXHq6bXX2n1xTVjVV4)_