### PR TITLE
Make the trim and Native AOT analyzer warnings reach the build

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,4 +1,4 @@
-is_global = true
+﻿is_global = true
 global_level = 0
 
 # =============================================================================
@@ -104,6 +104,33 @@ dotnet_diagnostic.IDE0063.severity = warning
 
 # IDE0031: Use null propagation
 dotnet_diagnostic.IDE0031.severity = warning
+
+# --- Trim / Native AOT analyzer (ILLink) ---
+# These have to be named explicitly. The catch-all default above is 'suggestion',
+# which is IDE-only, so IL2xxx/IL3xxx never reached the build and
+# TreatWarningsAsErrors never saw them: NAudio.WinMM was marked IsAotCompatible
+# and reported zero warnings while six IL3050s sat in it. Issue #1425 is what
+# happens when nobody is watching this family.
+#
+# They stay at 'warning' rather than 'error' because TreatWarningsAsErrors
+# already fails the build, and warning is the severity the SDK itself assigns —
+# so a project that legitimately needs to NoWarn one still can.
+#
+# Only projects setting IsAotCompatible/IsTrimmable/PublishAot run the analyzer
+# at all, so the sample and tool projects are unaffected.
+#
+# Note this only covers APIs annotated [RequiresDynamicCode]/[RequiresUnreferencedCode].
+# It cannot see the marshalling bugs behind #1425 and #1432 — publishing
+# NAudioAotSmokeTest and running it is what catches those.
+
+# IL2xxx: trim analysis (reflection over trimmed members)
+dotnet_analyzer_diagnostic.category-Trimming.severity = warning
+
+# IL3000-IL3002: single-file analysis (Assembly.Location and friends)
+dotnet_analyzer_diagnostic.category-SingleFile.severity = warning
+
+# IL3050+: Native AOT analysis (runtime code generation, e.g. Marshal.SizeOf(Type))
+dotnet_analyzer_diagnostic.category-AOT.severity = warning
 
 # --- Rules promoted to ERROR (genuine breakage, not style) ---
 # Source-generated COM interop diagnostics that mean the code is actually

--- a/src/NAudio.WinMM/Compression/WaveFilter.cs
+++ b/src/NAudio.WinMM/Compression/WaveFilter.cs
@@ -11,7 +11,7 @@ public class WaveFilter
     /// <summary>
     /// cbStruct
     /// </summary>
-    public int StructureSize = Marshal.SizeOf(typeof(WaveFilter));
+    public int StructureSize = Marshal.SizeOf<WaveFilter>();
     /// <summary>
     /// dwFilterTag
     /// </summary>

--- a/src/NAudio.WinMM/Midi/MidiIn.cs
+++ b/src/NAudio.WinMM/Midi/MidiIn.cs
@@ -113,7 +113,7 @@ public class MidiIn : IMidiInput
         if (SysexBufferHeaders.Length > 0) return;
 
         SysexBufferHeaders = new IntPtr[DefaultSysexBufferCount];
-        var hdrSize = Marshal.SizeOf(typeof(MidiInterop.MIDIHDR));
+        var hdrSize = Marshal.SizeOf<MidiInterop.MIDIHDR>();
         for (var i = 0; i < DefaultSysexBufferCount; i++)
         {
             var hdr = new MidiInterop.MIDIHDR();
@@ -156,7 +156,7 @@ public class MidiIn : IMidiInput
                 // parameter 2 is milliseconds since MidiInStart
                 if (SysexMessageReceived != null)
                 {
-                    MidiInterop.MIDIHDR hdr = (MidiInterop.MIDIHDR)Marshal.PtrToStructure(messageParameter1, typeof(MidiInterop.MIDIHDR));
+                    var hdr = Marshal.PtrToStructure<MidiInterop.MIDIHDR>(messageParameter1);
 
                     //  Copy the bytes received into an array so that the buffer is immediately available for re-use
                     var sysexBytes = new byte[hdr.dwBytesRecorded];
@@ -169,7 +169,7 @@ public class MidiIn : IMidiInput
                     //  BUT When disposing the (resetting the MidiIn port), LONGDATA midi message are fired with a zero length.
                     //  In that case, buffer should no be ReAdd to avoid an inifinite loop of callback as buffer are reused forever.
                     if (!disposeIsRunning)
-                        MidiInterop.midiInAddBuffer(hMidiIn, messageParameter1, Marshal.SizeOf(typeof(MidiInterop.MIDIHDR)));
+                        MidiInterop.midiInAddBuffer(hMidiIn, messageParameter1, Marshal.SizeOf<MidiInterop.MIDIHDR>());
                 }
                 break;
             case MidiInterop.MidiInMessage.LongError:
@@ -217,8 +217,8 @@ public class MidiIn : IMidiInput
                 //  Free up all created and allocated buffers for incoming Sysex messages
                 foreach (var lpHeader in SysexBufferHeaders)
                 {
-                    MidiInterop.MIDIHDR hdr = (MidiInterop.MIDIHDR)Marshal.PtrToStructure(lpHeader, typeof(MidiInterop.MIDIHDR));
-                    MmException.Try(MidiInterop.midiInUnprepareHeader(hMidiIn, lpHeader, Marshal.SizeOf(typeof(MidiInterop.MIDIHDR))), "midiInPrepareHeader");
+                    var hdr = Marshal.PtrToStructure<MidiInterop.MIDIHDR>(lpHeader);
+                    MmException.Try(MidiInterop.midiInUnprepareHeader(hMidiIn, lpHeader, Marshal.SizeOf<MidiInterop.MIDIHDR>()), "midiInPrepareHeader");
                     Marshal.FreeHGlobal(hdr.lpData);
                     Marshal.FreeHGlobal(lpHeader);
                 }

--- a/tests/NAudioAotSmokeTest/README.md
+++ b/tests/NAudioAotSmokeTest/README.md
@@ -48,12 +48,20 @@ The program runs in several phases against the default render endpoint:
 
 CI covers this project in two ways.
 
-**The `build` job** compiles it alongside the rest of the solution. With
-`<IsAotCompatible>true</IsAotCompatible>` and `<PublishAot>true</PublishAot>`
-set, the trim/AOT analyzer runs on every build. Any new `[RequiresUnreferencedCode]`-annotated
-call from `NAudio.Wasapi`, `NAudio.WinMM` or `NAudio.Core` (e.g. someone re-introducing
-`Marshal.GetObjectForIUnknown`-shaped reflection paths) will surface as an
-`IL2026` / `IL3050` warning, which is treated as an error here.
+**The `build` job** compiles it alongside the rest of the solution. Two settings
+have to line up for that to mean anything. `<IsAotCompatible>true</IsAotCompatible>`
+(or `<PublishAot>`) turns the ILLink analyzer on for a project, and
+[.globalconfig](../../.globalconfig) promotes its `Trimming`, `SingleFile` and
+`AOT` categories to warning. Without the second, the repo's catch-all
+`dotnet_analyzer_diagnostic.severity = suggestion` swallows them: they show in
+the IDE, never reach the build, and `TreatWarningsAsErrors` never sees them.
+That was the state until the categories were named explicitly, and it is worth
+knowing because the symptom is a clean build rather than an error — `NAudio.WinMM`
+was marked `IsAotCompatible` and reported zero warnings while six `IL3050`s sat
+in it. With both in place, a new `[RequiresUnreferencedCode]`- or
+`[RequiresDynamicCode]`-annotated call from any of the AOT-compatible projects
+(e.g. someone re-introducing `Marshal.GetObjectForIUnknown`-shaped reflection, or
+`Marshal.SizeOf(Type)` in place of `Marshal.SizeOf<T>()`) fails the build.
 
 **The `aot` job** publishes it with `PublishAot`, which runs ILC for real. This
 exists because the analyzer only sees *annotated* APIs, and a lot of AOT breakage


### PR DESCRIPTION
## Summary

`.globalconfig` sets `dotnet_analyzer_diagnostic.severity = suggestion` as a catch-all, and that swallowed the ILLink analyzer's whole `IL2xxx`/`IL3xxx` family along with everything else. The analyzer was running the entire time and producing diagnostics — they just landed at suggestion severity, which is IDE-only, so they never became build warnings and `TreatWarningsAsErrors` never saw them.

The symptom is a clean build rather than an error, which is why it went unnoticed: `NAudio.WinMM` was marked `IsAotCompatible` in #1427 and reported zero warnings while six `IL3050`s sat in it, and [tests/NAudioAotSmokeTest/README.md](../blob/main/tests/NAudioAotSmokeTest/README.md) claimed those diagnostics were "treated as an error here".

The fix names the three ILLink categories explicitly rather than listing dozens of rule IDs:

```ini
dotnet_analyzer_diagnostic.category-Trimming.severity = warning
dotnet_analyzer_diagnostic.category-SingleFile.severity = warning
dotnet_analyzer_diagnostic.category-AOT.severity = warning
```

They stay at `warning` rather than `error` because `TreatWarningsAsErrors` already fails the build, warning is the severity the SDK itself assigns, and it leaves a project able to `NoWarn` a genuinely safe case. The `.globalconfig` comment records why they have to be named at all, so nobody later deletes them as redundant.

Only projects setting `IsAotCompatible`/`IsTrimmable`/`PublishAot` run the analyzer, so the sample and tool projects are unaffected.

### The six hits

All behaviour-preserving swaps to the generic overloads the analyzer recommends:

| File | Before | After |
| --- | --- | --- |
| `MidiIn.cs` (×3) | `Marshal.SizeOf(typeof(MIDIHDR))` | `Marshal.SizeOf<MIDIHDR>()` |
| `MidiIn.cs` (×2) | `(MIDIHDR)Marshal.PtrToStructure(p, typeof(MIDIHDR))` | `Marshal.PtrToStructure<MIDIHDR>(p)` |
| `WaveFilter.cs` | `Marshal.SizeOf(typeof(WaveFilter))` | `Marshal.SizeOf<WaveFilter>()` |

### What this does *not* buy

The analyzer only sees APIs annotated `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]`. It is blind to the marshalling bugs behind #1425 and #1432, and to Hazard H11 in `MODERNIZATION.md` — all of which passed it cleanly while broken. Publishing `NAudioAotSmokeTest` and running the executable remains the only thing that catches those. The README now says so, and says what has to be configured for the analyzer to bite at all, instead of implying it has the whole problem covered.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

Build configuration plus internal overload swaps — nothing observable to consumers of the packages.

## Testing

**Verified the config actually bites, in both directions.** This mattered more than usual, since the failure mode being fixed *is* silence — a config that quietly does nothing looks identical to a clean codebase. Temporarily reintroducing violations in `NAudio.WinMM`:

| Probe | Before this PR | After |
| --- | --- | --- |
| `Marshal.SizeOf(typeof(WaveFilter))` | builds clean | **`error IL3050`, Build FAILED** |
| a `[RequiresUnreferencedCode]`-annotated call | builds clean | **`error IL2026`, Build FAILED** |

**Checked the blast radius across the whole solution,** not just `src/` — exactly six warnings, all in `NAudio.WinMM`, no fallout in the test or sample projects.

**Checked the one swap that isn't trivially identical.** `MIDIHDR` is a struct, so those five are equivalent by inspection. `WaveFilter` is a *class*, and its `StructureSize` field is a live `cbStruct` handed to `acmStreamOpen`, so a changed value would be a real bug. Both overloads return 32 under the JIT and under NativeAOT — measured before swapping, not assumed.

Full solution builds clean at 0 warnings; 1539 `NAudio.Core.Tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wc2YvXR3bnMNBgCas7GsiN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wc2YvXR3bnMNBgCas7GsiN)_