### PR TITLE
Probe exclusive formats with a real channel mask in the quick scan

### DIFF
--- a/samples/NAudioConsoleTest/Wasapi/Tests/WasapiExclusiveFormatHelper.cs
+++ b/samples/NAudioConsoleTest/Wasapi/Tests/WasapiExclusiveFormatHelper.cs
@@ -25,7 +25,7 @@ internal static class WasapiExclusiveFormatHelper
 
     public static readonly (int mask, string name)[] ChannelMasks =
     [
-        (0, "(default)"),
+        (0, "(unspecified)"),
         ((int)Speakers.Mono, "1.0 Mono (FC)"),
         ((int)Speakers.Stereo, "2.0 Stereo (FL|FR)"),
         ((int)(Speakers.FrontCenter | Speakers.LowFrequency), "1.1 (FC|LFE)"),
@@ -47,9 +47,18 @@ internal static class WasapiExclusiveFormatHelper
     public static WaveFormatExtensible CreateFormat(int rate, int bits, int channels, string encoding, int channelMask = 0)
         => new(rate, bits, channels, useIeeeFloat: encoding == "Float", validBitsPerSample: bits, channelMask);
 
+    /// <summary>
+    /// The canonical channel mask for a channel count &mdash; the first <paramref name="channels"/>
+    /// speaker positions, which is what <see cref="WaveFormatExtensible(int, int, int, int)"/> derives
+    /// when no mask is given and what <c>WasapiPlayer</c> therefore ends up probing with.
+    /// Many drivers (e.g. Realtek) reject a <c>dwChannelMask</c> of 0 outright, so probing with 0
+    /// reports nothing supported even on devices with plenty of exclusive-mode formats.
+    /// </summary>
+    public static int DefaultChannelMask(int channels) => (1 << channels) - 1;
+
     public static List<(int mask, string name)> GetMasksForChannelCount(int channelCount)
     {
-        var masks = new List<(int, string)> { (0, "(default)") };
+        var masks = new List<(int, string)> { (0, "(unspecified)") };
         foreach (var (mask, name) in ChannelMasks)
         {
             if (mask == 0) continue;

--- a/samples/NAudioConsoleTest/Wasapi/Tests/WasapiExclusiveQuickScanTest.cs
+++ b/samples/NAudioConsoleTest/Wasapi/Tests/WasapiExclusiveQuickScanTest.cs
@@ -1,4 +1,4 @@
-﻿using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi;
 using NAudioConsoleTest.Shared.Testing;
 using Spectre.Console;
 
@@ -33,7 +33,11 @@ internal sealed class WasapiExclusiveQuickScanTest : IConsoleTest
             foreach (var (bits, encoding) in WasapiExclusiveFormatHelper.BitDepthEncodings)
                 foreach (var ch in WasapiExclusiveFormatHelper.ChannelCounts)
                 {
-                    var format = WasapiExclusiveFormatHelper.CreateFormat(rate, bits, ch, encoding);
+                    // Probe with the canonical layout for the channel count, not dwChannelMask = 0:
+                    // drivers like Realtek reject an unspecified mask outright, so a zero mask made
+                    // the scan report nothing on devices that in fact support plenty of formats.
+                    var mask = WasapiExclusiveFormatHelper.DefaultChannelMask(ch);
+                    var format = WasapiExclusiveFormatHelper.CreateFormat(rate, bits, ch, encoding, mask);
                     if (client.IsFormatSupported(AudioClientShareMode.Exclusive, format))
                     {
                         table.AddRow($"{rate}Hz {bits}bit {encoding} {ch}ch", "[green]YES[/]");
@@ -42,7 +46,7 @@ internal sealed class WasapiExclusiveQuickScanTest : IConsoleTest
                 }
 
         if (supportedCount == 0)
-            AnsiConsole.MarkupLine("[yellow]No formats supported with default channel masks. " +
+            AnsiConsole.MarkupLine("[yellow]No formats supported with the canonical channel layouts. " +
                                    "Try 'Channel mask deep-dive' — your device may need a specific layout.[/]");
         else
             AnsiConsole.Write(table);


### PR DESCRIPTION
## Problem

The WASAPI **Quick scan exclusive formats** test in `NAudioConsoleTest` reported *no supported formats* on a Realtek XU built-in laptop device, which in reality supports a long list of exclusive-mode formats.

`WasapiExclusiveFormatHelper.CreateFormat` builds its probe format with the `WaveFormatExtensible(rate, bits, channels, useIeeeFloat, validBitsPerSample, channelMask)` overload, which writes `channelMask` through verbatim. The quick scan left it at its `0` default, so every probe went out as a `WAVEFORMATEXTENSIBLE` with `dwChannelMask = 0`. Realtek's driver rejects an unspecified mask outright.

The deep-dive test isolates it — same format, only the mask differs:

```
44100 16 PCM 0x0000 (default)          no
44100 16 PCM 0x0003 2.0 Stereo (FL|FR) YES
```

The library's own probing (`WasapiFormatAdaptation.FindSupportedExclusiveFormatAtSampleRate`) uses the 4-argument `WaveFormatExtensible` constructor, which derives `(1 << channels) - 1` when given 0, so it was never affected — this is a sample-app-only bug.

## Fix

Probe with the canonical layout for the channel count, via a new `WasapiExclusiveFormatHelper.DefaultChannelMask(int channels)` — the same mask the 4-argument constructor derives, and therefore the same one `WasapiPlayer` ends up probing with.

Also relabelled the deep-dive's mask-0 row from `(default)` to `(unspecified)`: it is the absence of a layout rather than the default one, which was exactly the confusion that hid this.

## Verification

Ran the scan against two real devices before and after:

| Device | Before | After |
| --- | --- | --- |
| Speakers (Realtek XU) | 0 formats | 48 formats (16/24-bit PCM, 44.1k–192k, 2/4/6/8ch) |
| Monitors L/R (SSL 18 USB) | 1 format | 2 formats (picks up 48kHz 32-bit PCM) |

Not vacuous: 32-bit float and mono still correctly report unsupported on the Realtek, and the SSL still only offers its current 48kHz rate.

No release-notes entry — sample-app only, nothing in a shipped package changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016w6GCBGbvk1GxbzBEia1mf
