### PR TITLE
Ship NAudio.MacOS as pre-release only, and add macOS tutorials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,10 +155,16 @@ jobs:
       # Pack the NAudio NuGet packages explicitly so we don't accidentally
       # ship the tool/sample apps. Tools (MixDiff, AudioFileInspector,
       # MidiFileConverter) keep their own <Version> in csproj but we never
-      # publish them to NuGet. NAudio.Alsa and NAudio.SoundFile are the
-      # cross-platform backend/codec packages — net9.0 (no -windows TFM),
-      # so they build and pack fine on the windows-latest runner; their
+      # publish them to NuGet. NAudio.Alsa, NAudio.SoundFile and NAudio.MacOS
+      # are the cross-platform backend/codec packages — net9.0 (no -windows
+      # TFM), so they build and pack fine on the windows-latest runner; their
       # *.Tests projects are IsPackable=false and excluded here.
+      #
+      # NAudio.MacOS is the one package that does not follow the lockstep
+      # version: it always packs pre-release, even on a final tag run. That
+      # is enforced in its own csproj rather than here, so nothing in this
+      # workflow needs to know about the exception — see the comment in
+      # src/NAudio.MacOS/NAudio.MacOS.csproj.
       - name: Pack
         shell: pwsh
         run: |
@@ -173,6 +179,7 @@ jobs:
             'NAudio.Vst3',
             'NAudio.Alsa',
             'NAudio.SoundFile',
+            'NAudio.MacOS',
             'NAudio.Sampler',
             'NAudio',
             'NAudio.Extras'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,7 @@ When opening a PR (where you have permission), apply one of: `breaking`, `enhanc
 
 ## Versioning
 
-Package versions are centralised in [Directory.Build.props](Directory.Build.props) as `<VersionPrefix>`. Do **not** add a per-csproj `<Version>` to NAudio packages — they're meant to stay in lockstep. The tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` and are exempt.
-
-`NAudio.MacOS` sets a `<VersionSuffix>` fallback in its csproj so that it always packs pre-release, even on a final tag run, while its API settles. That is deliberate, not a stray override to tidy up — it still shares the lockstep `<VersionPrefix>` and needs no per-release maintenance. See [ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md#naudiomacos-the-one-package-that-stays-pre-release) before changing it, and mark macOS entries in `RELEASE_NOTES.md` as `(preview)` — that section is embedded as `PackageReleaseNotes` in every package, stable ones included.
+Package versions are centralised in [Directory.Build.props](Directory.Build.props) as `<VersionPrefix>`. Do **not** add a per-csproj `<Version>` to NAudio packages — they're meant to stay in lockstep. The tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` and are exempt, as is the `<VersionSuffix>` in `NAudio.MacOS.csproj` that keeps that package pre-release ([why](Docs/Architecture/ReleaseStrategy.md#naudiomacos-the-one-package-that-stays-pre-release)).
 
 ## Building & testing on Linux
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ When opening a PR (where you have permission), apply one of: `breaking`, `enhanc
 
 Package versions are centralised in [Directory.Build.props](Directory.Build.props) as `<VersionPrefix>`. Do **not** add a per-csproj `<Version>` to NAudio packages — they're meant to stay in lockstep. The tool/sample apps (MixDiff, AudioFileInspector, MidiFileConverter) keep their own explicit `<Version>` and are exempt.
 
+`NAudio.MacOS` sets a `<VersionSuffix>` fallback in its csproj so that it always packs pre-release, even on a final tag run, while its API settles. That is deliberate, not a stray override to tidy up — it still shares the lockstep `<VersionPrefix>` and needs no per-release maintenance. See [ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md#naudiomacos-the-one-package-that-stays-pre-release) before changing it, and mark macOS entries in `RELEASE_NOTES.md` as `(preview)` — that section is embedded as `PackageReleaseNotes` in every package, stable ones included.
+
 ## Building & testing on Linux
 
 Some cloud and CI environments start without a .NET SDK on the PATH — this isn't a property of the repo but of the host. The default Anthropic cloud-agent sandbox is one example, and other infrastructure (GitHub Copilot agents, fresh CI runners, etc.) may differ now or in the future. So **first check whether `dotnet` is available**; only install it if it isn't. On Debian/Ubuntu, install .NET 10 via apt: add Microsoft's feed with `wget -q https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O /tmp/ms.deb && sudo dpkg -i /tmp/ms.deb && sudo apt-get update`, then `sudo apt-get install -y dotnet-sdk-10.0` (the SDK builds the `net9.0` libraries fine).

--- a/Docs/Architecture/ReleaseStrategy.md
+++ b/Docs/Architecture/ReleaseStrategy.md
@@ -60,6 +60,40 @@ All packages share one version, declared once in `Directory.Build.props` as `<Ve
 
 CI sets `<VersionSuffix>` for pre-release builds via `dotnet pack -p:VersionSuffix=preview.NN`; final-release builds set neither suffix.
 
+### `NAudio.MacOS`: the one package that stays pre-release
+
+`NAudio.MacOS` landed in #1398 as a large, brand-new native-interop surface, and it wants a settling-in period before its API is covered by the stable-release promise — while the rest of NAudio carries on shipping finals. So it is the single exception to lockstep: it tracks the shared `<VersionPrefix>` like everything else, but never packs a stable version.
+
+The obvious implementation — an explicit `<Version>` in the csproj — is the wrong one. A full `<Version>` overrides both `<VersionPrefix>` and `<VersionSuffix>`, so CI's `-p:VersionSuffix=preview.NN` would be ignored and the number would have to be hand-bumped before every release. Worse, forgetting is silent: `dotnet nuget push --skip-duplicate` turns the resulting 409 into a success, so a release would appear to ship a macOS package it had actually skipped.
+
+Pinning only the *suffix* avoids all of that. In `NAudio.MacOS.csproj`:
+
+```xml
+<VersionSuffix Condition="'$(VersionSuffix)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">preview.$(GITHUB_RUN_NUMBER)</VersionSuffix>
+<VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.0</VersionSuffix>
+```
+
+A command-line `-p:VersionSuffix` is a global property, so on preview runs it wins and both lines are inert. Only a final tag run — the one case where CI passes no suffix — falls through to the fallback. Reading `GITHUB_RUN_NUMBER` from the environment follows the same idiom as `<ContinuousIntegrationBuild>` in `Directory.Build.props`, and gives a counter that is unique per release-workflow run and only ever increases, so each macOS package sorts above the previous one and can never collide with a version already on NuGet.
+
+What the two triggers now produce (verified by packing the real projects at `<VersionPrefix>3.1.1</VersionPrefix>`):
+
+| Trigger | Other 13 packages | `NAudio.MacOS` |
+| --- | --- | --- |
+| `workflow_dispatch` (no milestone) | `3.1.1-preview.44` | `3.1.1-preview.44` |
+| `workflow_dispatch -f milestone=rc.1` | `3.1.1-rc.1` | `3.1.1-rc.1` |
+| `push` tag `v3.1.1` | `3.1.1` | `3.1.1-preview.<run_number>` |
+| local `dotnet pack` | `3.1.1` | `3.1.1-preview.0` |
+
+Keeping the rule in the csproj rather than special-casing the workflow's `Pack` loop matters for one concrete reason: a `-p:VersionSuffix` passed to just that `dotnet pack` invocation would be global to it, so `NAudio.Core` would evaluate with the suffix too and the packed dependency would read `NAudio.Core >= 3.1.1-preview.57` — a floor pointing at a version that was never published. Project-local, it stays `NAudio.Core >= 3.1.1`. The assembly's `AssemblyInformationalVersion` also matches the package version, because build and pack evaluate the same property; `AssemblyVersion` is unaffected by a suffix and stays `3.1.1.0` in lockstep with the rest.
+
+Constraints while this holds:
+
+- **The `NAudio` meta-package must not reference `NAudio.MacOS`.** A stable meta-package with a pre-release dependency drags pre-release semantics into everyone's graph, and plenty of shops block that outright. The meta-package has no macOS leg today; adding one is the graduation event, not a step along the way.
+- **`RELEASE_NOTES.md` bullets for macOS want a `(preview)` marker.** The same extracted section is embedded as `PackageReleaseNotes` in *every* package, so macOS entries appear on the stable packages' NuGet pages too.
+- **The `v*` GitHub Release lists the macOS `.nupkg` as an asset** alongside the stable ones, since the release step attaches everything in `artifacts/`. That is deliberate — it is an accurate record of what the run produced.
+
+**Graduating it:** delete the `<VersionSuffix>` PropertyGroup from `NAudio.MacOS.csproj`, add the `net9.0-macos` leg to the `NAudio` meta-package, and drop the pre-release wording from the package `<Description>` and README. It rejoins lockstep at the next release with no version discontinuity — the first stable `NAudio.MacOS` is simply whatever `<VersionPrefix>` is current, which sorts above every preview that came before it.
+
 ### Pre-release: manual trigger, auto-incrementing counter
 
 Pre-releases are triggered manually via `workflow_dispatch`. The workflow uses `github.run_number` as the auto-incrementing preview counter, producing versions like `3.0.0-preview.142`. A `milestone` input on the dispatch lets the maintainer override the suffix when cutting a named milestone (`alpha.1`, `beta.2`, `rc.1`).
@@ -284,6 +318,6 @@ The pragmatic path: disable the pipeline first, wait a couple of weeks, then del
 ## Out of scope
 
 - Migrating CHANGELOG generation tooling beyond the GitHub built-in (`.github/release.yml`). If we outgrow it, swap in something heavier later.
-- Per-package independent versioning. Lockstep is the chosen model; revisit only if it becomes painful.
+- Per-package independent versioning. Lockstep is the chosen model; revisit only if it becomes painful. `NAudio.MacOS` is a deliberate and self-maintaining exception — it shares the lockstep *version* and only pins the pre-release suffix, so it is not independent versioning in the sense rejected here.
 - Automatic changelog enforcement via CI block. Explicitly rejected as friction without value.
 - Appending the auto-generated PR list to GitHub Release bodies. `gh release create` makes `--notes-file` and `--generate-notes` mutually exclusive; adding both would require fetching auto-notes via `gh api` and concatenating. Possible follow-up if the curated notes alone prove insufficient.

--- a/Docs/PlayAudioFileMacOS.md
+++ b/Docs/PlayAudioFileMacOS.md
@@ -1,0 +1,94 @@
+## Play an Audio File on macOS with Core Audio
+
+On macOS there is no WASAPI or WaveOut. The `NAudio.MacOS` package adds
+`CoreAudioPlayer`, an `IWavePlayer` that plays through the Core Audio
+HAL. It is referenced explicitly (it is not part of the `NAudio`
+meta-package), and it ships pre-release only while its API settles, so
+`--prerelease` is required:
+
+```sh
+dotnet add package NAudio.MacOS --prerelease
+```
+
+`CoreAudioPlayer` plays any `IWaveProvider`. For a WAV file, use
+`WaveFileReader` from `NAudio.Core`:
+
+```c#
+using NAudio.Wave;
+
+using (var audioFile = new WaveFileReader("test.wav"))
+using (var outputDevice = new CoreAudioPlayer())   // default output device
+{
+    outputDevice.Init(audioFile);
+    outputDevice.Play();
+    while (outputDevice.PlaybackState == PlaybackState.Playing)
+    {
+        Thread.Sleep(200);
+    }
+}
+```
+
+There is no device-format negotiation to worry about: when the
+provider's format does not match the device's, `CoreAudioPlayer`
+configures a Core Audio converter internally and resamples for you.
+
+### Playing compressed formats
+
+`AudioFileReader` is not the answer here — its cross-platform build
+handles only PCM WAV and AIFF, and throws `NotSupportedException` for
+MP3 and everything else.
+
+Use `ExtendedAudioFileReaderFromURL` instead. It is a `WaveStream` over
+macOS Extended Audio File Services — the macOS equivalent of
+`MediaFoundationReader` — decoding to PCM with no extra install, because
+the codecs are part of the OS:
+
+```c#
+using NAudio.Wave;
+
+using var audioFile = ExtendedAudioFileReaderFromURL.CreateFromFile("test.m4a");
+using var outputDevice = new CoreAudioPlayer();
+outputDevice.Init(audioFile);
+outputDevice.Play();
+```
+
+That covers MP3, AAC/M4A, ALAC, FLAC and AIFF among others. The exact
+set depends on the macOS version, and can be queried at runtime:
+
+```c#
+using NAudio.MacOS.AudioToolbox;
+
+foreach (var extension in AudioFileLibraryInformation.RecognizedFileExtensions)
+{
+    Console.WriteLine(extension);
+}
+```
+
+Pass an `ExtendedAudioFileReaderSettings` to control what comes back —
+`RequestIeeeFloat` for 32-bit float, or `OutputFormat` for a specific
+`WaveFormat`, converted as the file is read.
+`ExtendedAudioFileReaderFromStream` does the same over a `Stream`.
+
+### Choosing an output device
+
+The default device comes from the system object; enumerate `Devices` to
+pick another one and pass it to the constructor:
+
+```c#
+using NAudio.MacOS.CoreAudio;
+
+foreach (var device in AudioSystemObject.Instance.Devices)
+{
+    if (device.GetStreams(AudioObjectPropertyScopeConstants.Output).Length > 0)
+    {
+        Console.WriteLine($"{device.Name} - {device.Manufacturer}");
+    }
+}
+// using var outputDevice = new CoreAudioPlayer(chosenDevice);
+```
+
+Note that `CoreAudioPlayer.Volume` is the *device's* volume, not a
+software gain like `AlsaOut.Volume` — setting it moves the system
+output level for that device. Handle `PlaybackStopped` to be notified
+when playback ends or fails; its `Exception` is `null` on a normal end
+of stream or an explicit `Stop()`.

--- a/Docs/RecordAudioFileMacOS.md
+++ b/Docs/RecordAudioFileMacOS.md
@@ -1,0 +1,114 @@
+## Record an Audio File on macOS with Core Audio
+
+The `NAudio.MacOS` package provides `CoreAudioRecorder`, which records
+from a Core Audio input device. It ships pre-release only while its API
+settles, so `--prerelease` is required:
+
+```sh
+dotnet add package NAudio.MacOS --prerelease
+```
+
+`CoreAudioRecorder` is **not** an `IWaveIn`, so the pattern differs from
+`WaveIn` and `AlsaIn` in two ways. There is an explicit
+`InitializeRecording()` step before `StartRecording()`, and the capture
+format is not something you request — the HAL decides it, and you read
+it back from `CaptureFormat` once initialized:
+
+```c#
+using NAudio.Wave;
+
+using var input = new CoreAudioRecorder();   // default input device
+input.InitializeRecording();
+
+var writer = new WaveFileWriter("recorded.wav", input.CaptureFormat);
+
+input.DataAvailable += (audioData, currentTime, firstByteTime) =>
+{
+    writer.Write(audioData);
+};
+
+input.RecordingStopped += (sender, a) =>
+{
+    writer.Dispose();
+    writer = null;
+};
+
+input.StartRecording();
+Thread.Sleep(5000);                          // record for 5 seconds
+input.StopRecording();
+```
+
+`audioData` is a `ReadOnlySpan<byte>` pointing at a buffer owned by the
+HAL, so write or copy it before the handler returns — storing the span
+itself will later read memory that has been reused.
+
+Alternatively, `CaptureAsync` yields `CoreAudioCaptureBuffer` objects,
+each with its own `byte[] Buffer`, and initializes the recorder for you:
+
+```c#
+using var input = new CoreAudioRecorder();
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+await foreach (var buffer in input.CaptureAsync(cts.Token))
+{
+    writer.Write(buffer.Buffer, 0, buffer.Buffer.Length);
+}
+```
+
+Both forms also hand you HAL timestamps (in seconds) for the start of
+the I/O cycle and for the first byte captured, which is what you need to
+line a recording up against another clock.
+
+### Recording straight to a compressed file
+
+`ExtendedAudioFileWriter` encodes as it writes, using the codecs built
+into macOS — so you can record to AAC/M4A, FLAC or CAF with no
+third-party encoder. It is a `Stream`, and the target container is
+chosen by MIME type:
+
+```c#
+using NAudio.Wave;
+using NAudio.MacOS.AudioToolbox;
+
+using var writer = ExtendedAudioFileWriter.CreateFromFilePath(
+    "recorded.m4a",
+    new ExtendedAudioFileWriterSettings
+    {
+        FileType = "audio/mp4",             // one of SupportedMimeTypes, see below
+        ProvidingFormat = input.CaptureFormat,
+    },
+    overwriteIfExists: true);
+```
+
+`ProvidingFormat` describes what you feed in, and must be PCM or IEEE
+float. The accepted `FileType` strings vary by macOS version — read them
+from `AudioFileLibraryInformation.SupportedMimeTypes` rather than
+hard-coding one.
+
+For plain uncompressed output, prefer `WaveFileWriter`: WAV is what
+every other tool reads. `AiffFileWriter` in `NAudio.Core` is there if
+you want AIFF, and handles the byte-order swap to AIFF's big-endian
+layout for you.
+
+### Choosing an input device, and permissions
+
+Enumerate `Devices` and pass one to the constructor:
+
+```c#
+using NAudio.MacOS.CoreAudio;
+
+foreach (var device in AudioSystemObject.Instance.Devices)
+{
+    if (device.GetStreams(AudioObjectPropertyScopeConstants.Input).Length > 0)
+    {
+        Console.WriteLine($"{device.Name} - {device.Manufacturer}");
+    }
+}
+// using var input = new CoreAudioRecorder(chosenDevice);
+```
+
+macOS gates microphone access, and the prompt is attributed to the host
+application — for a command-line tool that is the terminal, not your
+program. If access has been denied, capture typically yields silence
+rather than an error, so check System Settings › Privacy & Security ›
+Microphone if your recording comes out empty.

--- a/Docs/toc.yml
+++ b/Docs/toc.yml
@@ -112,3 +112,9 @@
       href: RecordAudioFileLinuxAlsa.md
     - name: Validating ALSA on Linux
       href: ValidatingAlsaOnLinux.md
+- name: macOS (Core Audio)
+  items:
+    - name: Play an audio file on macOS (Core Audio)
+      href: PlayAudioFileMacOS.md
+    - name: Record an audio file on macOS (Core Audio)
+      href: RecordAudioFileMacOS.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ the NuGet `PackageReleaseNotes` field, which has a hard 35,000-character
 limit and fails the release build if exceeded.
 -->
 
- * **macOS support** - A new wrappers library (is in pre-release stage for NAudio 3) is added wrapping macOS native API's for playback/recording, reading/writing files and resampling audio. Special thanks to @mdcdi1315 (#1325) for the work and the tests. For more information, see the [design](Docs/Architecture/MacOSWrappersDesign.md) doc that describes the decisions that helped shape the wrappers. (#1398)
+ * **macOS support (preview)** - A new wrappers library is added wrapping macOS native API's for playback/recording, reading/writing files and resampling audio. The `NAudio.MacOS` package ships pre-release only (`X.Y.Z-preview.N`) while its API settles, so it stays pre-release alongside stable releases of the other packages. Special thanks to @mdcdi1315 (#1325) for the work and the tests. For more information, see the [design](Docs/Architecture/MacOSWrappersDesign.md) doc that describes the decisions that helped shape the wrappers. (#1398)
 
 ### 3.1.0 (7 Sep 2026)
 

--- a/ReleaseInstructions.md
+++ b/ReleaseInstructions.md
@@ -10,9 +10,11 @@ Prerequisites: `gh` CLI authenticated, working directory inside the repo, on `ma
 gh workflow run release.yml
 ```
 
-Produces `<VersionPrefix>-preview.<run_number>` — e.g. `3.0.0-preview.5`. Watch in the [Actions tab](https://github.com/naudio/NAudio/actions/workflows/release.yml). On success, all 13 packages (`.nupkg` + `.snupkg`) appear on NuGet within a few minutes.
+Produces `<VersionPrefix>-preview.<run_number>` — e.g. `3.0.0-preview.5`. Watch in the [Actions tab](https://github.com/naudio/NAudio/actions/workflows/release.yml). On success, all 14 packages (`.nupkg` + `.snupkg`) appear on NuGet within a few minutes.
 
-The 13 packed packages are `NAudio.Core`, `NAudio.Midi`, `NAudio.WinMM`, `NAudio.Wasapi`, `NAudio.Asio`, `NAudio.Dmo`, `NAudio.WinForms`, `NAudio.Vst3`, `NAudio.Alsa`, `NAudio.SoundFile`, `NAudio.Sampler`, `NAudio.Extras` and the `NAudio` meta-package. The list lives in the `Pack` step of [release.yml](.github/workflows/release.yml) — a new package must be added there or it silently won't ship.
+The 14 packed packages are `NAudio.Core`, `NAudio.Midi`, `NAudio.WinMM`, `NAudio.Wasapi`, `NAudio.Asio`, `NAudio.Dmo`, `NAudio.WinForms`, `NAudio.Vst3`, `NAudio.Alsa`, `NAudio.SoundFile`, `NAudio.MacOS`, `NAudio.Sampler`, `NAudio.Extras` and the `NAudio` meta-package. The list lives in the `Pack` step of [release.yml](.github/workflows/release.yml) — a new package must be added there or it silently won't ship.
+
+**`NAudio.MacOS` is the one exception to lockstep versioning:** it always ships pre-release, including on a final tag run, where it packs as `<VersionPrefix>-preview.<run_number>` while everything else packs stable. Nothing needs doing to keep that true — it is enforced by a `<VersionSuffix>` fallback in [NAudio.MacOS.csproj](src/NAudio.MacOS/NAudio.MacOS.csproj). See [ReleaseStrategy.md](Docs/Architecture/ReleaseStrategy.md#naudiomacos-the-one-package-that-stays-pre-release).
 
 ## 2. Named pre-release milestone
 
@@ -50,7 +52,7 @@ The tag push triggers `release.yml`, which:
 
 - Validates the tag matches `<VersionPrefix>` in `Directory.Build.props`.
 - Validates `RELEASE_NOTES.md` has a matching `### 3.0.0` section, and that it fits NuGet's 35,000-character `PackageReleaseNotes` limit.
-- Packs all 13 NAudio packages (+ matching `.snupkg` symbol packages).
+- Packs all 14 NAudio packages (+ matching `.snupkg` symbol packages), `NAudio.MacOS` pre-release and the rest stable.
 - Pushes everything to NuGet via trusted publishing.
 - Creates a GitHub Release titled `NAudio 3.0.0` with body extracted from the `RELEASE_NOTES.md` section, with the 13 `.nupkg` files attached as release assets (symbol packages are not attached — they go to NuGet's symbol server).
 

--- a/src/NAudio.MacOS/NAudio.MacOS.csproj
+++ b/src/NAudio.MacOS/NAudio.MacOS.csproj
@@ -6,7 +6,33 @@
     <IsAotCompatible>true</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>macOS playback and recording support types for the NAudio audio library. macOS-only at runtime.</Description>
+    <Description>macOS playback and recording support types for the NAudio audio library. macOS-only at runtime. This package is pre-release while its API settles.</Description>
+  </PropertyGroup>
+
+  <!--
+    Pre-release only. Unlike every other NAudio package, NAudio.MacOS never packs
+    a stable version while its API settles: it tracks the shared <VersionPrefix>
+    from Directory.Build.props but always carries a pre-release suffix.
+
+    On a preview run the release workflow already passes -p:VersionSuffix (which
+    is a global property, so it wins) and both lines below are inert. On a final
+    tag run there is no suffix, so we supply one: GITHUB_RUN_NUMBER is unique per
+    release-workflow run and only ever increases, so each package sorts above the
+    previous preview and can never collide with a version already pushed to NuGet
+    (a collision would be swallowed silently by the push step's skip-duplicate
+    flag, so the package would appear to ship without actually shipping).
+
+    Setting the *suffix* rather than a whole <Version> is what keeps this
+    maintenance-free — nothing here needs bumping per release — and it is
+    project-local, so NAudio.Core is still evaluated without it and the packed
+    dependency stays a clean `NAudio.Core >= <VersionPrefix>`.
+
+    To graduate the package into the lockstep stable line, delete this
+    PropertyGroup (see Docs/Architecture/ReleaseStrategy.md).
+  -->
+  <PropertyGroup>
+    <VersionSuffix Condition="'$(VersionSuffix)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">preview.$(GITHUB_RUN_NUMBER)</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.0</VersionSuffix>
   </PropertyGroup>
 
   <!-- needed for perfomance profiling unit tests -->

--- a/tests/NAudio.MacOS.Tests/NAudio.MacOS.Tests.csproj
+++ b/tests/NAudio.MacOS.Tests/NAudio.MacOS.Tests.csproj
@@ -12,6 +12,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
+    <IsPackable>false</IsPackable>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
     <!-- Required for channel layout tests currently -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## Summary

Follow-up to #1398. Two related pieces of work.

**1. `NAudio.MacOS` ships pre-release only, while the rest of NAudio keeps cutting finals.**

It becomes the single exception to lockstep versioning: it tracks the shared `<VersionPrefix>` like every other package, but never packs a stable version. Nothing needs bumping per release.

The obvious implementation — an explicit `<Version>` in the csproj — is the wrong one. A full `<Version>` overrides both `<VersionPrefix>` and `<VersionSuffix>`, so CI's `-p:VersionSuffix=preview.NN` would be ignored and the number would need hand-bumping before every release. Forgetting would be silent, because the push step's `--skip-duplicate` turns the resulting 409 into a success, and the package would appear to ship without shipping.

Pinning only the *suffix* avoids that. A command-line `-p:VersionSuffix` is a global property, so on preview runs it wins and the fallback is inert; only a final tag run — the one case where CI passes no suffix — falls through to `preview.$(GITHUB_RUN_NUMBER)`, which is unique per release-workflow run and only ever increases. Reading the run number from the environment follows the same idiom as `<ContinuousIntegrationBuild>` in `Directory.Build.props`.

Keeping the rule in the csproj rather than special-casing the workflow's `Pack` loop also keeps the dependency floor honest: a `-p:VersionSuffix` passed to that one invocation would be global to it, so `NAudio.Core` would evaluate with the suffix too and the packed dependency would read `NAudio.Core >= 3.1.1-preview.57` — a floor pointing at a version that was never published.

`NAudio.MacOS` is also added to the release workflow's pack list, which it needs regardless — without it the package silently never ships. The two changes have to land together: the pack-list entry without the suffix fallback would publish a stable `NAudio.MacOS` on the next tag, and NuGet versions cannot be withdrawn, only unlisted.

`IsPackable=false` on `NAudio.MacOS.Tests` is included here too. It evaluated to `true` — it uses the NUnit MTP runner rather than `Microsoft.NET.Test.Sdk`, so nothing sets it implicitly — unlike its `NAudio.Alsa.Tests` and `NAudio.SoundFile.Tests` siblings. Nothing packs it today, but `release.yml`'s comment already claimed the `*.Tests` projects were `IsPackable=false`, and now that is true.

**2. macOS playback and recording tutorials.**

#1398 landed an architecture doc and a package README but no tutorials, while ALSA, ASIO and WASAPI each have a playback/recording pair. `Docs/PlayAudioFileMacOS.md` and `Docs/RecordAudioFileMacOS.md` fill that gap, in a new "macOS (Core Audio)" TOC group. They concentrate on what does *not* carry over from the other backends:

- `AudioFileReader` is a trap on macOS — the cross-platform build handles only PCM WAV and AIFF and throws `NotSupportedException` for MP3 and everything else, so the playback page points at `ExtendedAudioFileReaderFromURL` (the macOS `MediaFoundationReader` equivalent, with codecs supplied by the OS rather than by a package like `NAudio.SoundFile`).
- `CoreAudioRecorder` is not an `IWaveIn`: there's an explicit `InitializeRecording()` step, the capture format is read back from the HAL via `CaptureFormat` rather than requested, `DataAvailable` hands over a `ReadOnlySpan<byte>` that must be copied before the handler returns, and `CaptureAsync` offers an `IAsyncEnumerable` alternative.
- `CoreAudioPlayer.Volume` moves the device's own level, unlike the software gain of `AlsaOut.Volume`.
- Microphone access is gated by macOS and attributed to the terminal for a command-line tool, which surfaces as silence rather than an error.

Recording examples use `WaveFileWriter`, with `ExtendedAudioFileWriter` shown for encoding straight to AAC/M4A, FLAC or CAF — something neither the Windows nor the Linux docs can offer without a third-party encoder.

## Release notes

- [x] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [ ] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

The existing macOS bullet was retitled `(preview)` and now states that the package ships pre-release only. That section is embedded as `PackageReleaseNotes` in *every* package, stable ones included, so macOS entries want that marker.

## Testing

Packed the real projects at `<VersionPrefix>3.1.1</VersionPrefix>` on the .NET 10 SDK:

| Scenario | `NAudio.Core` | `NAudio.MacOS` |
| --- | --- | --- |
| final tag run (no suffix) | `3.1.1` | `3.1.1-preview.57` |
| dispatch `-p:VersionSuffix=preview.44` | `3.1.1-preview.44` | `3.1.1-preview.44` |
| local `dotnet pack` | `3.1.1` | `3.1.1-preview.0` |

The final-run nuspec reads `<dependency id="NAudio.Core" version="3.1.1" />` — the stable floor, not a phantom pre-release one — and the packed assembly carries `AssemblyInformationalVersion 3.1.1-preview.57+9ed0e5e` with `AssemblyVersion` still `3.1.1.0`, in lockstep with the rest.

Also:

- `IsPackable` re-evaluated as `false` for `NAudio.MacOS.Tests` after the change (it was `true`).
- `release.yml` re-parsed as YAML; the pack list reads as 14 entries.
- `./.github/scripts/check-docs-toc.sh` passes: "All 47 tutorials in Docs/ are referenced by Docs/toc.yml."
- Every code sample from both new tutorials was compiled against the real `NAudio.MacOS` and `NAudio.Core` projects — 0 warnings, 0 errors. Not executed: no macOS host here, so the `FileType` MIME literal in the compressed-recording sample is illustrative, and the docs tell readers to read `AudioFileLibraryInformation.SupportedMimeTypes` rather than trust it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uBGTeFheug7XhbDxHPua5

---
_Generated by [Claude Code](https://claude.ai/code/session_015uBGTeFheug7XhbDxHPua5)_