### PR TITLE
[NAudio 3] Fix XML documentation in most NAudio audio primitives

### DIFF
--- a/Docs/WaveProviders.md
+++ b/Docs/WaveProviders.md
@@ -1,50 +1,79 @@
-# WaveStream, IWaveProvider and ISampleProvider
+﻿# WaveStream, IWaveProvider and ISampleProvider
 
-When you play audio with NAudio or construct a playback graph, you are typically working with either `IWaveProvider` or `ISampleProvider` interface implementations. This article explains the three main base interfaces and classes you will encounter in NAudio and when you might use them.
+When you play audio with NAudio or construct a playback graph, you are typically working with either `IWaveProvider` or `ISampleProvider` interface implementations. 
+This article explains the three main base interfaces and classes you will encounter in NAudio and when you might use them.
 
-## WaveStream
+## `WaveStream`
 
-`WaveStream` was the first base class in NAudio, and inherits from `System.IO.Stream`. It represents a stream of audio data, and its format can be determined by looking at the `WaveFormat` property.
+`WaveStream` was the first base class in NAudio, inherits from `System.IO.Stream`,
+and implements `IWaveProvider` in newer versions.
+It represents a stream of audio data, and its format can be determined by querying the `WaveFormat` property.
+Typically, it is also seekable (repositionable), which it means that it is possible to get any sample of the stream at will.
 
-It supports reporting `Length` and `Position` and these are both measured in terms of bytes, not samples. `WaveStreams` can be repositioned (assuming the underlying implementation supports that), although care must often be taken to reposition to a multiple of the `BlockAlign` of the `WaveFormat`. For example if the wave stream produces 16 bit samples, you should always reposition to an even numbered byte position.
+Seeking (reposition) is implemented through the `System.IO.Stream` `Length` and `Position` properties. 
+These properties are both measured in terms of bytes, not samples.
+When a `WaveStream` is seekable (repositionable), care must often be taken to seek (reposition) to a multiple of the `BlockAlign` of the `WaveFormat`.
+If, for example, the stream produces 16 bit samples, you should always seek (reposition) to an even numbered byte position.
 
-Audio data is from a stream using the `Read` method which has the signature:
+Audio data are retrieved from a stream using the `Read` method which has the signature:
 
 ```c#
-int Read(byte[] destBuffer, int offset, int numBytes)
+int Read(Span<byte> buffer);
 ```
 
-This method is inherited from `System.IO.Stream`, and works in the standard way. The `destBuffer` is the buffer into which audio should be written. The `offset` parameter specifies where in the buffer to write audio to (this parameter is almost always 0), and the `numBytes` parameter is how many bytes of audio should be read.
+This method is also inherited from `System.IO.Stream`, and works in the standard way. 
+The `buffer` parameter is the buffer into which audio is expected to be written. 
+It's `Length` property denotes how many bytes are expected to be written to it.
 
-The `Read` method returns the number for bytes that were read. This should never be more than `numBytes` and can only be less if the end of the audio stream is reached. NAudio playback devices will stop playing when `Read` returns 0.
+The return value of the `Read` method must provide the number of bytes that were read. 
+This should never be more than `buffer.Length` bytes and can only be less if the end of the audio stream is reached. 
+By convention, NAudio playback devices will stop playing when `Read` returns 0.
 
-`WaveStream` is the base class for NAudio file reader classes such as `WaveFileReader`, `Mp3FileReader`, `AiffFileReader` and `MediaFoundationReader`. It is a good choice of base class because these inherently support repositioning. `RawSourceWaveStream` is also a `WaveStream`, and delegates repositioning requests down to its source stream.
+`WaveStream` is the base class for NAudio file reader classes such as `WaveFileReader`, `Mp3FileReader`, `AiffFileReader` and `MediaFoundationReader`.
+It is a good choice of base class because these inherently support repositioning. 
+`RawSourceWaveStream` is also a `WaveStream`, and delegates repositioning requests down to its source stream.
 
-For a more detailed look at all the methods on `WaveStream`, see [this article](http://markheath.net/post/naudio-wavestream-in-depth)
+For a more detailed look at all the methods on `WaveStream`, see [this article](http://markheath.net/post/naudio-wavestream-in-depth).
 
-## IWaveProvider
+## `IWaveProvider`
 
-Implementing `WaveStream` can be quite a lot of work, and for non-repositionable streams can seem like overkill. Also, streams that simply read from a source and modify or analyse audio as it passes through don't really benefit from inheriting from `WaveStream`.
+The `WaveStream` class is not suitable for all possible audio cases, and implementing all the properties/methods it requires can seem like overkill.
+Additionally, not every audio primitive provides immutable samples (samples that are not changed during the lifetime of the stream).
+It is also not necessary to implement when the source is non-seekable (not repositionable).
+Other audio primitives are often wrapping other primitives to implement an effect or analyze the incoming samples.
 
-So the `IWaveProvider` interface provides a much simpler, minimal interface that simply has the `Read` method, and a `WaveFormat` property.
+For all these reasons described above, the `IWaveProvider` interface was created.
+It provides a much simpler and straightforward interface that simply
+has the `Read` method, and a `WaveFormat` property:
 
 ```c#
 public interface IWaveProvider
 {
     WaveFormat WaveFormat { get; }
-    int Read(byte[] buffer, int offset, int count);
+    int Read(Span<byte> buffer);
 }
 ```
 
-The `IWavePlayer` interface only needs an `IWaveProvider` passed to its `Init` method in order to be able to play audio. `WaveFileWriter.CreateWaveFile` and `MediaFoundationEncoder.EncodeToMp3` also only needs an `IWaveProvider` to dump the audio out to a WAV file. So in many cases you won't need to create a `WaveStream` implementation, just implement `IWaveProvider` and you've got an audio source that can be played or rendered to a file.
+The `IWavePlayer` interface only needs an `IWaveProvider` passed to its `Init` method in order to be able to play audio. 
+`WaveFileWriter.CreateWaveFile` and `MediaFoundationEncoder.EncodeToMp3` also only need an `IWaveProvider` to dump the audio out to a WAV file.
+So, in many cases you won't need to create a `WaveStream` implementation, just implement `IWaveProvider` and you have an audio source 
+that can be played or rendered to a file.
 
 `BufferedWaveProvider` is a good example of a `IWaveProvider` as it has no ability to reposition - it simply returns any buffered audio from its `Read` method.
 
-## ISampleProvider
+## `ISampleProvider`
 
-The strength of `IWaveProvider` is that it can be used to represent audio in any format. It can be used for 16,24 or 32 bit PCM audio, and even for compressed audio (MP3, G.711 etc). But if you are performing any kind of signal processing or analysis on the audio, it is very likely that you want the audio to be in 32 bit IEEE floating point format. And it can be a pain to try to read floating point values out of a `byte[]` in C#.
+While implementing `IWaveProvider` is a useful approach to implement an audio effect, it has the caveat that
+decoding the samples depends of the bit rate (number of bits per sample) declared on the `WaveFormat`. 
+And, it can be difficult to get the samples as numbers and cover all the possible bit rates.
 
-So `ISampleProvider` defines an interface where the samples are all 32 bit floating point:
+While the `IWaveProvider` is able to represent a lot of audio formats, 
+just doing any signal processing suddenly becomes one of the hardest tasks to do.
+
+For these reasons, the `ISampleProvider` interface was created.
+
+This particular interface makes it easy to process the samples because it's `Read` 
+method provides 32-bit IEEE floating-point samples:
 
 ```c#
 public interface ISampleProvider
@@ -54,27 +83,41 @@ public interface ISampleProvider
 }
 ```
 
-The `WaveFormat` will always be 32 bit floating point, but the number of channels or sample rate may of course vary.
+The `WaveFormat` will always be 32 bit floating point,
+but the number of channels or sample rate may of course vary by implementation.
 
-The `Read` method's `count` parameter specifies the number of samples to be read, and the method returns the number of samples written into `buffer`.
+The `Read` method's `buffer` parameter specifies the buffer to place the processed samples into.
+The buffer's `Length` property denotes how many bytes are expected to be written to it.
 
-`ISampleProvider` is a great base interface to inherit from if you are implementing any kind of audio effects. In the `Read` method you typically read from your source `ISampleProvider`, then modify the floating point samples, before returning them. Here's the implementation of the `Read` method in `VolumeSampleProvider` showing how simple this can be:
+Finally, the return value indicates how many samples were written to the buffer.
+You should return 0 to signal that you do not have any other data to provide.
+
+To summarize, the `ISampleProvider` is a great base interface to use when you
+are implementing any kind of an audio effect.
+
+In the `Read` method you typically read from your source `ISampleProvider`, then modify the floating point samples, before returning them.
+Here's the implementation of the `Read` method in `VolumeSampleProvider` showing how simple this can be:
 
 ```c#
-public int Read(float[] buffer, int offset, int sampleCount)
+public int Read(Span<byte> buffer)
 {
-    int samplesRead = source.Read(buffer, offset, sampleCount);
+    int samplesRead = source.Read(buffer);
     if (volume != 1f)
     {
-        for (int n = 0; n < sampleCount; n++)
+        for (int n = 0; n < samplesRead; n++)
         {
-            buffer[offset + n] *= volume;
+            buffer[n] *= volume;
         }
     }
     return samplesRead;
 }
 ```
 
-NAudio makes it easy to go from an `IWaveProvider` to an `ISampleProvider` with the `ToSampleProvider` extension method. You can also use `AudioFileReader` which reads a wide variety of file types and implements `ISampleProvider`.
+To make the development of effects easier, NAudio provides built-in converters so that the transition
+from an `IWaveProvider` to an `ISampleProvider` (and vice-versa) is easy.
+For example, to convert any `IWaveProvider` to an `ISampleProvider` instance, you use the `ToSampleProvider` extension method.
+You can also get back to an `IWaveProvider` at any time you want by using the `ToWaveProvider` extension method.
+There is the `ToWaveProvider16` extension method too if you want specifically to get PCM 16 bit integer samples.
 
-You can get back to an `IWaveProvider` with the `ToWaveProvider` extension method. Or there's the `ToWaveProvider16` extension method if you want to go back to 16 bit integer samples.
+You can also use `AudioFileReader` which reads a wide variety of file types and implements `ISampleProvider`.
+

--- a/Docs/WaveProviders.md
+++ b/Docs/WaveProviders.md
@@ -64,8 +64,8 @@ that can be played or rendered to a file.
 ## `ISampleProvider`
 
 While implementing `IWaveProvider` is a useful approach to implement an audio effect, it has the caveat that
-decoding the samples depends of the bit rate (number of bits per sample) declared on the `WaveFormat`. 
-And, it can be difficult to get the samples as numbers and cover all the possible bit rates.
+decoding the samples depends of the bit depth (number of bits per sample) declared on the `WaveFormat`. 
+And, it can be difficult to get the samples as numbers and cover all the possible bit depths.
 
 While the `IWaveProvider` is able to represent a lot of audio formats, 
 just doing any signal processing suddenly becomes one of the hardest tasks to do.
@@ -79,7 +79,7 @@ method provides 32-bit IEEE floating-point samples:
 public interface ISampleProvider
 {
     WaveFormat WaveFormat { get; }
-    int Read(float[] buffer, int offset, int count);
+    int Read(Span<float> buffer);
 }
 ```
 
@@ -87,7 +87,7 @@ The `WaveFormat` will always be 32 bit floating point,
 but the number of channels or sample rate may of course vary by implementation.
 
 The `Read` method's `buffer` parameter specifies the buffer to place the processed samples into.
-The buffer's `Length` property denotes how many bytes are expected to be written to it.
+The buffer's `Length` property denotes how many samples are expected to be written to it.
 
 Finally, the return value indicates how many samples were written to the buffer.
 You should return 0 to signal that you do not have any other data to provide.
@@ -99,7 +99,7 @@ In the `Read` method you typically read from your source `ISampleProvider`, then
 Here's the implementation of the `Read` method in `VolumeSampleProvider` showing how simple this can be:
 
 ```c#
-public int Read(Span<byte> buffer)
+public int Read(Span<float> buffer)
 {
     int samplesRead = source.Read(buffer);
     if (volume != 1f)

--- a/src/NAudio.Core/Wave/WaveOutputs/ISampleProvider.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/ISampleProvider.cs
@@ -7,33 +7,27 @@ namespace NAudio.Wave;
 /// Like the <see cref="IWaveProvider"/> interface, the <see cref="ISampleProvider"/> interface is 
 /// also a low-level primitive that is an audio source, but all the audio samples are provided
 /// as 32-bit floating-point. <br />
-/// This was primarily useful back in .NET Framework when the Span API still not existed and reinterpreting
-/// samples as their numeric types needed loads of code in the Read implementation. For example, applying
-/// just a gain (volume) modifier on PCM 16 bit rate audio would require the following code:
-/// <code>
-/// float gain = 0.7f;
-/// IWaveProvider sourceProvider;
+/// <b>Why to use <see cref="ISampleProvider"/> instead of <see cref="IWaveProvider"/>?</b> <br /> <br />
+///
+/// While <see cref="IWaveProvider"/> gives you the raw audio data as is, you cannot 
+/// just 'magically' read the samples. That happens because the bit depth is typically different on
+/// each audio source, for example you may see a source that provides 8 bits per sample, while other
+/// one provides 24 bits per sample. <br /> <br />
+///
+/// As such, even creating a simple gain effect can prove extremely difficult as you must literally
+/// implement 5 different Read helpers to implement the rather simple effect for 8, 16, 24, 32 and 64 bit depth sources,
+/// and this is not all the possible bit depths that a source may be into, because there can also be bit depths of 10, or 12,
+/// which they are not powers of two and as such it becomes even worse to decode them. <br /> <br />
+///
+/// So, the <see cref="ISampleProvider"/> interface takes that pain away, and instead, it always gives you
+/// 32-bit floating-point samples that are really much easier to work with for any effect that you want to create.
+/// It is also very useful if you want to implement a metering control or something else that analyzes the samples
+/// as you are getting them.
+/// To be noted, the <see cref="WaveExtensionMethods"/> class provides extension methods to many
+/// converters that make the conversion of an <see cref="IWaveProvider"/> 
+/// to an <see cref="ISampleProvider"/> look effortless, and vice-versa. <br /> <br />
 /// 
-/// int Read(byte[] buffer, int offset, int count)
-/// {
-///     int read = sourceProvider.Read(buffer, offset, count);
-///
-///     for (int I = 0; I &lt; read; I += 2)
-///     {
-///         short sample = BitConverter.ToInt16(buffer, I + offset);
-///         sample = (short)(sample * gain);
-///         Array.Copy(BitConverter.GetBytes(sample), 0, buffer, I + offset, 2);
-///     }
-///
-///     return read;
-/// }
-/// </code>
-/// This example is only for 16-bit audio, and there are a lot of 
-/// bit rates to be covered, for example 8/24/32/64 bit audio. <br />
-/// Despite it's historical meaning, and the fact that the Span
-/// API's are now existing, this interface is still relevant today as
-/// just implementing gain (and any other audio effect) on all possible bit rates is impractical, 
-/// and using floating-point values to represent the sample values allow to: <br />
+/// Using floating-point values to represent the sample values allow to: <br />
 /// <list type="bullet">
 ///     <item>Cleanly separate each channel. Each <see cref="float"/> value in the buffer is a sample for a single channel.</item>
 ///     <item>Do complex floating-point arithmetic operations without the restrictions that integers do have.</item>
@@ -42,8 +36,6 @@ namespace NAudio.Wave;
 ///         The <see cref="SampleProviders.VolumeSampleProvider"/> uses this to implement the gain.
 ///     </item>
 /// </list>
-/// Note that the <see cref="WaveExtensionMethods"/> class provides extension methods that make it 
-/// just as easy to convert an <see cref="IWaveProvider"/> to an <see cref="ISampleProvider"/>, and vice-versa.
 /// </summary>
 public interface ISampleProvider
 {

--- a/src/NAudio.Core/Wave/WaveOutputs/ISampleProvider.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/ISampleProvider.cs
@@ -1,21 +1,65 @@
-﻿using System;
+﻿
+using System;
 
 namespace NAudio.Wave;
 
 /// <summary>
-/// Like IWaveProvider, but makes it much simpler to put together a 32 bit floating
-/// point mixing engine
+/// Like the <see cref="IWaveProvider"/> interface, the <see cref="ISampleProvider"/> interface is 
+/// also a low-level primitive that is an audio source, but all the audio samples are provided
+/// as 32-bit floating-point. <br />
+/// This was primarily useful back in .NET Framework when the Span API still not existed and reinterpreting
+/// samples as their numeric types needed loads of code in the Read implementation. For example, applying
+/// just a gain (volume) modifier on PCM 16 bit rate audio would require the following code:
+/// <code>
+/// float gain = 0.7f;
+/// IWaveProvider sourceProvider;
+/// 
+/// int Read(byte[] buffer, int offset, int count)
+/// {
+///     int read = sourceProvider.Read(buffer, offset, count);
+///
+///     for (int I = 0; I &lt; read; I += 2)
+///     {
+///         short sample = BitConverter.ToInt16(buffer, I + offset);
+///         sample = (short)(sample * gain);
+///         Array.Copy(BitConverter.GetBytes(sample), 0, buffer, I + offset, 2);
+///     }
+///
+///     return read;
+/// }
+/// </code>
+/// This example is only for 16-bit audio, and there are a lot of 
+/// bit rates to be covered, for example 8/24/32/64 bit audio. <br />
+/// Despite it's historical meaning, and the fact that the Span
+/// API's are now existing, this interface is still relevant today as
+/// just implementing gain (and any other audio effect) on all possible bit rates is impractical, 
+/// and using floating-point values to represent the sample values allow to: <br />
+/// <list type="bullet">
+///     <item>Cleanly separate each channel. Each <see cref="float"/> value in the buffer is a sample for a single channel.</item>
+///     <item>Do complex floating-point arithmetic operations without the restrictions that integers do have.</item>
+///     <item>
+///         Provide several performance optimizations in several cases, such as using tensor primitive operations.
+///         The <see cref="SampleProviders.VolumeSampleProvider"/> uses this to implement the gain.
+///     </item>
+/// </list>
+/// Note that the <see cref="WaveExtensionMethods"/> class provides extension methods that make it 
+/// just as easy to convert an <see cref="IWaveProvider"/> to an <see cref="ISampleProvider"/>, and vice-versa.
 /// </summary>
 public interface ISampleProvider
 {
     /// <summary>
-    /// Gets the WaveFormat of this Sample Provider.
+    /// Gets the wave format of this sample provider.
     /// </summary>
-    /// <value>The wave format.</value>
+    /// <returns>The wave format.</returns>
+    /// <remarks>
+    /// The audio format describes the wave data that are provided by successive <see cref="Read"/> calls. <br />
+    /// This must always be an IEEE 32-bit floating-point format, which can be created with the
+    /// <see cref="WaveFormat.CreateIeeeFloatWaveFormat(int, int)"/> helper method.
+    /// </remarks>
     WaveFormat WaveFormat { get; }
 
     /// <summary>
-    /// Fill the specified buffer with 32 bit floating point samples
+    /// Fills the specified buffer with 32 bit floating point samples
     /// </summary>
     /// <param name="buffer">The buffer to fill with samples.</param>
     /// <returns>The number of samples written. Return 0 to signal end of stream.</returns>

--- a/src/NAudio.Core/Wave/WaveOutputs/IWaveLatency.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/IWaveLatency.cs
@@ -1,0 +1,57 @@
+﻿
+using System;
+
+namespace NAudio.Wave;
+
+/// <summary>
+/// Interface for audio players and captures that can report the latency between a sample
+/// entering the audio pipeline and emerging from (or being delivered by) the hardware.
+/// Implement alongside <see cref="IWavePlayer"/> or <see cref="IWaveIn"/> to let downstream
+/// code synchronise visualisations, lighting, video, recording timecode, or any other
+/// time-aligned consumer with audible output or captured input.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Latency values are only meaningful during uninterrupted operation. When the device is
+/// stopped or paused, or when an underrun has occurred, implementations should return their
+/// best steady-state estimate rather than throw — consumers driving visualisations need a
+/// stable value to fall back on.
+/// </para>
+/// <para>
+/// The two properties answer different questions. <see cref="AverageLatency"/> describes the
+/// pipeline (it changes only when buffer settings change), so it is the right value for
+/// scheduling. <see cref="CurrentLatency"/> describes the live state of the pipeline at this
+/// instant and is the right value for drift detection or per-frame correction.
+/// </para>
+/// <para>
+/// <see cref="CurrentLatency"/> may be computed either as the forward queue depth (e.g. WASAPI
+/// <c>GetCurrentPadding</c> divided by sample rate — "if I queued a sample now, this is how
+/// long until I'd hear it") or as the wall-clock age of the sample currently at the play /
+/// capture head (timestamping each buffer fill). The two values converge in steady state and
+/// diverge only under irregular feed patterns; this interface deliberately permits either,
+/// so implementations can use whichever the underlying driver exposes most cheaply.
+/// </para>
+/// <para>
+/// For drivers whose buffer scheduling is fully predictable (notably ASIO, which always swaps
+/// fixed-size buffers at regular intervals), <see cref="CurrentLatency"/> may simply return
+/// <see cref="AverageLatency"/>. The approximation is exact to within half a buffer.
+/// </para>
+/// </remarks>
+public interface IWaveLatency
+{
+    /// <summary>
+    /// The steady-state latency from a sample being queued for output to it being emitted by
+    /// the audio hardware, assuming uninterrupted playback. This is a property of the buffer
+    /// configuration and the driver, not of the current playback state.
+    /// </summary>
+    TimeSpan AverageLatency { get; }
+
+    /// <summary>
+    /// The time that has elapsed since the sample currently emerging from the hardware was
+    /// queued for output. In steady state this is approximately equal to
+    /// <see cref="AverageLatency"/>; it differs during start-up, after an underrun, or when
+    /// the host is filling buffers irregularly. Implementations that cannot meaningfully
+    /// distinguish from the average are permitted to return <see cref="AverageLatency"/>.
+    /// </summary>
+    TimeSpan CurrentLatency { get; }
+}

--- a/src/NAudio.Core/Wave/WaveOutputs/IWavePlayer.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/IWavePlayer.cs
@@ -1,124 +1,103 @@
-﻿using System;
+﻿
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
 
 /// <summary>
-/// Represents the interface to a device that can play a WaveFile
+/// Represents a hardware audio device that can play any <see cref="IWaveProvider"/> 
+/// instance provided to it's <see cref="Init" /> method. <br />
+/// This interface is typically implemented by audio drivers, such as WASAPI on Windows. <br />
+/// You are expected to release the acquired audio hardware 
+/// (by calling <see cref="IDisposable.Dispose" />) once you are finished using it.
 /// </summary>
+/// <seealso cref="IWavePosition" />
+/// <seealso cref="IWaveLatency" />
 public interface IWavePlayer : IDisposable
 {
-    /// <summary>
-    /// Begin playback
-    /// </summary>
+    /// <summary>Begin playback</summary>
     void Play();
 
-    /// <summary>
-    /// Stop playback
-    /// </summary>
+    /// <summary>Stop playback</summary>
     void Stop();
 
-    /// <summary>
-    /// Pause Playback
-    /// </summary>
+    /// <summary>Pause Playback</summary>
+    /// <remarks>
+    /// The way this method works is that during the Pause state,
+    /// the buffers of the driver are not yet cleared, but the
+    /// playback has been stopped. As such, later resuming playback
+    /// is faster than doing <see cref="Stop"/>, then <see cref="Play"/>. <br />
+    /// Note that not all drivers do necessarily implement this
+    /// because it depends on the programming model the driver is using.
+    /// </remarks>
     void Pause();
 
     /// <summary>
-    /// Initialise playback
+    /// Initialises playback from a given wave
+    /// provider that provides the samples to play.
     /// </summary>
-    /// <param name="waveProvider">The wave provider to be played</param>
+    /// <param name="waveProvider">The wave provider to be played.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="waveProvider" /> is <see langword="null" />.</exception>
     void Init(IWaveProvider waveProvider);
 
     /// <summary>
-    /// The volume 
-    /// 1.0f is full scale
-    /// Note that not all implementations necessarily support volume changes
+    /// Allows to modify the gain (volume) of the output audio. <br />
+    /// 1.0f is full scale, while 0.0f is silence.
     /// </summary>
+    /// <returns>
+    /// A value indicating the gain (volume) of the output audio. <br />
+    /// Implementations are permitted to always return 1f if the driver does
+    /// not have gain controls.
+    /// </returns>
+    /// <remarks>
+    /// Not all implementations do necessarily support getting/setting a volume value. <br />
+    /// In some drivers, this modifies the stream's volume, and in some others the global or the device's hardware volume.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">When setting the property: Volume changes are not supported.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">When setting the property: The new volume exceeds 1f, or is less than 0f.</exception>
     float Volume { get; set; }
 
     /// <summary>
-    /// Current playback state
+    /// Queries the current state of the playback.
     /// </summary>
+    /// <returns>
+    /// A value from the <see cref="Wave.PlaybackState"/> 
+    /// enumeration that indicates the state of the playback.
+    /// </returns>
     PlaybackState PlaybackState { get; }
 
     /// <summary>
-    /// Indicates that playback has gone into a stopped state due to 
-    /// reaching the end of the input stream or an error has been encountered during playback
+    /// The audio format under which the driver
+    /// provides samples to the connected-to hardware device.
+    /// </summary>
+    /// <remarks>
+    /// This is not necessarily the same format as the 
+    /// one provided from the <see cref="IWaveProvider" /> during <see cref="Init" />.
+    /// </remarks>
+    WaveFormat OutputWaveFormat { get; }
+
+    /// <summary>
+    /// Event that is dispatching when playback has been stopped. <br />
+    /// Playback can be stopped due to any of the following three reasons: <br />
+    /// <list type="bullet">
+    ///     <item>
+    ///         You called the <see cref="Stop"/> method. <br />
+    ///         In this case, the event args object 
+    ///         <see cref="StoppedEventArgs.Exception" /> property is <see langword="null" />.
+    ///     </item>
+    ///     <item>
+    ///         The provided <see cref="IWaveProvider"/> instance
+    ///         has reached it's end (no more samples to play). <br />
+    ///         In this case, the event args object 
+    ///         <see cref="StoppedEventArgs.Exception" /> property is <see langword="null" />.
+    ///     </item>
+    ///     <item>
+    ///         An error/exception has been occurred either by calling <see cref="IWaveProvider.Read(Span{byte})" />,
+    ///         or the driver has encountered a failure which it forced to stop playback. <br />
+    ///         In this case, the event args object 
+    ///         <see cref="StoppedEventArgs.Exception" /> property is <em>not</em> <see langword="null" />.
+    ///     </item>
+    /// </list>
     /// </summary>
     event EventHandler<StoppedEventArgs> PlaybackStopped;
-
-    /// <summary>
-    /// The WaveFormat this device is using for playback
-    /// </summary>
-    WaveFormat OutputWaveFormat { get; }
-}
-
-/// <summary>
-/// Interface for IWavePlayers that can report position
-/// </summary>
-public interface IWavePosition
-{
-    /// <summary>
-    /// Position (in terms of bytes played - does not necessarily translate directly to the position within the source audio file)
-    /// </summary>
-    /// <returns>Position in bytes</returns>
-    long GetPosition();
-
-    /// <summary>
-    /// Gets a <see cref="Wave.WaveFormat"/> instance indicating the format the hardware is using.
-    /// </summary>
-    WaveFormat OutputWaveFormat { get; }
-}
-
-/// <summary>
-/// Interface for audio players and captures that can report the latency between a sample
-/// entering the audio pipeline and emerging from (or being delivered by) the hardware.
-/// Implement alongside <see cref="IWavePlayer"/> or <see cref="IWaveIn"/> to let downstream
-/// code synchronise visualisations, lighting, video, recording timecode, or any other
-/// time-aligned consumer with audible output or captured input.
-/// </summary>
-/// <remarks>
-/// <para>
-/// Latency values are only meaningful during uninterrupted operation. When the device is
-/// stopped or paused, or when an underrun has occurred, implementations should return their
-/// best steady-state estimate rather than throw — consumers driving visualisations need a
-/// stable value to fall back on.
-/// </para>
-/// <para>
-/// The two properties answer different questions. <see cref="AverageLatency"/> describes the
-/// pipeline (it changes only when buffer settings change), so it is the right value for
-/// scheduling. <see cref="CurrentLatency"/> describes the live state of the pipeline at this
-/// instant and is the right value for drift detection or per-frame correction.
-/// </para>
-/// <para>
-/// <see cref="CurrentLatency"/> may be computed either as the forward queue depth (e.g. WASAPI
-/// <c>GetCurrentPadding</c> divided by sample rate — "if I queued a sample now, this is how
-/// long until I'd hear it") or as the wall-clock age of the sample currently at the play /
-/// capture head (timestamping each buffer fill). The two values converge in steady state and
-/// diverge only under irregular feed patterns; this interface deliberately permits either,
-/// so implementations can use whichever the underlying driver exposes most cheaply.
-/// </para>
-/// <para>
-/// For drivers whose buffer scheduling is fully predictable (notably ASIO, which always swaps
-/// fixed-size buffers at regular intervals), <see cref="CurrentLatency"/> may simply return
-/// <see cref="AverageLatency"/>. The approximation is exact to within half a buffer.
-/// </para>
-/// </remarks>
-public interface IWaveLatency
-{
-    /// <summary>
-    /// The steady-state latency from a sample being queued for output to it being emitted by
-    /// the audio hardware, assuming uninterrupted playback. This is a property of the buffer
-    /// configuration and the driver, not of the current playback state.
-    /// </summary>
-    TimeSpan AverageLatency { get; }
-
-    /// <summary>
-    /// The time that has elapsed since the sample currently emerging from the hardware was
-    /// queued for output. In steady state this is approximately equal to
-    /// <see cref="AverageLatency"/>; it differs during start-up, after an underrun, or when
-    /// the host is filling buffers irregularly. Implementations that cannot meaningfully
-    /// distinguish from the average are permitted to return <see cref="AverageLatency"/>.
-    /// </summary>
-    TimeSpan CurrentLatency { get; }
 }

--- a/src/NAudio.Core/Wave/WaveOutputs/IWavePosition.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/IWavePosition.cs
@@ -1,0 +1,19 @@
+﻿
+namespace NAudio.Wave;
+
+/// <summary>
+/// Extension interface for <see cref="IWavePlayer"/> implementations that can report position.
+/// </summary>
+public interface IWavePosition
+{
+    /// <summary>
+    /// Position (in terms of bytes played - does not necessarily translate directly to the position within the source audio file)
+    /// </summary>
+    /// <returns>Position in bytes</returns>
+    long GetPosition();
+
+    /// <summary>
+    /// Gets a <see cref="Wave.WaveFormat"/> instance indicating the format the hardware is using.
+    /// </summary>
+    WaveFormat OutputWaveFormat { get; }
+}

--- a/src/NAudio.Core/Wave/WaveOutputs/IWaveProvider.cs
+++ b/src/NAudio.Core/Wave/WaveOutputs/IWaveProvider.cs
@@ -1,20 +1,33 @@
-﻿using System;
+﻿
+using System;
 
 namespace NAudio.Wave;
 
 /// <summary>
-/// Generic interface for all WaveProviders.
+/// The <see cref="IWaveProvider" /> interface is the lowest-level primitive in NAudio that is an audio source -
+/// either that comes from a file that contains the samples, or from a signal generator
+/// generating audio on the fly, or even by wrapping another provider that manipulates it's samples. <br />
+/// Instances of this interface can form an audio pipeline that gets samples from a file (or generating them),
+/// optionally modifying them in a way, and then are fed to a native player API that can be used to listen to the
+/// processed result, or even storing them to a file for long-term access.
 /// </summary>
+/// <seealso cref="WaveStream" />
+/// <seealso cref="ISampleProvider" />
 public interface IWaveProvider
 {
     /// <summary>
-    /// Gets the WaveFormat of this WaveProvider.
+    /// Gets the wave format of this wave provider.
     /// </summary>
-    /// <value>The wave format.</value>
+    /// <returns>The wave format.</returns>
+    /// <remarks>
+    /// The audio format describes the wave data that are provided by successive <see cref="Read" /> calls. <br />
+    /// Without this, it is not possible to know how the audio samples are laid out. <br /> <br />
+    /// For most NAudio implementations, this typically returns a PCM or an IEEE floating-point format.
+    /// </remarks>
     WaveFormat WaveFormat { get; }
 
     /// <summary>
-    /// Fill the specified buffer with wave data.
+    /// Fills the specified buffer with wave data.
     /// </summary>
     /// <param name="buffer">The buffer to fill with audio data.</param>
     /// <returns>The number of bytes written. Return 0 to signal end of stream.</returns>

--- a/src/NAudio.Core/Wave/WaveStreams/WaveStream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveStream.cs
@@ -1,13 +1,37 @@
-﻿// created on 27/12/2002 at 20:20
+﻿
+// Created on 27/12/2002 at 20:20
+
 using System;
 using System.IO;
+
 // ReSharper disable once CheckNamespace
 namespace NAudio.Wave;
 
 /// <summary>
-/// Base class for all WaveStream classes. Derives from stream.
+/// The base class for seekable (repositionable) audio sources. <br />
+/// Derives from <see cref="Stream"/>, and 
+/// implements <see cref="IWaveProvider"/> so
+/// that it can be directly consumed by the entire NAudio audio processing pipeline. <br />
+/// Typically, this is used by file format readers, such as the <see cref="WaveFileReader"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>
+/// Building a new audio capable class: 
+/// <see cref="WaveStream"/> or <see cref="IWaveProvider"/> —
+/// what is more suitable to use and when?
+/// </b>
+/// </para>
+/// <para>
+/// The <see cref="WaveStream"/> class is suitable to be used as a base class when
+/// you are providing a new source into the NAudio audio pipeline that has immutable
+/// audio - that is, audio whose samples are not changed and their
+/// exact count is known once the object is initialized.
+/// File format readers is a primary example. <br />
+/// Instead, <see cref="IWaveProvider"/> is the interface that its implementation wraps
+/// another <see cref="IWaveProvider"/> and manipulates the audio samples in some way. <br />
+/// Using <see cref="IWaveProvider"/> is also suitable when building any signal generator.
+/// </para>
 /// <para>
 /// <b>Implementing a WaveStream — which Read method should I override?</b>
 /// </para>
@@ -31,11 +55,6 @@ namespace NAudio.Wave;
 /// </remarks>
 public abstract class WaveStream : Stream, IWaveProvider
 {
-    /// <summary>
-    /// Retrieves the WaveFormat for this stream
-    /// </summary>
-    public abstract WaveFormat WaveFormat { get; }
-
     // base class includes long Position get; set
     // base class includes long Length get
     // base class includes Read
@@ -57,15 +76,34 @@ public abstract class WaveStream : Stream, IWaveProvider
     public override bool CanWrite => false;
 
     /// <summary>
+    /// Retrieves the <see cref="Wave.WaveFormat"/> for this wave stream.
+    /// </summary>
+    /// <returns>The wave format.</returns>
+    /// <remarks>
+    /// The audio format describes the wave data that are provided by successive <see cref="Stream.Read(Span{byte})"/> calls. <br />
+    /// Without this, it is not possible to know how the audio samples are laid out. <br /> <br />
+    /// For most NAudio implementations, this typically returns a PCM or an IEEE floating-point format.
+    /// </remarks>
+    public abstract WaveFormat WaveFormat { get; }
+
+    /// <summary>
+    /// The block alignment for this wave stream. <br />
+    /// Do not modify the Position property to anything that is not a whole multiple of this value
+    /// </summary>
+    public virtual int BlockAlign => WaveFormat.BlockAlign;
+
+    /// <summary>
     /// Flush does not need to do anything
     /// See <see cref="Stream.Flush"/>
     /// </summary>
     public override void Flush() { }
 
-    /// <summary>
-    /// An alternative way of repositioning.
-    /// See <see cref="Stream.Seek"/>
-    /// </summary>
+    /// <summary>Sets the position within the current wave stream.</summary>
+    /// <param name="offset">A byte offset relative to the <paramref name="origin"/> parameter.</param>
+    /// <param name="origin">A value of type <see cref="SeekOrigin"/> indicating the reference point used to obtain the new position.</param>
+    /// <returns>The new position within the current wave stream.</returns>
+    /// <exception cref="IOException">An I/O error occurred.</exception>
+    /// <exception cref="ObjectDisposedException">The wave stream is disposed.</exception>
     public override long Seek(long offset, SeekOrigin origin)
     {
         if (origin == SeekOrigin.Begin)
@@ -78,79 +116,80 @@ public abstract class WaveStream : Stream, IWaveProvider
     }
 
     /// <summary>
-    /// Sets the length of the WaveStream. Not Supported.
+    /// Sets the length of the wave stream. <br />
+    /// This method call is not supported and will always throw <see cref="NotSupportedException"/>.
     /// </summary>
-    /// <param name="length"></param>
+    /// <param name="length" />
+    /// <exception cref="NotSupportedException">This method call is not supported.</exception>
     public override void SetLength(long length)
-    {
-        throw new NotSupportedException("Can't set length of a WaveFormatString");
-    }
+        => throw new NotSupportedException("Setting a new length value on a wave stream object is not possible.");
 
     /// <summary>
-    /// Writes to the WaveStream. Not Supported.
+    /// Writes to the wave stream. <br />
+    /// This method call is not supported and will always throw <see cref="NotSupportedException"/>.
     /// </summary>
+    /// <exception cref="NotSupportedException">This method call is not supported.</exception>
     public override void Write(byte[] buffer, int offset, int count)
-    {
-        throw new NotSupportedException("Can't write to a WaveFormatString");
-    }
+        => throw new NotSupportedException("A wave stream is not writeable.");
 
     /// <summary>
-    /// The block alignment for this wavestream. Do not modify the Position
-    /// to anything that is not a whole multiple of this value
-    /// </summary>
-    public virtual int BlockAlign => WaveFormat.BlockAlign;
-
-    /// <summary>
-    /// Moves forward or backwards the specified number of seconds in the stream
+    /// Moves forwards or backwards the specified number of seconds in the wave stream. <br />
+    /// If the computed new position exceeds the length of the wave stream, or is less than 0,
+    /// the value is clamped in the range [0..length], before setting it as a new position value.
     /// </summary>
     /// <param name="seconds">Number of seconds to move, can be negative</param>
+    /// <exception cref="IOException">An I/O error occurred.</exception>
+    /// <exception cref="ObjectDisposedException">The wave stream is disposed.</exception>
     public void Skip(int seconds)
     {
+        long length = Length;
         long newPosition = Position + WaveFormat.AverageBytesPerSecond * seconds;
         if (newPosition > Length)
-            Position = Length;
-        else if (newPosition < 0)
-            Position = 0;
+            newPosition = Length;
+        else if (newPosition < 0L)
+            newPosition = 0L;
         else
             Position = newPosition;
     }
 
     /// <summary>
-    /// The current position in the stream in Time format.
-    /// On set, the resulting byte position is rounded down to a multiple of
-    /// <see cref="BlockAlign"/> so the stream stays on a valid block boundary.
+    /// Gets/sets the current position in the stream in canonical time format. <br />
+    /// When this property is set, the resulting byte position is rounded down
+    /// to a multiple of <see cref="BlockAlign"/> so that the stream always stay
+    /// on a valid block boundary.
     /// </summary>
+    /// <returns>The current position in the wave stream, expressed as a <see cref="TimeSpan"/> structure.</returns>
+    /// <exception cref="IOException">An I/O error occurred.</exception>
+    /// <exception cref="ObjectDisposedException">The wave stream is disposed.</exception>
     public virtual TimeSpan CurrentTime
     {
-        get
-        {
-            return TimeSpan.FromSeconds((double)Position / WaveFormat.AverageBytesPerSecond);
-        }
+        get => TimeSpan.FromSeconds((double)Position / WaveFormat.AverageBytesPerSecond);
         set
         {
+            long length = Length;
             long bytePosition = (long)(value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
-            Position = bytePosition - (bytePosition % BlockAlign);
+            if (bytePosition < 0L)
+                Position = 0L;
+            else if (bytePosition > length)
+                Position = length;
+            else
+                Position = bytePosition - (bytePosition % BlockAlign);
         }
     }
 
     /// <summary>
     /// Total length in real-time of the stream (may be an estimate for compressed files)
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The wave stream is disposed.</exception>
     public virtual TimeSpan TotalTime
-    {
-        get
-        {
-            return TimeSpan.FromSeconds((double)Length / WaveFormat.AverageBytesPerSecond);
-        }
-    }
+        => TimeSpan.FromSeconds((double)Length / WaveFormat.AverageBytesPerSecond);
 
     /// <summary>
-    /// Whether the WaveStream has non-zero sample data at the current position for the 
-    /// specified count
+    /// Queries whether the wave stream has non-zero sample 
+    /// data at the current position for the specified <paramref name="count"/>.
     /// </summary>
-    /// <param name="count">Number of bytes to read</param>
-    public virtual bool HasData(int count)
-    {
-        return Position < Length;
-    }
+    /// <param name="count">Number of bytes to read.</param>
+    /// <exception cref="IOException">An I/O error occurred.</exception>
+    /// <exception cref="ObjectDisposedException">The wave stream is disposed.</exception>
+    public virtual bool HasData(int count) => Position < Length;
 }

--- a/src/NAudio.Core/Wave/WaveStreams/WaveStream.cs
+++ b/src/NAudio.Core/Wave/WaveStreams/WaveStream.cs
@@ -144,12 +144,12 @@ public abstract class WaveStream : Stream, IWaveProvider
     {
         long length = Length;
         long newPosition = Position + WaveFormat.AverageBytesPerSecond * seconds;
-        if (newPosition > Length)
-            newPosition = Length;
+        if (newPosition > length)
+            newPosition = length;
         else if (newPosition < 0L)
             newPosition = 0L;
-        else
-            Position = newPosition;
+
+        Position = newPosition;
     }
 
     /// <summary>
@@ -166,11 +166,24 @@ public abstract class WaveStream : Stream, IWaveProvider
         get => TimeSpan.FromSeconds((double)Position / WaveFormat.AverageBytesPerSecond);
         set
         {
-            long length = Length;
+            long length;
+            try
+            {
+                // Attempt to get the length.
+                // It is not necessary that all the streams will implement it,
+                // so we get the value only if we are able to do so, and otherwise
+                // set to 0 to indicate we could not get the length.
+                // This is special-cased in the if statement below.
+                length = Length;
+            }
+            catch
+            {
+                length = 0L;
+            }
             long bytePosition = (long)(value.TotalSeconds * WaveFormat.AverageBytesPerSecond);
             if (bytePosition < 0L)
                 Position = 0L;
-            else if (bytePosition > length)
+            else if (length > 0L && bytePosition > length) // Do the bound check only if we are able to do so.
                 Position = length;
             else
                 Position = bytePosition - (bytePosition % BlockAlign);


### PR DESCRIPTION
## Summary

This PR aims to fix the poorly provided documentation on the `WaveStream`, `IWaveProvider` and `ISampleProvider` classes.

The `WaveProviders.md` document has been also updated to match the new Span API contract these classes do require from now on, and it's text is also updated to better describe what each class does.

As a side effect, the `IWavePlayer` XML docs have been also updated, and the extension interfaces (`IWavePosition` and `IWaveLatency`) have gained their own source file.

Feel free to push back on the provided XML documentation if you feel that there is missing something, or if something was written too verbose or anything else.

While modifying the XML docs in the `WaveStream` class, there was also something that captured my attention: the `CurrentTime` setter does not bound-check the Position value it passes to the Position setter. Typically, all the Position setters do bound-check so this is not a bug or a concerning issue but it is rather done to have it right.

By the way, I am also working on the macOS wrappers documentation alongside this one, I will open the PR when that is ready.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [X] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

No testing required, most of the changes are documentation,
and rather does and a reliability fix in the WaveStream CurrentTime property setter.