### PR TITLE
Bump VersionPrefix to 3.1.1 for post-3.1.0 development

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- Lockstep version for all NAudio NuGet packages. CI overrides
          <VersionSuffix> on pre-release builds (e.g. preview.NN). Sample/tool
          apps with their own <Version> in the csproj override this. -->
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
 
     <!-- The sample/tool apps target net9.0 so they still build on the .NET 9
          SDK, but the default roll-forward policy (Minor) refuses to cross a


### PR DESCRIPTION
## Summary

Step 3c of [ReleaseInstructions.md](../blob/main/ReleaseInstructions.md) — the post-release version bump, so `main` is ready for 3.1.x bugfixes.

One line in `Directory.Build.props`: `<VersionPrefix>` `3.1.0` → `3.1.1`.

3.1.0 shipped from tag `v3.1.0` on 7 Sep 2026. Preview builds are versioned `<VersionPrefix>-preview.<run_number>`, so leaving the prefix at `3.1.0` would make the next `release.yml` dispatch produce `3.1.0-preview.<N>` — which under SemVer 2 sorts *below* the `3.1.0` already on NuGet, making it invisible on a prerelease feed. With the prefix at `3.1.1`, previews sort above the release.

Patch rather than minor because it only needs to exceed what shipped. The number can be raised later if the next release carries features — the release workflow validates the tag against this value at that point, so a mismatch fails fast rather than shipping the wrong version.

This mirrors #1411, which did the same after 3.0.1.

## Release notes

- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)

The prefix only sets the version of the *next* release, which the release notes name in their own heading. Same call as #1411.

## Testing

Single-property MSBuild change, no code touched. What I checked:

- `VersionPrefix` is the only version declaration in the file, and per `CLAUDE.md` the NAudio packages carry no per-csproj `<Version>` — so all 13 packages stay in lockstep off this one value.
- The branch is restarted from `main` at `0aaef29d` (the merged #1436), so this sits directly on the released tree with nothing else in the diff.
- No `RELEASE_NOTES.md` change, so the `### Unreleased` section stays empty and the release workflow's pre-release path is unaffected.

Not blocking, but worth noting: the `v3.1.0` release run ([run 28](https://github.com/naudio/NAudio/actions/runs/34095196426)) was still in progress when I opened this. Worth confirming it went green and all 13 packages reached NuGet before merging this on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174ozB992rLJgjjBoJM75a2

---
_Generated by [Claude Code](https://claude.ai/code/session_0174ozB992rLJgjjBoJM75a2)_