### PR TITLE
Docs: make WasapiPlayer/WasapiRecorder the default in tutorials

### DIFF
--- a/Docs/AudioEffects.md
+++ b/Docs/AudioEffects.md
@@ -18,7 +18,7 @@ var audio = new AudioFileReader("example.mp3");
 var reverb = new ReverbEffect { Mix = 0.25f };
 var output = new EffectSampleProvider(audio, reverb);
 
-var device = new WaveOutEvent();
+var device = new WasapiPlayerBuilder().Build();
 device.Init(output);
 device.Play();
 ```

--- a/Docs/ConcatenatingAudio.md
+++ b/Docs/ConcatenatingAudio.md
@@ -14,6 +14,7 @@ var third = new AudioFileReader("third.mp3");
 var playlist = new ConcatenatingSampleProvider(new[] { first, second, third });
 
 // to play:
+var outputDevice = new WasapiPlayerBuilder().Build();
 outputDevice.Init(playlist);
 outputDevice.Play();
 

--- a/Docs/ConvertBetweenStereoAndMono.md
+++ b/Docs/ConvertBetweenStereoAndMono.md
@@ -17,8 +17,9 @@ using(var inputReader = new AudioFileReader(monoFilePath))
     stereo.RightVolume = 1.0f; // full volume in right channel
 
     // can either use this for playback:
-    myOutputDevice.Init(stereo);
-    myOutputDevice.Play();
+    var outputDevice = new WasapiPlayerBuilder().Build();
+    outputDevice.Init(stereo);
+    outputDevice.Play();
     // ...
 
     // ... OR ... could write the stereo audio out to a WAV file
@@ -45,8 +46,9 @@ using(var inputReader = new AudioFileReader(stereoFilePath))
     mono.RightVolume = 1.0f; // keep the right channel
 
     // can either use this for playback:
-    myOutputDevice.Init(mono);
-    myOutputDevice.Play();
+    var outputDevice = new WasapiPlayerBuilder().Build();
+    outputDevice.Init(mono);
+    outputDevice.Play();
     // ...
 
     // ... OR ... could write the mono audio out to a WAV file
@@ -76,8 +78,9 @@ using(var inputReader = new AudioFileReader(monoFilePath))
     panner.Pan = -0.5f; // pan 50% left
 
     // can either use this for playback:
-    myOutputDevice.Init(panner);
-    myOutputDevice.Play();
+    var outputDevice = new WasapiPlayerBuilder().Build();
+    outputDevice.Init(panner);
+    outputDevice.Play();
     // ...
 
     // ... OR ... could write the stereo audio out to a WAV file

--- a/Docs/EnumerateOutputDevices.md
+++ b/Docs/EnumerateOutputDevices.md
@@ -1,8 +1,61 @@
 # Enumerating Audio Devices
 
-The technique you use to enumerate audio devices depends on what audio output (or input) driver type you are using. This article shows the technique for each supported output device.
+The technique you use to enumerate audio devices depends on what audio output (or input) driver type you are using. This article shows the technique for each supported output device. On Windows, start with the WASAPI section — `WasapiPlayer` and `WasapiRecorder` are the recommended playback and capture devices, and `MMDeviceEnumerator` is how you discover the endpoints they use.
+
+## WASAPI Devices
+
+WASAPI playback (render) and recording (capture) devices can both be accessed via the `MMDeviceEnumerator` class. This allows you to enumerate only the type of devices you want (`DataFlow.Render` or `DataFlow.Capture` or `DataFlow.All`).
+
+You can also choose whether you want to include devices that are active, or also include disabled, unplugged or otherwise not present devices with the `DeviceState` bitmask. Here we show them all:
+
+```c#
+var enumerator = new MMDeviceEnumerator();
+foreach (var wasapi in enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.All))
+{
+    Console.WriteLine($"{wasapi.DataFlow} {wasapi.FriendlyName} {wasapi.DeviceFriendlyName} {wasapi.State}");
+}
+```
+
+Unlike the WinMM device names below, these names are not truncated.
+
+To open the device you want, pass the device in to the appropriate WASAPI builder depending on whether you are playing back or recording...
+
+```c#
+var outputDevice = new WasapiPlayerBuilder().WithDevice(mmDevice).Build();
+var recordingDevice = new WasapiRecorderBuilder().WithDevice(captureDevice).Build();
+var loopbackCapture = new WasapiRecorderBuilder().WithDevice(loopbackDevice).WithLoopbackCapture().Build();
+```
+
+You can also use the MMEnumerator to request what the default device is for a number of different scenarios (playback or record, and voice, multimedia or 'console'):
+
+```c#
+enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+```
+
+If you just want the default device, you don't need to enumerate at all — building a `WasapiPlayer` or `WasapiRecorder` with no `WithDevice` call uses the system default. See [WasapiPlayer](WasapiPlayer.md) and [WasapiRecorder](WasapiRecorder.md).
+
+## ASIO
+
+You can discover the registered ASIO drivers on your system with `AsioDevice.GetDriverNames`. There is no guarantee that the associated soundcard is currently connected to the system.
+
+```c#
+foreach (var asio in AsioDevice.GetDriverNames())
+{
+    Console.WriteLine(asio);
+}
+```
+
+You can then use the driver name to open the device:
+
+```c#
+using var device = AsioDevice.Open(driverName);
+```
+
+(`AsioDevice` is the NAudio 3 ASIO API. The legacy `AsioOut` class still works — see [Migrating from AsioOut to AsioDevice](AsioMigration.md).)
 
 ## WaveOut
+
+`WaveOut` wraps the legacy WinMM APIs. Prefer WASAPI for new code, but the enumeration API is here if you need it.
 
 To discover the number of output devices you can use `WaveOut.DeviceCount`. Then you can call `WaveOut.GetCapabilities` passing in the index of a device to find out its name (and some basic information about its capabilities).
 
@@ -42,7 +95,7 @@ Once you've selected the device you want, you can open it by creating an instanc
 var recordingDevice = new WaveIn() { DeviceNumber = deviceNumber };
 ```
 
-# DirectSoundOut
+## DirectSoundOut
 
 `DirectSoundOut` exposes the `Devices` static method allowing you to enumerate through all the output devices. This has the benefit over `WaveOut` of not having truncated device names:
 
@@ -61,54 +114,7 @@ var outputDevice = new DirectSoundOut(deviceGuid);
 
 There are also a couple of special device GUIDs you can use to open the default playback device (`DirectSoundOut.DSDEVID_DefaultPlayback`) or default voice playback device (`DirectSoundOut.DSDEVID_DefaultVoicePlayback`)
 
-# WASAPI Devices
-
-WASAPI playback (render) and recording (capture) devices can both be accessed via the `MMDeviceEnumerator` class. This allows you to enumerate only the type of devices you want (`DataFlow.Render` or `DataFlow.Capture` or `DataFlow.All`).
-
-You can also choose whether you want to include devices that are active, or also include disabled, unplugged or otherwise not present devices with the `DeviceState` bitmask. Here we show them all:
-
-```c#
-var enumerator = new MMDeviceEnumerator();
-foreach (var wasapi in enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.All))
-{
-    Console.WriteLine($"{wasapi.DataFlow} {wasapi.FriendlyName} {wasapi.DeviceFriendlyName} {wasapi.State}");
-}
-```
-
-To open the device you want, pass the device in to the appropriate WASAPI builder depending on whether you are playing back or recording...
-
-```c#
-var outputDevice = new WasapiPlayerBuilder().WithDevice(mmDevice).Build();
-var recordingDevice = new WasapiRecorderBuilder().WithDevice(captureDevice).Build();
-var loopbackCapture = new WasapiRecorderBuilder().WithDevice(loopbackDevice).WithLoopbackCapture().Build();
-```
-
-You can also use the MMEnumerator to request what the default device is for a number of different scenarios (playback or record, and voice, multimedia or 'console'):
-
-```c#
-enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-```
-
-# ASIO
-
-You can discover the registered ASIO drivers on your system with `AsioDevice.GetDriverNames`. There is no guarantee that the associated soundcard is currently connected to the system.
-
-```c#
-foreach (var asio in AsioDevice.GetDriverNames())
-{
-    Console.WriteLine(asio);
-}
-```
-
-You can then use the driver name to open the device:
-
-```c#
-using var device = AsioDevice.Open(driverName);
-```
-
-(`AsioDevice` is the NAudio 3 ASIO API. The legacy `AsioOut` class still works — see [Migrating from AsioOut to AsioDevice](AsioMigration.md).)
-
-# Management Objects
+## Management Objects
 
 Finally you can use Windows Management Objects to get hold of details of the sound devices installed. This doesn't map specifically to any of the NAudio output device types, but can be a source of useful information
 

--- a/Docs/FadeInOutSampleProvider.md
+++ b/Docs/FadeInOutSampleProvider.md
@@ -17,9 +17,9 @@ fade.BeginFadeIn(2000);
 Now we can pass our `FadeInOutSampleProvider` to an output device and start playing. We'll hear the audio fading in over the first two seconds.
 
 ```c#
-var waveOutDevice = new WaveOut();
-waveOutDevice.Init(fade);
-waveOutDevice.Play();
+var outputDevice = new WasapiPlayerBuilder().Build();
+outputDevice.Init(fade);
+outputDevice.Play();
 ```
 
 At some point in the future, we might want to fade out, and we can trigger that with `BeginFadeOut`, again specifying a 2 second fadeout. 

--- a/Docs/MixMicrophoneAndSystemAudio.md
+++ b/Docs/MixMicrophoneAndSystemAudio.md
@@ -7,7 +7,7 @@ In this tutorial we will show how to capture audio from multiple devices (e.g. r
 `MixingSampleProvider` sums its inputs sample‑for‑sample. For that to be meaningful, **every input must have the same wave format**: the same sample rate, the same channel count, and 32‑bit IEEE float samples. Two capture devices almost never agree on this:
 
 - **System audio** — captured with [`WasapiRecorder`](WasapiRecorder.md) and `WithLoopbackCapture()` (or the legacy `WasapiLoopbackCapture`) — is delivered as **IEEE float at the render device's mix format**, commonly 48 kHz, stereo.
-- **The microphone** — captured with `WasapiRecorder` (or a legacy `WaveInEvent`) — has the **capture device's mix format**, often a different sample rate and channel count (e.g. 44.1 kHz, mono). A legacy `WaveInEvent` mic is usually **16‑bit PCM** as well.
+- **The microphone** — captured with `WasapiRecorder` (or a legacy `WaveIn`) — has the **capture device's mix format**, often a different sample rate and channel count (e.g. 44.1 kHz, mono). A legacy `WaveIn` mic is usually **16‑bit PCM** as well.
 
 So before mixing you have to bring both sources to a **common format**. The pipeline for each source is:
 
@@ -120,7 +120,7 @@ For diagnostics, `CaptureMixerInput` exposes `BufferedFrames` (and `HasReceivedD
 - **Loopback silence.** WASAPI loopback capture only raises `DataAvailable` while audio is actually playing, so `RealtimeCaptureMixer` fills those gaps with silence (the output stays paced to the wall clock) — a loopback source with nothing playing simply contributes silence.
 - **Clock drift.** The microphone and the soundcard are driven by independent clocks, but the wall-clock-paced output keeps both locked to real time (see above). This isn't sample-accurate; if you need tighter long-run A/V sync you'd add per-source adaptive resampling driven by the measured QPC-vs-samples error.
 - **Disposal order.** Stop both captures, let the pump loop finish, *then* dispose the recorders and the writer. `WasapiRecorder` also implements `IAsyncDisposable`, so prefer `await recorder.DisposeAsync()` (or `await using`) off a UI thread.
-- **Legacy capture devices.** `CaptureMixerInput` is device-agnostic: to mix a classic `IWaveIn` device (`WaveInEvent`, `WasapiLoopbackCapture`) add it with `mixer.AddInput(waveIn.WaveFormat)` and feed it the same way — `waveIn.DataAvailable += (s, a) => input.AddSamples(a.Buffer.AsSpan(0, a.BytesRecorded));`.
+- **Legacy capture devices.** `CaptureMixerInput` is device-agnostic: to mix a classic `IWaveIn` device (`WaveIn`, `WasapiLoopbackCapture`) add it with `mixer.AddInput(waveIn.WaveFormat)` and feed it the same way — `waveIn.DataAvailable += (s, a) => input.AddSamples(a.Buffer.AsSpan(0, a.BytesRecorded));`.
 
 ## Mixing vs. separate channels
 

--- a/Docs/PlayAudioFileConsoleApp.md
+++ b/Docs/PlayAudioFileConsoleApp.md
@@ -1,6 +1,6 @@
 ## Play an Audio File from a Console application
 
-To play a file from a console application, we will use `AudioFileReader` as a simple way of opening our audio file, and `WaveOut` as the output device.
+To play a file from a console application, we will use `AudioFileReader` as a simple way of opening our audio file, and `WasapiPlayer` as the output device. `WasapiPlayer` is the recommended output device on Windows — it's built with the fluent `WasapiPlayerBuilder`, and with no configuration at all it opens the default playback device in shared mode.
 
 We simply need to pass the `audioFile` into the `outputDevice` with the `Init` method, and then call `Play`. 
 
@@ -9,8 +9,10 @@ Since `Play` only means "start playing" and isn't blocking, we can wait in a loo
 Afterwards, we need to `Dispose` our `audioFile` and `outputDevice`, which in this example we do by virtue of putting them inside `using` blocks.
 
 ```c#
-using(var audioFile = new AudioFileReader(audioFile))
-using(var outputDevice = new WaveOut())
+using NAudio.Wave;
+
+using(var audioFile = new AudioFileReader(audioFilePath))
+using(var outputDevice = new WasapiPlayerBuilder().Build())
 {
     outputDevice.Init(audioFile);
     outputDevice.Play();
@@ -20,3 +22,15 @@ using(var outputDevice = new WaveOut())
     }
 }
 ```
+
+`WasapiPlayer` also implements `IAsyncDisposable`, so in an async `Main` you can `await using` it instead and avoid blocking while the playback thread is joined. See [Playing Audio with WasapiPlayer](WasapiPlayer.md) for the full set of builder options (device selection, exclusive mode, latency, low latency and raw mode).
+
+## Other output devices
+
+Every output device in NAudio implements `IWavePlayer`, so the code above works unchanged whichever one you pick — only the line that constructs the device changes:
+
+- **`WaveOut`** — the legacy WinMM device (`new WaveOut()`). Still supported, but has higher latency than WASAPI and no reason to be preferred in new code.
+- **`AsioDevice`** — for professional low-latency audio interfaces, see [Play audio with ASIO](AsioPlayback.md).
+- **`AlsaOut`** (`NAudio.Alsa`) on Linux, and **`CoreAudioPlayer`** (`NAudio.MacOS`) on macOS.
+
+[Choose an output device type](OutputDeviceTypes.md) compares them in more detail.

--- a/Docs/PlayAudioFileWinForms.md
+++ b/Docs/PlayAudioFileWinForms.md
@@ -10,7 +10,7 @@ using NAudio.Wave.SampleProviders;
 
 public class MainForm : Form
 {
-    private WaveOut outputDevice;
+    private WasapiPlayer outputDevice;
     private AudioFileReader audioFile;
 
     public MainForm()
@@ -43,7 +43,7 @@ public class MainForm : Form
 
 Now we've not defined the button handlers yet, so let's do that. First of all the Play button. The first time we click this, we won't have opened our output device or audio file.
 
-So we'll create an output device of type `WaveOut`. This is only one of several options for sending audio to the soundcard, but its a good choice in many scenarios, due to its ease of use and broad platform support.
+So we'll create an output device of type `WasapiPlayer`, using `WasapiPlayerBuilder`. This is the recommended way to play audio on Windows: with no builder configuration it opens the default playback device in shared mode, where WASAPI resamples whatever we give it to the device's format. Other output devices are available (see [Choose an output device type](OutputDeviceTypes.md)) and they all implement `IWavePlayer`, so only this line would change if you picked a different one.
 
 We'll also subscribe to the `PlaybackStopped` event, which we can use to do some cleaning up.
 
@@ -58,7 +58,7 @@ private void OnButtonPlayClick(object sender, EventArgs args)
 {
     if (outputDevice == null)
     {
-        outputDevice = new WaveOut();
+        outputDevice = new WasapiPlayerBuilder().Build();
         outputDevice.PlaybackStopped += OnPlaybackStopped;
     }
     if (audioFile == null)
@@ -110,7 +110,7 @@ Obviously it is important that when the form is closed we do properly stop playb
 Here's the code
 
 ```c#
-var wo = new WaveOut();
+var wo = new WasapiPlayerBuilder().Build();
 var af = new AudioFileReader(@"example.mp3");
 var closing = false;
 wo.PlaybackStopped += (s, a) => { if (closing) { wo.Dispose(); af.Dispose(); } };
@@ -135,7 +135,7 @@ In this example, we'll build on the previous one by adding in a volume slider. W
 
 When the user moves the trackbar, the `Scroll` event fires and we can adjust the volume in one of two ways.
 
-First, we can simply change the volume of our output device. It's important to note that this is a floating point value where 0.0f is silence and 1.0f is the maximum value. So we'll need to divide the value of our `TrackBar` by 100.
+First, we can simply change the volume of our output device. It's important to note that this is a floating point value where 0.0f is silence and 1.0f is the maximum value. So we'll need to divide the value of our `TrackBar` by 100. On `WasapiPlayer` this is your application's own slider in the Windows volume mixer, so it doesn't affect what other applications are playing.
 
 ```c#
 t.Scroll += (s, a) => wo.Volume = t.Value / 100f;
@@ -150,7 +150,7 @@ t.Scroll += (s, a) => af.Volume = t.Value / 100f;
 Let's see the revised version of our form:
 
 ```c#
-var wo = new WaveOut();
+var wo = new WasapiPlayerBuilder().Build();
 var af = new AudioFileReader(inputFilePath);
 var closing = false;
 wo.PlaybackStopped += (s, a) => { if (closing) { wo.Dispose(); af.Dispose(); } };

--- a/Docs/PlaySineWave.md
+++ b/Docs/PlaySineWave.md
@@ -12,7 +12,7 @@ var sine20Seconds = new SignalGenerator() {
     Frequency = 500,
     Type = SignalGeneratorType.Sin}
     .Take(TimeSpan.FromSeconds(20));
-using (var wo = new WaveOut())
+using (var wo = new WasapiPlayerBuilder().Build())
 {
     wo.Init(sine20Seconds);
     wo.Play();

--- a/Docs/PlaybackStopped.md
+++ b/Docs/PlaybackStopped.md
@@ -1,6 +1,6 @@
 # Handling Playback Stopped
 
-In NAudio, you use an implementation of the `IWavePlayer` class to play audio. Examples include `WaveOut`, `WasapiPlayer`, `AsioDevice` etc. To specify the audio to be played, you call the `Init` method passing in an `IWaveProvider`. And to start playing you call `Play`.
+In NAudio, you use an implementation of the `IWavePlayer` class to play audio. Examples include `WasapiPlayer`, `AsioDevice`, `WaveOut` etc. To specify the audio to be played, you call the `Init` method passing in an `IWaveProvider`. And to start playing you call `Play`.
 
 ## Manually Stopping Playback
 

--- a/Docs/RawSourceWaveStream.md
+++ b/Docs/RawSourceWaveStream.md
@@ -38,7 +38,7 @@ var rs = new RawSourceWaveStream(ms, new WaveFormat(sampleRate, 16, 1));
 And now we can play the `RawSourceWaveStream` just like it was any other `WaveStream`:
 
 ```c#
-var wo = new WaveOut();
+var wo = new WasapiPlayerBuilder().Build();
 wo.Init(rs);
 wo.Play();
 while (wo.PlaybackState == PlaybackState.Playing)

--- a/Docs/RecordWavFileWinFormsWaveIn.md
+++ b/Docs/RecordWavFileWinFormsWaveIn.md
@@ -1,6 +1,6 @@
-# Recording a WAV file in a WinForms app with WaveIn
+# Recording a WAV file in a WinForms app
 
-In this example we'll see how to create a very simple WinForms app that records audio to a WAV File.
+In this example we'll see how to create a very simple WinForms app that records audio to a WAV File. We'll use `WasapiRecorder`, which is the recommended capture device on Windows. It's created with the fluent `WasapiRecorderBuilder`, and with no configuration it records from the default capture device (your microphone) in shared mode. If you need the legacy WinMM device instead, there's a `WaveIn` version of the same app at the end of this article.
 
 First of all, let's choose where to put the recorded audio. It will go to a file called `recorded.wav` in a `NAudio` folder on your desktop:
 
@@ -10,10 +10,10 @@ Directory.CreateDirectory(outputFolder);
 var outputFilePath = Path.Combine(outputFolder,"recorded.wav");
 ```
 
-Next, let's create the recording device. I'm going to use `WaveIn` in this case. We could also use [`WasapiRecorder`](WasapiRecorder.md) for WASAPI capture.
+Next, let's create the recording device. Create it on the UI thread — `WasapiRecorder` captures the `SynchronizationContext` that is current when it is constructed, and raises `RecordingStopped` back on it, which lets us update our buttons directly in that handler.
 
 ```c#
-var waveIn = new WaveIn();
+var recorder = new WasapiRecorderBuilder().Build();
 ```
 
 I'll declare a `WaveFileWriter` but it won't get created until we start recording:
@@ -32,60 +32,62 @@ var buttonStop = new Button() { Text = "Stop", Left = buttonRecord.Right, Enable
 f.Controls.AddRange(new Control[] { buttonRecord, buttonStop });
 ```
 
-Now we need some event handlers. When we click `Record`, we'll create a new `WaveFileWriter`, specifying the path for the WAV file to create and the format we are recording in. This must be the same as the recording device format as that is the format we'll receive recorded data in. So we use `waveIn.WaveFormat`.
+Now we need some event handlers. When we click `Record`, we'll create a new `WaveFileWriter`, specifying the path for the WAV file to create and the format we are recording in. This must be the same as the recording device format as that is the format we'll receive recorded data in. So we use `recorder.WaveFormat`. In shared mode that's the capture device's mix format, which is usually 32 bit IEEE float — `WaveFileWriter` will write a valid WAV file for that. (If you need a specific format instead, ask for it when building with `WithFormat(...)` and WASAPI will convert.)
 
-Then we start recording with `waveIn.StartRecording()` and set the button enabled states appropriately.
+Then we start recording with `recorder.StartRecording()` and set the button enabled states appropriately.
 
 
 ```c#
 buttonRecord.Click += (s, a) => 
 {
-    writer = new WaveFileWriter(outputFilePath, waveIn.WaveFormat); 
-    waveIn.StartRecording(); 
+    writer = new WaveFileWriter(outputFilePath, recorder.WaveFormat); 
+    recorder.StartRecording(); 
     buttonRecord.Enabled = false; 
     buttonStop.Enabled = true; 
 };
 ```
 
 
-We also need a handler for the `DataAvailable` event on our input device. This will start firing periodically after we start recording. We can just write the buffer in the event args to our writer. Make sure you write `a.BytesRecorded` bytes, not `a.Buffer.Length`
+We also need a handler for the `DataAvailable` event on our input device. This will start firing periodically after we start recording. `WasapiRecorder` hands us a `ReadOnlySpan<byte>` straight over the WASAPI buffer, so there's no intermediate copy and no byte count to get wrong — we can write the whole span. The span is only valid for the duration of the callback, so if you want to keep the audio for later you must copy it out; writing it to a file like this is fine. The remaining parameters carry the buffer flags and the device/QPC positions for the packet, which we don't need here, so we discard them with `_`.
 
 ```c#
-waveIn.DataAvailable += (s, a) =>
+recorder.DataAvailable += (buffer, _, _, _) =>
 {
-    writer.Write(a.Buffer, 0, a.BytesRecorded);
+    writer.Write(buffer);
 };
 ```
 
 One safety feature I often add when recording WAV is to limit the size of a WAV file. They grow quickly and can't be over 4GB in any case. Here I'll request that recording stops after 30 seconds:
 
 ```c#
-waveIn.DataAvailable += (s, a) =>
+recorder.DataAvailable += (buffer, _, _, _) =>
 {
-    writer.Write(a.Buffer, 0, a.BytesRecorded);
-    if (writer.Position > waveIn.WaveFormat.AverageBytesPerSecond * 30)
+    writer.Write(buffer);
+    if (writer.Position > recorder.WaveFormat.AverageBytesPerSecond * 30)
     {
-        waveIn.StopRecording();
+        recorder.StopRecording();
     }
 };
 ```
 
-Now we need to handle the stop recording button. This is simple, we just call `waveIn.StopRecording()`. However, we might still receive more data in the `DataAvailable` callback, so don't dispose you `WaveFileWriter` just yet.
+Note that unlike `WaveIn`, this event is raised on the capture thread rather than being marshalled back to the UI thread, so don't touch any controls from inside it.
+
+Now we need to handle the stop recording button. This is simple, we just call `recorder.StopRecording()`. However, we might still receive more data in the `DataAvailable` callback, so don't dispose your `WaveFileWriter` just yet.
 
 ```c#
-buttonStop.Click += (s, a) => waveIn.StopRecording();
+buttonStop.Click += (s, a) => recorder.StopRecording();
 ```
 
 We'll also add a safety measure that if you try to close the form while you're recording, we'll call `StopRecording` and set a flag so we know we can also dispose the input device:
 
 ```c#
-f.FormClosing += (s, a) => { closing=true; waveIn.StopRecording(); };
+f.FormClosing += (s, a) => { closing=true; recorder.StopRecording(); };
 ```
 
 To safely dispose our `WaveFileWriter`, (which we need to do in order to produce a valid WAV file), we should handle the `RecordingStopped` event on our recording device. We `Dispose` the `WaveFileWriter` which fixes up the headers in our WAV file so that it is valid. Then we set the button states. Finally, if we're closing the form, the input device should be disposed.
 
 ```c#
-waveIn.RecordingStopped += (s, a) =>
+recorder.RecordingStopped += (s, a) =>
 {
     writer?.Dispose(); 
     writer = null; 
@@ -93,10 +95,12 @@ waveIn.RecordingStopped += (s, a) =>
     buttonStop.Enabled = false;
     if (closing) 
     { 
-        waveIn.Dispose();
+        recorder.Dispose();
     }
 };
 ```
+
+`WasapiRecorder` also implements `IAsyncDisposable`, so away from an event handler you can `await recorder.DisposeAsync()` instead and avoid blocking while the capture thread is joined.
 
 Now all our handlers are set up, we're ready to show the dialog:
 
@@ -111,7 +115,7 @@ var outputFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFol
 Directory.CreateDirectory(outputFolder);
 var outputFilePath = Path.Combine(outputFolder,"recorded.wav");
 
-var waveIn = new WaveIn();
+var recorder = new WasapiRecorderBuilder().Build();
 
 WaveFileWriter writer = null;
 bool closing = false;
@@ -122,13 +126,53 @@ f.Controls.AddRange(new Control[] { buttonRecord, buttonStop });
 
 buttonRecord.Click += (s, a) => 
 { 
-    writer = new WaveFileWriter(outputFilePath, waveIn.WaveFormat); 
-    waveIn.StartRecording(); 
+    writer = new WaveFileWriter(outputFilePath, recorder.WaveFormat); 
+    recorder.StartRecording(); 
     buttonRecord.Enabled = false; 
     buttonStop.Enabled = true; 
 };
 
-buttonStop.Click += (s, a) => waveIn.StopRecording();
+buttonStop.Click += (s, a) => recorder.StopRecording();
+
+recorder.DataAvailable += (buffer, _, _, _) =>
+{
+    writer.Write(buffer);
+    if (writer.Position > recorder.WaveFormat.AverageBytesPerSecond * 30)
+    {
+        recorder.StopRecording();
+    }
+};
+
+recorder.RecordingStopped += (s, a) =>
+{
+    writer?.Dispose(); 
+    writer = null; 
+    buttonRecord.Enabled = true;
+    buttonStop.Enabled = false;
+    if (closing) 
+    { 
+        recorder.Dispose();
+    }
+};
+
+f.FormClosing += (s, a) => { closing=true; recorder.StopRecording(); };
+f.ShowDialog();
+```
+
+See [Recording Audio with WasapiRecorder](WasapiRecorder.md) for the rest of what the recorder can do — selecting a specific device, exclusive mode, low-latency capture, loopback capture of system audio, and consuming audio as an `IAsyncEnumerable` with `CaptureAsync`.
+
+## Doing the same thing with WaveIn
+
+`WaveIn` is the legacy WinMM capture device. It's still supported, and it differs from `WasapiRecorder` in a few ways that matter here:
+
+- `DataAvailable` is an ordinary `EventHandler<WaveInEventArgs>` giving you a `byte[]` and a `BytesRecorded` count — write `a.BytesRecorded` bytes, not `a.Buffer.Length`.
+- That event is marshalled back onto the synchronization context that was active when `StartRecording` was called, so if you start recording from the UI thread you can update controls from within it.
+- Its default recording format is 44.1kHz 16 bit stereo PCM rather than the device mix format.
+
+Only the device creation and the `DataAvailable` handler change:
+
+```c#
+var waveIn = new WaveIn();
 
 waveIn.DataAvailable += (s, a) =>
 {
@@ -138,20 +182,6 @@ waveIn.DataAvailable += (s, a) =>
         waveIn.StopRecording();
     }
 };
-
-waveIn.RecordingStopped += (s, a) =>
-{
-    writer?.Dispose(); 
-    writer = null; 
-    buttonRecord.Enabled = true;
-    buttonStop.Enabled = false;
-    if (closing) 
-    { 
-        waveIn.Dispose();
-    }
-};
-
-f.FormClosing += (s, a) => { closing=true; waveIn.StopRecording(); };
-f.ShowDialog();
 ```
 
+`StartRecording`, `StopRecording`, `RecordingStopped` and `WaveFormat` all work the same way, so the rest of the program above is unchanged.

--- a/Docs/RecordingLevelMeter.md
+++ b/Docs/RecordingLevelMeter.md
@@ -8,98 +8,103 @@ In NAudio, the method you call to start capturing audio from an input device is 
 
 So if you want to allow the user to set up their volume levels before they start "recording", you'll actually need to call `StartRecording` to start capturing the audio simply for the purposes of updating the level meter.
 
-We won't go into great detail in this article on how to record audio as that's [covered elsewhere](RecordWavFileWinFormsWaveIn.md), but here we'll create a new recording device, subscribe to the data available event, and start capturing audio by calling `StartRecording`.
+We won't go into great detail in this article on how to record audio as that's [covered elsewhere](RecordWavFileWinFormsWaveIn.md), but here we'll create a new recording device, subscribe to the data available event, and start capturing audio by calling `StartRecording`. We'll use `WasapiRecorder`, the recommended capture device on Windows, built with `WasapiRecorderBuilder`. Omit `WithDevice` if you just want the default microphone; see [enumerating audio devices](EnumerateOutputDevices.md) for how to get an `MMDevice` for a specific one.
 
 ```c#
-var waveIn = new WaveIn() { DeviceNumber = deviceNumber };
-waveIn.DataAvailable += OnDataAvailable;
-waveIn.StartRecording();
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+var recorder = new WasapiRecorderBuilder()
+    .WithDevice(captureDevice)
+    .WithLowLatency()       // optional: smaller, more frequent buffers for a responsive meter
+    .Build();
+recorder.DataAvailable += OnDataAvailable;
+recorder.StartRecording();
 ```
 
 ## Handling Captured Audio
 
-In the `DataAvailable` event handler, if we were simply recording audio, we'd write to a `WaveFileWriter` like this:
+`WasapiRecorder` gives the `DataAvailable` handler a `ReadOnlySpan<byte>` over the captured audio, along with the buffer flags and the packet's device and QPC positions. The span is only valid for the duration of the callback, so anything you want to keep must be copied out — writing it straight to a `WaveFileWriter` is fine. If we were simply recording audio, the handler would look like this:
 
 ```c#
-private void OnDataAvailable(object sender, WaveInEventArgs args)
+private void OnDataAvailable(ReadOnlySpan<byte> buffer, AudioClientBufferFlags flags,
+                             long devicePosition, long qpcPosition)
 {
-    writer.Write(args.Buffer, 0, args.BytesRecorded);
-};
+    writer.Write(buffer);
+}
 ```
 
 But if we're just letting the user get their levels set up, we'd only write to the file if the user had actually begun recording. So we might have a boolean flag that says whether we're recording or not. So when we get the `DataAvailable` event we don't necessarily write to a file.
 
 ```c#
-private void OnDataAvailable(object sender, WaveInEventArgs args)
+private void OnDataAvailable(ReadOnlySpan<byte> buffer, AudioClientBufferFlags flags,
+                             long devicePosition, long qpcPosition)
 {
     if (isRecording) 
     {
-        writer.Write(args.Buffer, 0, args.BytesRecorded);
+        writer.Write(buffer);
     }
-};
+}
 ```
 
 ## Calculating Peak Values
 
-The `WaveInEventArgs.Buffer` property contains the captured audio. Unfortunately this is represented as a byte array. This means that we must convert to samples.
+The captured audio arrives as bytes. This means that we must convert to samples.
 
-The way this works depends on the bit depth being recorded at. The two most common options are 16 bit signed integers (`short`'s in C#), which is what `WaveIn` will supply by default. And 32 bit IEEE floating point numbers (`float`'s in C#) which is what `WasapiCapture` or `WasapiLoopbackCapture` will supply by default.
+The way this works depends on the bit depth being recorded at. The two most common options are 32 bit IEEE floating point numbers (`float`'s in C#), which is what `WasapiRecorder` supplies by default since it captures at the device's mix format, and 16 bit signed integers (`short`'s in C#), which is what the legacy `WaveIn` supplies by default, and what you'll get from `WasapiRecorder` if you asked for it with `WithFormat`. Check `recorder.WaveFormat` if you're not sure which you have.
 
-Here's how we might discover the maximum sample value if the incoming audio is 16 bit. Notice that we are simply taking the absolute value of each sample, and we are calculating one maximum value irrespective of whether it is mono or stereo audio. If you wanted, you could calculate the maximum values for each channel separately, by maintaining separate max values for each channel (the samples are interleaved):
+`MemoryMarshal.Cast` (from `System.Runtime.InteropServices`) lets us reinterpret the byte span as a span of samples with no copying. Here's how we might discover the maximum sample value for the default floating point case. Notice that we are simply taking the absolute value of each sample, and we are calculating one maximum value irrespective of whether it is mono or stereo audio. If you wanted, you could calculate the maximum values for each channel separately, by maintaining separate max values for each channel (the samples are interleaved):
+
+```c#
+void OnDataAvailable(ReadOnlySpan<byte> buffer, AudioClientBufferFlags flags,
+                     long devicePosition, long qpcPosition)
+{
+    if (isRecording) 
+    {
+        writer.Write(buffer);
+    }
+
+    float max = 0;
+    // interpret as 32 bit floating point audio
+    foreach (var sample in MemoryMarshal.Cast<byte, float>(buffer))
+    {
+        // absolute value 
+        var abs = sample < 0 ? -sample : sample;
+        // is this the max value?
+        if (abs > max) max = abs;
+    }
+}
+```
+
+For 16 bit audio, cast to `short` instead and divide by 32768 to get back to the same 0.0f to 1.0f range:
+
+```c#
+    float max = 0;
+    // interpret as 16 bit audio
+    foreach (var sample in MemoryMarshal.Cast<byte, short>(buffer))
+    {
+        var sample32 = sample / 32768f;
+        if (sample32 < 0) sample32 = -sample32;
+        if (sample32 > max) max = sample32;
+    }
+```
+
+If you're working with a legacy `IWaveIn` device such as `WaveIn`, the handler is an `EventHandler<WaveInEventArgs>` and you get a `byte[]` plus a `BytesRecorded` count instead. The same casts work on `args.Buffer.AsSpan(0, args.BytesRecorded)`, or you can use NAudio's `WaveBuffer` class, which can 'cast' a `byte[]` to a `short[]` or `float[]` — something that is not normally possible in C#:
 
 ```c#
 void OnDataAvailable(object sender, WaveInEventArgs args)
 {
-    if (isRecording) 
-    {
-        writer.Write(args.Buffer, 0, args.BytesRecorded);
-    }
-
     float max = 0;
-    // interpret as 16 bit audio
-    for (int index = 0; index < args.BytesRecorded; index += 2)
+    var buffer = new WaveBuffer(args.Buffer);
+    // interpret as 16 bit audio via ShortBuffer (FloatBuffer for 32 bit float)
+    for (int index = 0; index < args.BytesRecorded / 2; index++)
     {
-        short sample = (short)((args.Buffer[index + 1] << 8) |
-                                args.Buffer[index + 0]);
-        // to floating point
-        var sample32 = sample/32768f;
-        // absolute value 
+        var sample32 = buffer.ShortBuffer[index] / 32768f;
         if (sample32 < 0) sample32 = -sample32;
-        // is this the max value?
         if (sample32 > max) max = sample32;
     }
 }
 ```
-
-The previous example showed using bit manipulation, but NAudio also has a clever trick up its sleeve called `WaveBuffer`. This allows us to 'cast' from a `byte[]` to a `short[]` or `float[]`, something that is not normally possible in C#.
-
-Here's it working for floating point audio:
-
-```c#
-void OnDataAvailable(object sender, WaveInEventArgs args)
-{
-    if (isRecording) 
-    {
-        writer.Write(args.Buffer, 0, args.BytesRecorded);
-    }
-
-    float max = 0;
-    var buffer = new WaveBuffer(args.Buffer);
-    // interpret as 32 bit floating point audio
-    for (int index = 0; index < args.BytesRecorded / 4; index++)
-    {
-        var sample = buffer.FloatBuffer[index];
-
-        // absolute value 
-        if (sample < 0) sample = -sample;
-        // is this the max value?
-        if (sample > max) max = sample;
-    }
-}
-```
-
-The same approach can be used for 16 bit audio, by accessing `ShortBuffer` instead of `FloatBuffer`.
-
 
 ## Updating the Volume Meter
 
@@ -111,6 +116,6 @@ In both our examples, we calulated `max` as a floating point value between 0.0f 
 progressBar.Value = 100 * max;
 ```
 
-Note that you are updating the UI in the `OnDataAvailable` callback. `WaveIn` marshals this event back onto the synchronization context that was active when `StartRecording` was called, so if you start recording from the UI thread you can update controls directly. Other capture classes such as `WasapiCapture` and `WasapiLoopbackCapture` raise `DataAvailable` on a background thread, so you'll need to marshal to the UI thread yourself (e.g. `Control.Invoke` in WinForms or `Dispatcher.Invoke` in WPF) before updating a control. 
+Note that you are updating the UI in the `OnDataAvailable` callback. `WasapiRecorder` raises `DataAvailable` on its capture thread, so you must marshal to the UI thread yourself (e.g. `Control.Invoke` in WinForms or `Dispatcher.Invoke` in WPF) before touching a control. Do the peak calculation in the callback and marshal only the resulting number — you can't pass the span itself to another thread. The legacy `WaveIn` is the exception here: it marshals `DataAvailable` back onto the synchronization context that was active when `StartRecording` was called, so if you start recording from the UI thread you can update controls directly.
 
 Also, this approach means that the frequency of meter updates will match the size of recording buffers. This is the simplest approach, and normally works just fine as there will usually be at least 10 buffers per second which is usually adequate for a volume meter.

--- a/Docs/Sampler.md
+++ b/Docs/Sampler.md
@@ -35,7 +35,7 @@ var sampler = new SoundFontSampler(soundFont);
 // before sending it events from outside the audio thread
 var live = new LiveMidiInstrument(sampler);
 
-using var device = new WaveOutEvent();
+using var device = new WasapiPlayerBuilder().Build();
 device.Init(live);
 device.Play();
 
@@ -46,7 +46,7 @@ live.NoteOff(0, 60);
 
 The sampler consumes MIDI through `ProcessMidiEvent(MidiEvent)` (plus the `NoteOn`/`NoteOff` convenience methods) and produces audio through `Read`. Both must be called from the same thread — see [Live MIDI input](#live-midi-input) for why the example above wraps the sampler in `LiveMidiInstrument`. When a host such as `SequencedMidiPlayer` drives the sampler on the audio thread itself, no wrapper is needed.
 
-`WaveOutEvent` is used in these examples for brevity; the sampler is just an `ISampleProvider`, so any output device works — `WasapiPlayer` on Windows, `AlsaOut` on Linux, or anything else from [Choose an output device type](OutputDeviceTypes.md).
+`WasapiPlayer` is used in these examples as it's the recommended output device on Windows; the sampler is just an `ISampleProvider`, so any output device works — `AlsaOut` on Linux, `CoreAudioPlayer` on macOS, or anything else from [Choose an output device type](OutputDeviceTypes.md).
 
 ### Channels, banks and percussion
 
@@ -88,7 +88,7 @@ var sampler = new SoundFontSampler(new SoundFont("FluidR3_GM.sf2"));
 var transport = new Transport(sequence.TempoMap, sampler.WaveFormat.SampleRate);
 var player = new SequencedMidiPlayer(transport, sequence.Timeline, sampler);
 
-using var device = new WaveOutEvent();
+using var device = new WasapiPlayerBuilder().Build();
 device.Init(player);
 device.Play();
 transport.Play();
@@ -122,7 +122,7 @@ The sampler engine is **single-threaded by design**: `Read` and every MIDI entry
 var sampler = SfzSampler.FromFile(@"instruments\piano.sfz");
 var live = new LiveMidiInstrument(sampler);
 
-using var device = new WaveOutEvent();
+using var device = new WasapiPlayerBuilder().Build();
 device.Init(live);
 device.Play();
 

--- a/Docs/SmbPitchShiftingSampleProvider.md
+++ b/Docs/SmbPitchShiftingSampleProvider.md
@@ -16,7 +16,7 @@ var downOneTone = 1.0/upOneTone;
 using (var reader = new MediaFoundationReader(inPath))
 {
     var pitch = new SmbPitchShiftingSampleProvider(reader.ToSampleProvider());
-    using(var device = new WaveOut())
+    using(var device = new WasapiPlayerBuilder().Build())
     {
         pitch.PitchFactor = (float)upOneTone; // or downOneTone
         // just playing the first 10 seconds of the file


### PR DESCRIPTION
## Summary

Several tutorials still presented the legacy WinMM devices as *the* way to play and record audio, contradicting `Docs/OutputDeviceTypes.md` (which says WASAPI is recommended) and the docfx landing page (whose quick example already uses `WasapiPlayerBuilder`). This updates them to lead with `WasapiPlayer` and `WasapiRecorder`.

**Playback — now `new WasapiPlayerBuilder().Build()`**

- `PlayAudioFileConsoleApp.md` — rewritten. It's the page the docfx landing page links to as *Tutorials*, so it now opens with `WasapiPlayer`, mentions `IAsyncDisposable`, and closes with a short "other output devices" list (`WaveOut` as legacy, ASIO, `AlsaOut`/`CoreAudioPlayer`).
- `PlayAudioFileWinForms.md` — the field is now `WasapiPlayer`, all three examples build via the builder, and the paragraph recommending `WaveOut` "due to its ease of use and broad platform support" is replaced with a WASAPI shared-mode rationale. Adds a note that `Volume` on `WasapiPlayer` is the application's own slider in the Windows mixer.
- `PlaySineWave.md`, `RawSourceWaveStream.md`, `FadeInOutSampleProvider.md`, `SmbPitchShiftingSampleProvider.md` — device swap.
- `AudioEffects.md`, `Sampler.md` — these used `WaveOutEvent`, which is `[Obsolete]` in NAudio 3 (renamed to `WaveOut`, see `src/NAudio.WinMM/WaveOut.cs`), so the samples emitted a warning as written. Sampler's "WaveOutEvent is used for brevity" note now points at `AlsaOut`/`CoreAudioPlayer` for the non-Windows cases.
- `ConcatenatingAudio.md`, `ConvertBetweenStereoAndMono.md` — snippets referenced an undeclared `outputDevice`/`myOutputDevice`; now declared.
- `PlaybackStopped.md` — reordered the `IWavePlayer` examples so `WasapiPlayer` leads.
- `EnumerateOutputDevices.md` — restructured to lead with WASAPI/`MMDeviceEnumerator`, then ASIO, with WaveOut/WaveIn and DirectSound following and marked legacy. Heading levels normalised to `##` (the file mixed `#` and `##`).

**Recording — now `new WasapiRecorderBuilder().Build()`**

- `RecordWavFileWinFormsWaveIn.md` — rebuilt around `WasapiRecorder`: the span-based `DataAvailable` signature, `WaveFileWriter.Write(ReadOnlySpan<byte>)`, a note to construct on the UI thread (`RecordingStopped` is marshalled to the captured `SynchronizationContext`) and a warning not to touch controls from the capture thread. The `WaveIn` version is kept as a closing section covering the three differences that matter.
- `RecordingLevelMeter.md` — same treatment. Peak calculation uses `MemoryMarshal.Cast` over the span for float (the mix-format default) and short; the `WaveBuffer`/`WaveInEventArgs` approach is kept for legacy `IWaveIn` devices. The UI-marshalling paragraph is inverted to match reality: WASAPI raises on the capture thread, `WaveIn` is the exception.
- `MixMicrophoneAndSystemAudio.md` — `WaveInEvent` → `WaveIn` (also an obsolete NAudio 2 name).

**Filename note:** `RecordWavFileWinFormsWaveIn.md` keeps its name so the published URL doesn't break — DocFX has no redirect for it. Its H1 is now "Recording a WAV file in a WinForms app", and the `Docs/toc.yml` entry already read "Record a WAV file (WinForms)", so nothing user-facing still says WaveIn. Happy to take the URL break if you'd prefer the file renamed.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

Docs-only, no API or behaviour change — per the "skip for docs fixes" guidance in CLAUDE.md. Say the word if you'd rather it appeared in the changelog.

## Testing

No code changed, so there's nothing to build or run. The WASAPI samples can't be compiled on the Linux agent this was written on, so every API used was checked against the source instead:

- `WasapiPlayerBuilder.Build()` → `WasapiPlayer : IWavePlayer, IWavePosition, IWaveLatency, IAsyncDisposable`
- `WasapiRecorderBuilder.Build()` → `WasapiRecorder : IDisposable, IAsyncDisposable, IWaveLatency`, with `WithDevice`, `WithFormat`, `WithLowLatency`
- `CaptureDataAvailableHandler(ReadOnlySpan<byte>, AudioClientBufferFlags, long, long)` — `AudioClientBufferFlags` is in `NAudio.CoreAudioApi`
- `WaveFileWriter.Write(ReadOnlySpan<byte>)` (`src/NAudio.Core/Wave/WaveOutputs/WaveFileWriter.cs:390`)
- `WaveIn`'s default format (44.1kHz 16-bit stereo) against `src/NAudio.WinMM/WaveIn.cs:42`

No files were added or removed, so the `Docs/toc.yml` CI check is unaffected. All cross-links added point at existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUyofRHptqtvQVfNJHa3nf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUyofRHptqtvQVfNJHa3nf)_