### PR TITLE
Stop forcing Windows PDBs in Debug (fixes CS8911 in NAudio.MacOS)

### DIFF
--- a/src/NAudio.Dmo/NAudio.Dmo.csproj
+++ b/src/NAudio.Dmo/NAudio.Dmo.csproj
@@ -8,12 +8,6 @@
     <Description>DirectX Media Objects (echo, chorus, reverb, MP3 decoder, resampler) and DirectSound output for the NAudio audio library.</Description>
   </PropertyGroup>
 
-  <!-- needed for perfomance profiling unit tests -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-	<DebugType>full</DebugType>
-	<DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\NAudio.Core\NAudio.Core.csproj" />
   </ItemGroup>

--- a/src/NAudio.MacOS/NAudio.MacOS.csproj
+++ b/src/NAudio.MacOS/NAudio.MacOS.csproj
@@ -36,18 +36,17 @@
   </PropertyGroup>
 
   <!--
-    No <DebugType>full</DebugType> here, unlike the Dmo/Wasapi/WinMM/Vst3
-    projects. On Windows that selects the legacy Windows PDB writer, which
-    records using-aliases in debug info by serialising the aliased type's
-    name — and GlobalUsings.cs aliases function pointer types, which that
-    format cannot express. The result was a Debug-only, Windows-only
-    "CSC : error CS8911: Using a function pointer type in this context is
-    not supported", with no file or line because it comes out of the emit
-    layer rather than the binder. CI never saw it: it builds Release, where
-    the condition did not apply. Other platforms never saw it either, as
-    csc silently falls back to a portable PDB when the native writer is
-    unavailable. The SDK default (portable) carries the same debug
-    information, so nothing is lost by leaving it alone.
+    Do not set <DebugType>full</DebugType> here. On Windows that selects the
+    legacy Windows PDB writer, which records using-aliases in debug info by
+    serialising the aliased type's name — and GlobalUsings.cs aliases
+    function pointer types, which that format cannot express. The result is
+    a Debug-only, Windows-only "CSC : error CS8911: Using a function pointer
+    type in this context is not supported", with no file or line because it
+    comes out of the emit layer rather than the binder. CI never saw it: it
+    builds Release, where the condition did not apply. Other platforms never
+    saw it either, as csc silently falls back to a portable PDB when the
+    native writer is unavailable. The SDK default (portable) carries the
+    same debug information.
   -->
 
   <!-- Provide assembly attributes here -->

--- a/src/NAudio.MacOS/NAudio.MacOS.csproj
+++ b/src/NAudio.MacOS/NAudio.MacOS.csproj
@@ -35,11 +35,20 @@
     <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.0</VersionSuffix>
   </PropertyGroup>
 
-  <!-- needed for perfomance profiling unit tests -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-	  <DebugType>full</DebugType>
-	  <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
+  <!--
+    No <DebugType>full</DebugType> here, unlike the Dmo/Wasapi/WinMM/Vst3
+    projects. On Windows that selects the legacy Windows PDB writer, which
+    records using-aliases in debug info by serialising the aliased type's
+    name — and GlobalUsings.cs aliases function pointer types, which that
+    format cannot express. The result was a Debug-only, Windows-only
+    "CSC : error CS8911: Using a function pointer type in this context is
+    not supported", with no file or line because it comes out of the emit
+    layer rather than the binder. CI never saw it: it builds Release, where
+    the condition did not apply. Other platforms never saw it either, as
+    csc silently falls back to a portable PDB when the native writer is
+    unavailable. The SDK default (portable) carries the same debug
+    information, so nothing is lost by leaving it alone.
+  -->
 
   <!-- Provide assembly attributes here -->
   <ItemGroup>

--- a/src/NAudio.Vst3/NAudio.Vst3.csproj
+++ b/src/NAudio.Vst3/NAudio.Vst3.csproj
@@ -9,11 +9,6 @@
     <PackageTags>$(PackageTags) vst vst3 plugin host</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\NAudio.Core\NAudio.Core.csproj" />
     <ProjectReference Include="..\NAudio.Midi\NAudio.Midi.csproj" />

--- a/src/NAudio.Wasapi/NAudio.Wasapi.csproj
+++ b/src/NAudio.Wasapi/NAudio.Wasapi.csproj
@@ -15,12 +15,6 @@
     <Description>WASAPI playback and capture (including loopback and process loopback) and Media Foundation codecs for the NAudio audio library. Windows-only at runtime.</Description>
   </PropertyGroup>
 
-  <!-- needed for perfomance profiling unit tests -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-	<DebugType>full</DebugType>
-	<DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\NAudio.Core\NAudio.Core.csproj" />
     <!-- NAudio.Midi reference dropped: WinRT MIDI (its only consumer here) moved

--- a/src/NAudio.WinMM/NAudio.WinMM.csproj
+++ b/src/NAudio.WinMM/NAudio.WinMM.csproj
@@ -8,12 +8,6 @@
     <Description>winmm.dll-based Windows audio APIs (WaveOut, WaveIn, MidiIn, MidiOut, ACM) for the NAudio audio library.</Description>
   </PropertyGroup>
 
-	<!-- needed for perfomance profiling unit tests -->
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
       <_Parameter1>windows</_Parameter1>


### PR DESCRIPTION
## Summary

A Debug build of `NAudio.MacOS` on Windows fails with no file or line:

```
NAudio.MacOS net9.0 failed with 1 error(s)
    CSC : error CS8911: Using a function pointer type in this context is not supported.
```

The cause is in our csproj, not the compiler. `NAudio.MacOS.csproj` set `<DebugType>full</DebugType>` for `Debug|AnyCPU`, copied from the Dmo/Wasapi/WinMM/Vst3 projects along with their `needed for perfomance profiling unit tests` comment. On Windows, `full` selects the legacy Windows PDB writer, which records `using`-aliases in debug info by serialising the aliased type's name — and `GlobalUsings.cs` aliases seven `delegate* unmanaged[Cdecl]<...>` types, which that format cannot express. `full` is a PDB *format*, not a completeness setting, so nothing is lost by dropping it: `portable` (the SDK default) carries the same debug information.

Two things hid this:

- **CI builds Release**, where the condition never applied, so `build.yml` has been green throughout.
- **Only Windows can reach the failure.** On Linux and macOS `csc` has no native PDB writer available and silently falls back to a portable PDB — with `DebugType` still `full`, the emitted PDB carries the portable `BSJB` signature and the build succeeds. That is why it reproduces on a maintainer's Windows 11 box and nowhere else.

Evidence for the mechanism: CS8911 has exactly two location-less reporting sites in `Microsoft.CodeAnalysis.dll`, both in `Microsoft.Cci`, one of them reached from `PdbWriter.GetOrCreateSerializedTypeName` — which is why the diagnostic arrives from the emit layer with no source location instead of from the binder. The failing build's binlog shows `/debug:full` on the `csc` command line. Related, and arguably still a compiler bug since a PDB format limitation should not fail a build: https://github.com/dotnet/roslyn/issues/77389

Second commit removes the same property group from `NAudio.Dmo`, `NAudio.Wasapi`, `NAudio.WinMM` and `NAudio.Vst3`. None of them can hit CS8911 today — that needs a function pointer using-alias, which only `NAudio.MacOS` declares — but the property buys nothing and sets the trap for whoever adds one next. All five projects now produce portable PDBs, like the rest of the repo.

## Release notes

- [x] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)

Packages are built in Release, where none of this applied, so the shipped artifacts are unaffected; this only changes the PDB format of a local Debug build.

## Testing

- **Confirmed on Windows 11 / .NET SDK 10.0.400**: the Debug build of this branch succeeds on the machine that reported the failure. That is the check that matters, since Windows is the only platform where the native PDB writer is reachable and therefore the only one where the bug reproduces.
- `NAudio.MacOS` builds clean in Debug and Release, and `DebugType` now evaluates to `portable` in Debug for all five projects.
- Full `dotnet build NAudio.slnx -c Debug -t:Rebuild` succeeds with 0 errors.
- Ruled out the alternatives before landing on the PDB writer: the project builds clean against Roslyn 4.11, 4.12, 4.13, 4.14, 5.0, 5.3, 5.6 and 5.9 toolsets, and against `Microsoft.NETCore.App.Ref` 9.0.0 / 9.0.4 / 9.0.11 / 9.0.20, so neither the compiler version nor the source generators were implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdtDoXpk9r7DvHHtbxB3hy