### PR TITLE
Retry the measurement window in EffectAllocationTests

### DIFF
--- a/tests/NAudio.Core.Tests/Effects/EffectAllocationTests.cs
+++ b/tests/NAudio.Core.Tests/Effects/EffectAllocationTests.cs
@@ -27,6 +27,13 @@ public class EffectAllocationTests
         new Equalizer(EqualizerBand.Peaking(1000f, 1f, 6f))
     };
 
+    private const int ProcessCallsPerWindow = 512;
+
+    /// <summary>
+    /// How many consecutive measurement windows an effect may use to produce an allocation-free one.
+    /// </summary>
+    private const int MeasurementWindows = 3;
+
     [Test]
     public void SteadyStateProcessDoesNotAllocate(
         [ValueSource(nameof(Representative))] AudioEffect effect)
@@ -42,12 +49,34 @@ public class EffectAllocationTests
         for (var w = 0; w < 64; w++)
             effect.Process(buffer);
 
-        var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var p = 0; p < 512; p++)
-            effect.Process(buffer);
-        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        // Measure more than once, stopping at the first allocation-free window. Warm-up cannot
+        // fully guarantee that nothing one-off lands on this thread afterwards - a tiering
+        // transition or a lazy runtime init has no call count we can wait out - and this test has
+        // failed in CI on a single one-off of ~1.4KB, which is not a per-call cost. What the claim
+        // actually needs is that no window allocates, and a genuine per-call allocation dirties
+        // every window, so retrying keeps the guarantee strict while dropping that false failure.
+        var allocated = long.MaxValue;
+        var windowsUsed = 0;
+        while (windowsUsed < MeasurementWindows && allocated != 0)
+        {
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var p = 0; p < ProcessCallsPerWindow; p++)
+                effect.Process(buffer);
+            allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            windowsUsed++;
+        }
+
+        if (allocated == 0 && windowsUsed > 1)
+        {
+            // Not a failure, but worth surfacing: if this line starts appearing routinely, the
+            // cause is likely a real lazy allocation rather than one-off runtime noise.
+            TestContext.WriteLine(
+                $"{effect.GetType().Name}: allocation-free on window {windowsUsed} of {MeasurementWindows}, " +
+                "after an earlier window allocated.");
+        }
 
         Assert.That(allocated, Is.EqualTo(0L),
-            $"{effect.GetType().Name} allocated {allocated} bytes across 512 Process calls");
+            $"{effect.GetType().Name} allocated {allocated} bytes across {ProcessCallsPerWindow} Process " +
+            $"calls in every one of {MeasurementWindows} consecutive windows");
     }
 }

--- a/tests/NAudio.Core.Tests/Effects/EffectAllocationTests.cs
+++ b/tests/NAudio.Core.Tests/Effects/EffectAllocationTests.cs
@@ -55,6 +55,7 @@ public class EffectAllocationTests
         // failed in CI on a single one-off of ~1.4KB, which is not a per-call cost. What the claim
         // actually needs is that no window allocates, and a genuine per-call allocation dirties
         // every window, so retrying keeps the guarantee strict while dropping that false failure.
+        var windows = new long[MeasurementWindows];
         var allocated = long.MaxValue;
         var windowsUsed = 0;
         while (windowsUsed < MeasurementWindows && allocated != 0)
@@ -63,7 +64,7 @@ public class EffectAllocationTests
             for (var p = 0; p < ProcessCallsPerWindow; p++)
                 effect.Process(buffer);
             allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-            windowsUsed++;
+            windows[windowsUsed++] = allocated;
         }
 
         if (allocated == 0 && windowsUsed > 1)
@@ -76,7 +77,7 @@ public class EffectAllocationTests
         }
 
         Assert.That(allocated, Is.EqualTo(0L),
-            $"{effect.GetType().Name} allocated {allocated} bytes across {ProcessCallsPerWindow} Process " +
-            $"calls in every one of {MeasurementWindows} consecutive windows");
+            $"{effect.GetType().Name} allocated on every one of {windowsUsed} consecutive windows of " +
+            $"{ProcessCallsPerWindow} Process calls: {string.Join(", ", windows[..windowsUsed])} bytes");
     }
 }


### PR DESCRIPTION
## Summary

`EffectAllocationTests.SteadyStateProcessDoesNotAllocate` failed once in CI (on #1443, whose diff is entirely in `NAudio.Wasapi` and cannot reach this code) with:

```
CompressorEffect allocated 1424 bytes across 512 Process calls
```

1424 bytes over 512 calls is ~2.8 bytes per call, so it is a **single one-off allocation** billed to the measuring thread, not a steady-state cost. `CompressorEffect.ProcessBlock` is float math over a `Span<float>` with no allocating path — no boxing, closures or lazy buffers.

Warm-up can't rule that out on its own, because the events that can land after it (a tiering transition, a lazy runtime init) aren't gated on a call count we can wait out. Raising the warm-up count only narrows the window; it doesn't close it, since the delays involved are wall-clock based.

What the test exists to pin is that *no window allocates*. So it now measures up to three consecutive windows and stops at the first clean one:

- a genuine per-call allocation dirties **every** window and still fails
- a one-off can only dirty **one**, and no longer fails the run

A window that needed a retry is reported through `TestContext`, so if this starts happening routinely it stays visible rather than being silently swallowed — that would point at a real lazy allocation worth chasing.

This costs nothing in the common case, where the first window is already clean and the loop exits after one pass.

### Why not the alternatives

- **More warm-up** narrows but doesn't close the race, and isn't free: measured per-call `Process` cost across the six representative effects totals ~89 µs, so warm-up 64 → 1000 adds ~83 ms to the fixture.
- **Disabling tiered compilation** for the assembly would close it, but changes JIT behaviour for every test in `NAudio.Core.Tests`, including the throughput-sensitive ones.
- **`RuntimeHelpers.PrepareMethod`** does not help: it guarantees the method is compiled, but under tiered compilation it can still be tier-0 and re-JIT later, which is the event in question.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

Full `NAudio.Core.Tests` suite passes in Release: 1542 total, 0 failed, 3 skipped.

Because the flake could not be reproduced, the fix was verified by injecting the failure instead. Temporary fake effects were passed to the real test method:

- one allocating a single 1400-byte block on the first call after warm-up (the shape of the CI failure) — now **passes**
- one allocating on every call — still **fails**

Both scaffolds were removed before committing.

**Reproduction attempt (for the record):** the flake did not reproduce locally in ~5,500 samples. A standalone probe replicating the test — 64 warm-up calls, then three measured windows per effect, one process per cold-JIT opportunity — produced zero dirty first windows across 400 idle runs (2400 samples), 200 runs under 3× CPU oversubscription (1200 samples), and a sweep of `DOTNET_TC_CallCountingDelayMs` from 0 to 400 ms (900 samples). Looping the real NUnit test 40 times under load added another 240 clean samples. So on Linux/Release the rate is below roughly 1 in 5,000 case-executions; CI is Windows/Release under six concurrently running test assemblies, which is the environment where it did appear. The specific mechanism therefore remains **unconfirmed** — the fix is deliberately mechanism-agnostic, which is part of why I'd prefer it to a targeted guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N6xNEbsxFXMrjTERGsJg9

---
_Generated by [Claude Code](https://claude.ai/code/session_012N6xNEbsxFXMrjTERGsJg9)_