### PR TITLE
macOS wrappers documentation

### DIFF
--- a/Docs/ExtendedAudioFileServicesReader.md
+++ b/Docs/ExtendedAudioFileServicesReader.md
@@ -1,0 +1,237 @@
+﻿
+### Reading audio files with Extended Audio File Services (macOS)
+
+Along with the new `CoreAudio` HAL backend, the new `NAudio.MacOS` package 
+also ships wrappers for the Extended Audio File Services API (Audio Toolbox), 
+which is equivalent to `MediaFoundationReader`. Let's see what it offers.
+
+First of all, you need to reference the `NAudio.MacOS` package into your project.
+Note that it ships pre-release only while its API settles, so `--prerelease` is also required:
+
+~~~C#
+dotnet add package NAudio.MacOS --prerelease
+~~~
+
+### Reading an audio file
+
+Let's assume that you want to read an MP3 file.
+With the reader of Extended Audio File Services, you can do it this way:
+
+~~~C#
+using NAudio.Wave;
+
+using var reader = ExtendedAudioFileReaderFromURL.CreateFromFile(
+    "/Users/user_name/a_file.mp3"
+);
+~~~
+
+You can of course specify any file path; the path provided here is purely illustrative.
+
+It is possible to open a file from a .NET data stream as well:
+
+~~~C#
+using NAudio.Wave;
+
+using var reader = new ExtendedAudioFileReaderFromStream(
+    dataStream
+);
+~~~
+
+> [!NOTE]
+The reader extends the `WaveStream` class, so you have a seekable
+(repositionable) source of data for any file supported through the reader.
+
+> [!NOTE]
+The reader does the best effort to decode to PCM, as such you will only ever
+recieve PCM audio data through the reader, or it will fail fast during initialization.
+
+### Supported formats
+
+The reader has been tested and verified to work with:
+
+- MP3
+- MP4/AAC
+- CAF
+- WAV
+- AIFF
+- FLAC
+- OGG Vorbis
+
+Which of those formats is actually supported and which not depends on 
+the macOS version you use.
+You are able to query the supported file formats as MIME types at run-time:
+
+~~~C#
+using System;
+using NAudio.MacOS.AudioToolbox;
+
+foreach (var mimeType in AudioFileLibraryInformation.SupportedMimeTypes)
+{
+    Console.WriteLine(mimeType);
+}
+~~~
+
+### Modifying the initialization behavior of the reader.
+
+Both of these reader classes do accept a settings object that modifies 
+how the reader should initialize. That settings class is the `ExtendedAudioFileReaderSettings`
+class, and it is located into `NAudio.MacOS.AudioToolbox`:
+
+~~~C#
+using NAudio.Wave;
+
+namespace NAudio.MacOS.AudioToolbox;
+
+public class ExtendedAudioFileReaderSettings
+{
+    public bool RequestIeeeFloat { get; set; }
+
+    public bool AllowNonPowerOfTwoBitDepths { get; set; }
+
+    public WaveFormat OutputFormat { get; set; }
+}
+~~~
+
+#### The `RequestIeeeFloat` property
+
+When you assign this property to `true`, you instruct the reader 
+to return 32-bit IEEE floating-point audio samples. It is useful 
+for injecting the reader into an `ISampleProvider` chain,
+and you can also very easily manipulate the samples.
+
+Even though that the reader does not implement `ISampleProvider`
+inherently, you can use the `ToSampleProvider` extension method
+to get an `ISampleProvider` that will give you the floating-point samples.
+
+The default value of this property is `false`, which indicates to the reader
+to use whatever format the file is into, and convert it to it's closest PCM format.
+
+#### The `AllowNonPowerOfTwoBitDepths` property
+
+When you assign this property to `true`, you instruct the reader to use whatever
+bit depth the audio format is into. Most of the times, the samples of the audio files
+are subject to be modified in a way, so this assures that you can use a numeric
+type that you can easily handle, if you are doing the processing yourself.
+
+If, however, you do not intend to somehow modify the samples, you can keep this to `false`.
+
+> [!WARNING]
+When the `RequestIeeeFloat` property is defined to `true`, that will take precendence
+over this one as the reader will go ahead and directly specify a 32-bit IEEE floating-point format.
+
+#### The `OutputFormat` property
+
+While the internal algorithm does a decent job defining a good PCM or IEEE floating-point format,
+you might need a very specific format that you need to read the file into.
+With this property, you can specify a completely specified PCM or IEEE floating-point format
+to use. It also supports specifying the format with `WaveFormatExtensible` and honours the provided `ChannelMask`.
+
+The default value of this property is `null`, which instructs 
+the reader to use the internal algorithm to define the output format.
+
+> [!WARNING]
+When this property is appropriately defined, it takes precedence over the `RequestIeeeFloat`
+and the `AllowNonPowerOfTwoBitDepths` properties as these properties are solely existing
+for modifying the behavior of the internal algorithm.
+
+There is also an extended variant of this settings object, provided only
+for when you work with streams. This is the `ExtendedAudioFileReaderFromStreamSettings` class,
+and derives from `ExtendedAudioFileReaderSettings`, so it inherits all the properties from it:
+
+~~~C#
+using NAudio.MacOS.AudioToolbox;
+
+namespace NAudio.Wave;
+
+public sealed class ExtendedAudioFileReaderFromStream : ExtendedAudioFileServicesReader
+{
+    public sealed class ExtendedAudioFileReaderFromStreamSettings : ExtendedAudioFileReaderSettings
+    {
+        public string MimeType { get; set; }
+
+        public string FileName { get; set; }
+    }
+}
+~~~
+
+#### The `MimeType` property
+
+A MIME type string treated as a hint to the reader that will better help to identify the type
+of the audio file being decoded. 
+
+It is optional, and the reader does a decent job finding the audio file type of the provided stream.
+
+The MIME types can be queried at run-time using this code:
+
+~~~C#
+using System;
+using NAudio.MacOS.AudioToolbox;
+
+foreach (var mimeType in AudioFileLibraryInformation.SupportedMimeTypes)
+{
+    Console.WriteLine(mimeType);
+}
+~~~
+
+> [!CAUTION]
+Try not to hardcode the MIME type given to this parameter as it subject to change
+in different macOS versions. Make sure to call first the `SupportedMimeTypes` property
+and use one of those values.
+
+#### The `FileName` property
+
+There might be cases that you cannot know the MIME type of the stream, but
+you know it's name. So, you can provide it to this property.
+You may also just provide a bare file extension, such as `.m4a`.
+
+Just like the `MimeType` property, this is just a hint and the reader
+does a decent job finding the audio file type of the provided stream.
+
+> [!CAUTION]
+If you specify both `FileName` and `MimeType` properties, the reader
+will prefer to use the `MimeType` property as the MIME type property
+is a formal description of the data stream.
+
+The supported file types (by extension) can be also queried with this snippet:
+
+~~~C#
+using System;
+using NAudio.MacOS.AudioToolbox;
+
+foreach (var extension in AudioFileLibraryInformation.RecognizedFileExtensions)
+{
+    Console.WriteLine(mimeType);
+}
+~~~
+
+> [!CAUTION]
+The file extensions returned through the `RecognizedFileExtensions` property
+do *not* have a dot prepended to them. Make sure to prepend a dot if you want
+to use them with the `System.IO` API's.
+
+### Play back a MP3 file.
+
+This rather simple code example illustrates how to read an MP3 file
+using the Extended Audio File Services reader and use the `CoreAudioPlayer` API to play it back.
+
+Make sure to read the [`CoreAudioPlayer`](PlayAudioFileMacOS.md) document 
+first to understand what the below does, if you have not.
+
+
+~~~C#
+using NAudio.Wave;
+
+using var reader = ExtendedAudioFileReaderFromURL.CreateFromFile(
+    "/Users/user_name/a_second_file.mp3"
+);
+
+using var player = new CoreAudioPlayer();
+
+player.Init(reader);
+player.Play();
+
+while (player.PlaybackState == PlaybackState.Playing)
+{
+    System.Threading.Thread.Sleep(400);
+}
+~~~

--- a/Docs/ExtendedAudioFileServicesReader.md
+++ b/Docs/ExtendedAudioFileServicesReader.md
@@ -174,7 +174,7 @@ foreach (var mimeType in AudioFileLibraryInformation.SupportedMimeTypes)
 ~~~
 
 > [!CAUTION]
-Try not to hardcode the MIME type given to this parameter as it subject to change
+Try not to hardcode the MIME type given to the property as it subject to change
 in different macOS versions. Make sure to call first the `SupportedMimeTypes` property
 and use one of those values.
 

--- a/Docs/ExtendedAudioFileServicesWriter.md
+++ b/Docs/ExtendedAudioFileServicesWriter.md
@@ -1,0 +1,68 @@
+﻿
+## Creating new audio files with Extended Audio File Services (macOS)
+
+Along with the new `CoreAudio` HAL backend, the new `NAudio.MacOS` package 
+also ships wrappers for the Extended Audio File Services API (Audio Toolbox), 
+which is equivalent to `MediaFoundationEncoder`. Let's see what it offers.
+
+First of all, you need to reference the `NAudio.MacOS` package into your project.
+Note that it ships pre-release only while its API settles, so `--prerelease` is also required:
+
+~~~C#
+dotnet add package NAudio.MacOS --prerelease
+~~~
+
+### Writing an audio file
+
+Let's assume that we want to write a new MP4 AAC file (MP3 is not supported).
+
+Let's also assume that we provide the data to write in 16 bit 44.1 kHz PCM with 2 channels:
+
+Doing so is pretty much straightforward:
+
+~~~C#
+using NAudio.Wave;
+using NAudio.MacOS.AudioToolbox;
+
+var writer = ExtendedAudioFileWriter.CreateToFilePath(
+    "/Users/your_name/a_file.m4a",
+    new ExtendedAudioFileWriterSettings()
+    {
+        FileType = "audio/mp4",
+        ProvidingFormat = new WaveFormat(44100, 16, 2) // The format of the audio data you provide to the writer.
+    },
+    true // Overwrites the file, if /Users/your_name/a_file.m4a exists. If false, it throws an exception if the file exists.
+);
+
+// Write the data you want to write. Use writer.Write(Span<byte>) to do so.
+// Close the writer with Dispose() so that the writer can patch and finalize the file for consumption.
+~~~
+
+> [!NOTE]
+For plain uncompressed output, prefer `WaveFileWriter`: WAV is what
+every other tool reads. `AiffFileWriter` in the Core library is there if
+you want AIFF, and handles the byte-order swap to AIFF's big-endian
+layout for you.
+
+> [!NOTE]
+The writer also supports creating a file into a .NET data stream.
+The same settings apply to that case, except for the last parameter,
+which it does not exist. See the `CreateToStream` static method
+in `ExtendedAudioFileWriter` for more information.
+
+> [!CAUTION]
+For the writer to write files into a .NET `System.IO.Stream`, the object
+must support all the operations, that is, reading, writing and seeking.
+If your object is not that capable, use a `MemoryStream` so that
+the writer can handle the stream, then copy it's data to your 
+target stream.
+
+> [!NOTE]
+The `ProvidingFormat` setting must be a PCM or IEEE floating-point format.
+
+> [!CAUTION]
+Do not try to hardcode the `FileType` property as it's acceptable values
+may vary by macOS version. You can read the supported values at
+run-time from the `AudioFileLibraryInformation.SupportedMimeTypes` property.
+
+

--- a/Docs/PlayAudioFileMacOS.md
+++ b/Docs/PlayAudioFileMacOS.md
@@ -1,4 +1,4 @@
-## Play an Audio File on macOS with Core Audio
+﻿## Play an Audio File on macOS with Core Audio
 
 On macOS there is no WASAPI or WaveOut. The `NAudio.MacOS` package adds
 `CoreAudioPlayer`, an `IWavePlayer` that plays through the Core Audio
@@ -6,17 +6,17 @@ HAL. It is referenced explicitly (it is not part of the `NAudio`
 meta-package), and it ships pre-release only while its API settles, so
 `--prerelease` is required:
 
-```sh
+~~~sh
 dotnet add package NAudio.MacOS --prerelease
-```
+~~~
 
-`CoreAudioPlayer` plays any `IWaveProvider`. For a WAV file, use
-`WaveFileReader` from `NAudio.Core`:
+`CoreAudioPlayer` can play any `IWaveProvider` you give to it. 
+For a WAV file, you can use `WaveFileReader` from the Core library:
 
-```c#
+~~~C#
 using NAudio.Wave;
 
-using (var audioFile = new WaveFileReader("test.wav"))
+using (var audioFile = new WaveFileReader("any.wav"))
 using (var outputDevice = new CoreAudioPlayer())   // default output device
 {
     outputDevice.Init(audioFile);
@@ -26,57 +26,25 @@ using (var outputDevice = new CoreAudioPlayer())   // default output device
         Thread.Sleep(200);
     }
 }
-```
+~~~
 
-There is no device-format negotiation to worry about: when the
-provider's format does not match the device's, `CoreAudioPlayer`
-configures a Core Audio converter internally and resamples for you.
+> [!NOTE]
+The `CoreAudioPlayer` does not require any device format negotiation to be done
+by your side. That is managed by the internal algorithms of the class. When the format
+of your wave provider does not match the HAL's current format, it resamples internally
+to match it. Because the HAL format changes frequently, 
+the class handles these changes for you appropriately.
 
-### Playing compressed formats
+### Selecting the output device to perform playback
 
-`AudioFileReader` is not the answer here — its cross-platform build
-handles only PCM WAV and AIFF, and throws `NotSupportedException` for
-MP3 and everything else.
+If you do not want to use the default output device to perform the playback,
+you can enumerate the available devices on the system by getting the `Devices`
+property on the HAL's audio system object:
 
-Use `ExtendedAudioFileReaderFromURL` instead. It is a `WaveStream` over
-macOS Extended Audio File Services — the macOS equivalent of
-`MediaFoundationReader` — decoding to PCM with no extra install, because
-the codecs are part of the OS:
-
-```c#
-using NAudio.Wave;
-
-using var audioFile = ExtendedAudioFileReaderFromURL.CreateFromFile("test.m4a");
-using var outputDevice = new CoreAudioPlayer();
-outputDevice.Init(audioFile);
-outputDevice.Play();
-```
-
-That covers MP3, AAC/M4A, ALAC, FLAC and AIFF among others. The exact
-set depends on the macOS version, and can be queried at runtime:
-
-```c#
-using NAudio.MacOS.AudioToolbox;
-
-foreach (var extension in AudioFileLibraryInformation.RecognizedFileExtensions)
-{
-    Console.WriteLine(extension);
-}
-```
-
-Pass an `ExtendedAudioFileReaderSettings` to control what comes back —
-`RequestIeeeFloat` for 32-bit float, or `OutputFormat` for a specific
-`WaveFormat`, converted as the file is read.
-`ExtendedAudioFileReaderFromStream` does the same over a `Stream`.
-
-### Choosing an output device
-
-The default device comes from the system object; enumerate `Devices` to
-pick another one and pass it to the constructor:
-
-```c#
+~~~C#
 using NAudio.MacOS.CoreAudio;
 
+// Enumerate all the devices that provide output.
 foreach (var device in AudioSystemObject.Instance.Devices)
 {
     if (device.GetStreams(AudioObjectPropertyScopeConstants.Output).Length > 0)
@@ -84,11 +52,47 @@ foreach (var device in AudioSystemObject.Instance.Devices)
         Console.WriteLine($"{device.Name} - {device.Manufacturer}");
     }
 }
-// using var outputDevice = new CoreAudioPlayer(chosenDevice);
-```
+// Once you have selected an audio device, you can give it to the player:
+// using var createdPlayer = new CoreAudioPlayer(chosenDevice);
+~~~
 
-Note that `CoreAudioPlayer.Volume` is the *device's* volume, not a
-software gain like `AlsaOut.Volume` — setting it moves the system
-output level for that device. Handle `PlaybackStopped` to be notified
-when playback ends or fails; its `Exception` is `null` on a normal end
-of stream or an explicit `Stop()`.
+> [!NOTE]
+The `Devices` property returns all the devices installed to the system at the time of calling it.
+That includes input and output devices.
+
+> [!NOTE]
+You can also retrieve a hidden device by using the `ConvertUIDToDevice` method,
+that is provided in the instance of the audio system object.
+You have to know it's UID to retrieve such device.
+You can also always retrieve the UID of the device, 
+by calling the `DeviceUID` property on the device object. 
+For the `CoreAudioPlayer`, you can retrieve the device object 
+that it uses to do playback by invoking the `Device` property.
+
+### Changing the gain (volume) of the device
+
+The device's volume can be changed by setting the `Volume` property on the `CoreAudioPlayer` instance:
+
+~~~C#
+createdPlayer.Volume = 0.8f;
+~~~
+
+> [!WARNING]
+Unlike many other `IWavePlayer` implementations, this implementation directly modifies the 
+hardware volume control of the device. It is not recommended to modify this value as the
+user of the OS sets this to a desired value. If you want to modify the gain without 
+disrupting the user's value, use a `VolumeSampleProvider`.
+
+In some cases, you might be able to modify the volume of the device per-channel.
+To do this, retrieve the device's control list and enumerate through the controls:
+
+~~~C#
+foreach (var control in createdPlayer.Device.ControlList)
+{
+    if (control is AudioLevelControl lc && lc.Kind == AudioControlKind.VolumeControl)
+    {
+        System.Console.WriteLine("Modifying volume of channel {0}.", lc.Element);
+        lc.ScalarValue = 0.8f;
+    }
+}
+~~~

--- a/Docs/RecordAudioFileMacOS.md
+++ b/Docs/RecordAudioFileMacOS.md
@@ -1,20 +1,32 @@
-## Record an Audio File on macOS with Core Audio
+﻿## Record from a device on macOS with Core Audio
 
 The `NAudio.MacOS` package provides `CoreAudioRecorder`, which records
-from a Core Audio input device. It ships pre-release only while its API
+from a Core Audio (HAL) input device. It ships pre-release only while its API
 settles, so `--prerelease` is required:
 
 ```sh
 dotnet add package NAudio.MacOS --prerelease
 ```
 
-`CoreAudioRecorder` is **not** an `IWaveIn`, so the pattern differs from
-`WaveIn` and `AlsaIn` in two ways. There is an explicit
-`InitializeRecording()` step before `StartRecording()`, and the capture
-format is not something you request — the HAL decides it, and you read
-it back from `CaptureFormat` once initialized:
+It has to be noted down that the `CoreAudioRecorder` class does *not* implement
+`IWaveIn`. As such, it diverges from the classic recording pattern in two ways:
 
-```c#
+1. Recording requires an explicit initialization.
+
+This happens because the HAL decides the audio format to record, not us.
+Because we have to do several things to ensure that it is possible to record,
+this preparation takes some time.
+
+2. The recording format is not something that you can request.
+
+The format is decided by the HAL and may be changed at any time.
+It is not something you decide.
+
+An example creating a new wave file directly from recording:
+
+~~~C#
+using System.Threading;
+
 using NAudio.Wave;
 
 using var input = new CoreAudioRecorder();   // default input device
@@ -36,16 +48,17 @@ input.RecordingStopped += (sender, a) =>
 input.StartRecording();
 Thread.Sleep(5000);                          // record for 5 seconds
 input.StopRecording();
-```
+~~~
 
+> [!CAUTION]
 `audioData` is a `ReadOnlySpan<byte>` pointing at a buffer owned by the
-HAL, so write or copy it before the handler returns — storing the span
-itself will later read memory that has been reused.
+HAL, so write or copy it to your own buffer before the handler returns 
+— storing the span itself will later read memory that has been reused.
 
 Alternatively, `CaptureAsync` yields `CoreAudioCaptureBuffer` objects,
 each with its own `byte[] Buffer`, and initializes the recorder for you:
 
-```c#
+~~~c#
 using var input = new CoreAudioRecorder();
 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
@@ -53,50 +66,45 @@ await foreach (var buffer in input.CaptureAsync(cts.Token))
 {
     writer.Write(buffer.Buffer, 0, buffer.Buffer.Length);
 }
-```
+~~~
 
-Both forms also hand you HAL timestamps (in seconds) for the start of
+> [!NOTE]
+Both recording forms hand you HAL timestamps (in seconds) for the start of
 the I/O cycle and for the first byte captured, which is what you need to
 line a recording up against another clock.
 
-### Recording straight to a compressed file
+> [!NOTE]
+As it was mentioned before, the capture format may be changed multiple
+times during capture. Once that happens, the recording is stopped,
+and the `CaptureFormatChanged` event dispatches.
+You can restart the recording, or completely abort it.
 
-`ExtendedAudioFileWriter` encodes as it writes, using the codecs built
-into macOS — so you can record to AAC/M4A, FLAC or CAF with no
-third-party encoder. It is a `Stream`, and the target container is
-chosen by MIME type:
+### Recording permissions
 
-```c#
-using NAudio.Wave;
-using NAudio.MacOS.AudioToolbox;
+If the application you are using this API has not explicitly been given permission to capture,
+macOS will prompt at the first time to capture from the device.
+Even if the user denies access to the device, HAL does automatically write silence to the provided
+buffers for the duration of the recording.
 
-using var writer = ExtendedAudioFileWriter.CreateFromFilePath(
-    "recorded.m4a",
-    new ExtendedAudioFileWriterSettings
-    {
-        FileType = "audio/mp4",             // one of SupportedMimeTypes, see below
-        ProvidingFormat = input.CaptureFormat,
-    },
-    overwriteIfExists: true);
-```
+If you want to check that your application has access to the capture device, check
+in your macOS System Settings app -> go to Privacy &amp; Security -> scroll down to Microphone section and click it ->
+find your app.
 
-`ProvidingFormat` describes what you feed in, and must be PCM or IEEE
-float. The accepted `FileType` strings vary by macOS version — read them
-from `AudioFileLibraryInformation.SupportedMimeTypes` rather than
-hard-coding one.
+> [!NOTE]
+If you cannot find your app in the list, and you are using the terminal to run your app,
+make sure that the Terminal is granted access to the microphone. 
+The prompt is attributed to the app that macOS users can easily identify.
 
-For plain uncompressed output, prefer `WaveFileWriter`: WAV is what
-every other tool reads. `AiffFileWriter` in `NAudio.Core` is there if
-you want AIFF, and handles the byte-order swap to AIFF's big-endian
-layout for you.
+### Selecting a different capture device than the default
 
-### Choosing an input device, and permissions
+If you do not want to use the default input device to perform the capture,
+you can enumerate the available devices on the system by getting the `Devices`
+property on the HAL's audio system object:
 
-Enumerate `Devices` and pass one to the constructor:
-
-```c#
+~~~C#
 using NAudio.MacOS.CoreAudio;
 
+// Enumerate all the devices that provide input.
 foreach (var device in AudioSystemObject.Instance.Devices)
 {
     if (device.GetStreams(AudioObjectPropertyScopeConstants.Input).Length > 0)
@@ -104,11 +112,6 @@ foreach (var device in AudioSystemObject.Instance.Devices)
         Console.WriteLine($"{device.Name} - {device.Manufacturer}");
     }
 }
-// using var input = new CoreAudioRecorder(chosenDevice);
-```
-
-macOS gates microphone access, and the prompt is attributed to the host
-application — for a command-line tool that is the terminal, not your
-program. If access has been denied, capture typically yields silence
-rather than an error, so check System Settings › Privacy & Security ›
-Microphone if your recording comes out empty.
+// Once you have selected an audio device, you can give it to the recorder:
+// using var createdRecorder = new CoreAudioRecorder(chosenDevice);
+~~~

--- a/Docs/Resampling.md
+++ b/Docs/Resampling.md
@@ -1,33 +1,74 @@
-# Resampling Audio
+﻿# Resampling Audio
 
 Every now and then you'll find you need to resample audio with NAudio. For example, to mix files together of different sample rates, you need to get them all to a common sample rate first. Or if you're playing audio through an API like ASIO, audio must be resampled to match the output device's current sample rate before being sent to the device.
 
 There are also some gotchas you need to be aware of when resampling. In particular there is the danger of "aliasing". The main takeaway is that if you lower the sample rate, you really ought to use a low pass filter first, to get rid of high frequencies that cannot be correctly represented at the lower sample rate.
 
-## Option 1: MediaFoundationResampler
+## Option 1: MediaFoundationResampler (Windows)
 
 Probably the most powerful resampler available with NAudio is the `MediaFoundationResampler`. This uses the Windows Media Foundation resampler MFT, which is available on all supported versions of Windows (Windows 10+). It has a customisable quality level (60 is the highest quality, down to 1 which is linear interpolation). It's fast enough to run on top quality. It's also quite flexible and is often able to change to a different channel count or bit depth at the same time.
 
 Here's a code sample that resamples an MP3 file (usually 44.1kHz) down to 16kHz. The `MediaFoundationResampler` takes an `IWaveProvider` as input, and a desired output `WaveFormat`:
 
-```c#
+~~~c#
+using NAudio.Wave;
+
 int outRate = 16000;
+
 var inFile = @"test.mp3";
 var outFile = @"test resampled MF.wav";
-using (var reader = new Mp3FileReader(inFile))
-{
-    var outFormat = new WaveFormat(outRate, reader.WaveFormat.Channels);
-    using (var resampler = new MediaFoundationResampler(reader, outFormat))
-    {
-        // resampler.ResamplerQuality = 60; // default is already 60 (best quality)
-        WaveFileWriter.CreateWaveFile(outFile, resampler);
-    }
-}
-```
 
-## Option 2: WdlResamplingSampleProvider
+using var reader = new MediaFoundationReader(inFile);
 
-The second option is based on the Cockos WDL resampler for which we were kindly granted permission to use as part of NAudio. It works with floating point samples, so you'll need an `ISampleProvider` to pass in. Here we use `AudioFileReader` to get to floating point and then make a resampled 16 bit WAV file:
+var outFormat = new WaveFormat(outRate, reader.WaveFormat.Channels);
+using var resampler = new MediaFoundationResampler(reader, outFormat);
+
+// resampler.ResamplerQuality = 60; // default is already 60 (best quality)
+WaveFileWriter.CreateWaveFile(outFile, resampler);
+~~~
+
+## Option 2: AudioConverter (macOS)
+
+An equally powerful resampler as the `MediaFoundationResampler` that is provided with macOS
+in the new macOS wrappers package.
+Note that it ships pre-release only while its API settles, so `--prerelease` is also required:
+
+~~~C#
+dotnet add package NAudio.MacOS --prerelease
+~~~
+
+This resampler provides top-notch quality as the Windows Media resampler,
+but has a caveat: You cannot change any of the input stream format properties at any time.
+
+However, it allows us to select a resampling algorithm, quality and dithering algorithm if we want to.
+Also, it supports mapping the input channels to different outputs, or even disable input channels:
+
+~~~C#
+using NAudio.Wave;
+using NAudio.MacOS.AudioToolbox;
+
+int outRate = 16000;
+
+var inFile = @"test.mp3";
+var outFile = @"test resampled AudioConverter.wav";
+
+using var reader = ExtendedAudioFileReaderFromURL.CreateFromFile(inFile);
+
+var outFormat = new WaveFormat(outRate, reader.WaveFormat.Channels);
+using var resampler = new MacAudioConverter(reader, outFormat);
+
+// The default is Normal, minimum is Min, and Max is the maximum.
+// Resampling quality also depends on the resampling algorithm you use.
+// resampler.Quality = AudioConverterQuality.Max; 
+
+WaveFileWriter.CreateWaveFile(outFile, resampler);
+~~~
+
+As mentioned above, this requires running on macOS to be able to use this.
+
+## Option 3: WdlResamplingSampleProvider (cross-platform)
+
+The third option is based on the Cockos WDL resampler for which we were kindly granted permission to use as part of NAudio. It works with floating point samples, so you'll need an `ISampleProvider` to pass in. Here we use `AudioFileReader` to get to floating point and then make a resampled 16 bit WAV file:
 
 ```c#
 int outRate = 16000;
@@ -42,9 +83,9 @@ using (var reader = new AudioFileReader(inFile))
 
 The big advantage that the WDL resampler brings to the table is that it is fully managed code. This means it can be used in cross-platform scenarios where Windows Media Foundation is not available.
 
-The disadvantage is that performance will not necessarily be as fast as using `MediaFoundationResampler`.
+The disadvantage is that performance will not necessarily be as fast as using `MediaFoundationResampler` (or `MacAudioConverter` for macOS).
 
-## Option 3: ACM Resampler (legacy)
+## Option 4: ACM Resampler (Windows, legacy)
 
 You can also use `WaveFormatConversionStream` which is an ACM based resampler that has been in NAudio since the beginning. This is a legacy option - for new code, prefer `MediaFoundationResampler` or `WdlResamplingSampleProvider`. ACM resamples 16 bit audio only and you can't change the channel count at the same time. It requires a `WaveStream` as input. Here's it being used to resample an MP3 file:
 
@@ -62,6 +103,6 @@ using (var reader = new Mp3FileReader(inFile))
 }
 ```
 
-## Option 4: Do it yourself
+## Option 5: Do it yourself
 
 Of course the fact that NAudio lets you have raw access to the samples means you are able to write your own resampling algorithm, which could be linear interpolation or something more complex. However, you're likely to end up with significant aliasing if you don't also write a low pass filter. Given NAudio now has the WDL resampler, that should be used for all cases where you need a fully managed resampler.

--- a/Docs/toc.yml
+++ b/Docs/toc.yml
@@ -1,4 +1,4 @@
-- name: Upgrading
+﻿- name: Upgrading
   items:
     - name: Migrating from NAudio 2 to NAudio 3
       href: MigratingFromNAudio2.md
@@ -116,8 +116,12 @@
       href: RecordAudioFileLinuxAlsa.md
     - name: Validating ALSA on Linux
       href: ValidatingAlsaOnLinux.md
-- name: macOS (Core Audio)
+- name: macOS
   items:
+    - name: Use the Extended Audio File Services reader to read compressed files
+      href: ExtendedAudioFileServicesReader.md
+    - name: Use the Extended Audio File Services reader to write compressed files
+      href: ExtendedAudioFileServicesWriter.md
     - name: Play an audio file on macOS (Core Audio)
       href: PlayAudioFileMacOS.md
     - name: Record an audio file on macOS (Core Audio)

--- a/src/NAudio.MacOS/MacOS/AudioToolbox/AudioConverterDitheringAlgorithm.cs
+++ b/src/NAudio.MacOS/MacOS/AudioToolbox/AudioConverterDitheringAlgorithm.cs
@@ -1,4 +1,4 @@
-// This interop definition was derived from the file AudioConverter.h of the Audio Toolbox Framework.
+﻿// This interop definition was derived from the file AudioConverter.h of the Audio Toolbox Framework.
 // See https://developer.apple.com/documentation/audiotoolbox for more information.
 
 using System.Runtime.Versioning;
@@ -7,7 +7,7 @@ namespace NAudio.MacOS.AudioToolbox;
 
 /// <summary>
 /// Dithering algorithms for audio converters <br />
-/// Constants to be used as the value for kAudioConverterPropertyDithering.
+/// Constants to be used as the value for the <see cref="Wave.MacAudioConverter.Dithering"/> property.
 /// </summary>
 [SupportedOSPlatform("macos")]
 [UnsupportedOSPlatform("ios")]

--- a/src/NAudio.MacOS/MacOS/AudioToolbox/AudioConverterQuality.cs
+++ b/src/NAudio.MacOS/MacOS/AudioToolbox/AudioConverterQuality.cs
@@ -1,11 +1,11 @@
-// This interop definition was derived from the file AudioConverter.h of the Audio Toolbox Framework.
+﻿// This interop definition was derived from the file AudioConverter.h of the Audio Toolbox Framework.
 // See https://developer.apple.com/documentation/audiotoolbox for more information.
 
 namespace NAudio.MacOS.AudioToolbox;
 
 /// <summary>
 /// Quality constants for audio converters <br />
-/// Constants to be used with <see cref="Wave.MacAudioConverter.Quality"/> property.
+/// Constants to be used with the <see cref="Wave.MacAudioConverter.Quality"/> property.
 /// </summary>
 public enum AudioConverterQuality : uint
 {

--- a/src/NAudio.MacOS/MacOS/AudioToolbox/ExtendedAudioFileReaderSettings.cs
+++ b/src/NAudio.MacOS/MacOS/AudioToolbox/ExtendedAudioFileReaderSettings.cs
@@ -1,4 +1,4 @@
-
+﻿
 using NAudio.Wave;
 
 namespace NAudio.MacOS.AudioToolbox;
@@ -30,7 +30,7 @@ public class ExtendedAudioFileReaderSettings
     /// it will take precendence over this one and the reader will go 
     /// ahead and specify IEEE 32-bit depth.
     /// </remarks>
-    public bool AllowNonPowerOfTwoBitRates { get; set; }
+    public bool AllowNonPowerOfTwoBitDepths { get; set; }
 
     /// <summary>
     /// A completely specified PCM or IEEE floating-point <see cref="WaveFormat"/>
@@ -41,7 +41,7 @@ public class ExtendedAudioFileReaderSettings
     /// </summary>
     /// <remarks>
     /// Note that this property, when appropriately defined, is exclusive to both
-    /// <see cref="RequestIeeeFloat"/> and <see cref="AllowNonPowerOfTwoBitRates"/>
+    /// <see cref="RequestIeeeFloat"/> and <see cref="AllowNonPowerOfTwoBitDepths"/>
     /// properties as they are purely existing to manipulate the default built-in logic
     /// of the reader.
     /// </remarks>

--- a/src/NAudio.MacOS/MacOS/AudioToolbox/ExtendedAudioFileServicesReader.cs
+++ b/src/NAudio.MacOS/MacOS/AudioToolbox/ExtendedAudioFileServicesReader.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Numerics;
 using System.Threading;
@@ -58,7 +58,7 @@ public abstract class ExtendedAudioFileServicesReader : WaveStream
         // The wave format is constructed with minimal effort 
         // closest to the file's one, if no special options were given by the user.
 
-        bool allowNonPowerOfTwoRates = true;
+        bool allowNonPowerOfTwoDepths = true;
         bool needsIeeeFloatSpecifically = false;
         Speakers decodedSpeakers = Speakers.None;
 
@@ -68,7 +68,7 @@ public abstract class ExtendedAudioFileServicesReader : WaveStream
             if (targetFormat is null)
             {
                 needsIeeeFloatSpecifically = settings.RequestIeeeFloat;
-                allowNonPowerOfTwoRates = settings.AllowNonPowerOfTwoBitRates;
+                allowNonPowerOfTwoDepths = settings.AllowNonPowerOfTwoBitDepths;
             }
             else if (targetFormat is WaveFormatExtensible ext)
             {
@@ -96,7 +96,7 @@ public abstract class ExtendedAudioFileServicesReader : WaveStream
                 // The bit rate might not be a power of two for some files,
                 // so we need to flag that to not lose any information 
                 // (if of course the user wants non-power of two bit depth rates)
-                bitRateSpecified = !allowNonPowerOfTwoRates;
+                bitRateSpecified = !allowNonPowerOfTwoDepths;
                 bitRate = (int)sourceAsbd.mBitsPerChannel;
             }
 

--- a/src/NAudio.MacOS/MacOS/AudioToolbox/ExtendedAudioFileServicesReader.cs
+++ b/src/NAudio.MacOS/MacOS/AudioToolbox/ExtendedAudioFileServicesReader.cs
@@ -79,25 +79,25 @@ public abstract class ExtendedAudioFileServicesReader : WaveStream
         if (targetFormat is null)
         {
             // Source format may be wildly incomplete, so try to complete it and do validation on it.
-            bool bitRateSpecified = false;
-            int bitRate, sampleRate, channels;
+            bool bitDepthSpecified = false;
+            int bitDepth, sampleRate, channels;
             if (needsIeeeFloatSpecifically)
             {
-                bitRate = 32;
+                bitDepth = 32;
             }
             // Bit rate may be specified as zero, so define good defaults for it.
             else if (sourceAsbd.mBitsPerChannel == 0U)
             {
                 // 16 bit depth suffices for most cases.
-                bitRate = 16;
+                bitDepth = 16;
             }
             else
             {
-                // The bit rate might not be a power of two for some files,
+                // The bit depth might not be a power of two for some files,
                 // so we need to flag that to not lose any information 
-                // (if of course the user wants non-power of two bit depth rates)
-                bitRateSpecified = !allowNonPowerOfTwoDepths;
-                bitRate = (int)sourceAsbd.mBitsPerChannel;
+                // (if of course the user wants non-power of two bit depths)
+                bitDepthSpecified = !allowNonPowerOfTwoDepths;
+                bitDepth = (int)sourceAsbd.mBitsPerChannel;
             }
 
             if (sourceAsbd.mSampleRate == 0d)
@@ -128,14 +128,14 @@ public abstract class ExtendedAudioFileServicesReader : WaveStream
             bool extensibleIsNeeded = false;
             decodedSpeakers = ComputeFileSpeakersValue(out extensibleIsNeeded);
 
-            if (extensibleIsNeeded || (bitRateSpecified && (!BitOperations.IsPow2(bitRate))))
+            if (extensibleIsNeeded || (bitDepthSpecified && (!BitOperations.IsPow2(bitDepth))))
             {
                 targetFormat = new WaveFormatExtensible(
                     sampleRate,
-                    bitRateSpecified ? (int)BitOperations.RoundUpToPowerOf2((uint)bitRate) : bitRate,
+                    bitDepthSpecified ? (int)BitOperations.RoundUpToPowerOf2((uint)bitDepth) : bitDepth,
                     channels,
                     needsIeeeFloatSpecifically,
-                    bitRate,
+                    bitDepth,
                     decodedSpeakers
                 );
             }
@@ -143,7 +143,7 @@ public abstract class ExtendedAudioFileServicesReader : WaveStream
             {
                 targetFormat = needsIeeeFloatSpecifically ?
                     WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels) :
-                    new(sampleRate, bitRate, channels);
+                    new(sampleRate, bitDepth, channels);
             }
         }
 

--- a/src/NAudio.MacOS/Wave/CaptureDataAvailableHandler.cs
+++ b/src/NAudio.MacOS/Wave/CaptureDataAvailableHandler.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 
 namespace NAudio.Wave;
@@ -15,7 +15,7 @@ namespace NAudio.Wave;
 /// your own buffer before the execution of the method reaches it's end.
 /// </remarks>
 /// <param name="audioData">The span of bytes containing the capture data.</param>
-/// <param name="currentTimeInSeconds">A HAL timestamp, in seconds, that indicate when the HAL invoked the handler.</param>
+/// <param name="currentTimeInSeconds">A HAL timestamp, in seconds, that indicate when the HAL started the I/O cycle.</param>
 /// <param name="firstByteAcquiredFromHALTimeInSeconds">A HAL timestamp, in seconds, that indicate when the first byte of the currently provided audio data was retrieved.</param>
 public delegate void CoreAudioCaptureDataAvailableHandler(
     ReadOnlySpan<byte> audioData,

--- a/src/NAudio.MacOS/Wave/CoreAudioPlayer.BaseAPI.cs
+++ b/src/NAudio.MacOS/Wave/CoreAudioPlayer.BaseAPI.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Threading;
 using System.Diagnostics;
@@ -49,7 +49,7 @@ public sealed partial class CoreAudioPlayer : IWavePlayer, IWaveLatency, IWavePo
     /// Initializes a new Core Audio player instance that renders
     /// audio to the system's default output device. <br />
     /// If a synchronization context is assigned for the thread where this instance
-    /// is created to, it is used during playback stopped events.
+    /// is created to, it is used when a playback stopped event is dispatching.
     /// </summary>
     public CoreAudioPlayer() : this(AudioSystemObject.Instance.DefaultOutputDevice) { }
 
@@ -57,7 +57,7 @@ public sealed partial class CoreAudioPlayer : IWavePlayer, IWaveLatency, IWavePo
     /// Initializes a new Core Audio player instance that renders audio
     /// to the specified Core Audio <see cref="AudioDevice"/> instance. <br />
     /// If a synchronization context is assigned for the thread where this instance
-    /// is created to, it is used during playback stopped events.
+    /// is created to, it is used when a playback stopped event is dispatching.
     /// </summary>
     /// <param name="device">The audio device where the audio will be rendered to</param>
     /// <exception cref="ArgumentNullException"><paramref name="device"/> is <see langword="null"/>.</exception>
@@ -384,9 +384,6 @@ public sealed partial class CoreAudioPlayer : IWavePlayer, IWaveLatency, IWavePo
     /// </remarks>
     public void Pause()
     {
-        // The below function call is not required; it is implicitly 
-        // handled by the call of OutputWaveFormat property, passed
-        // to the CurrentRunBytes method.
         ThrowIfInvalidOrDisposed();
         ioProcedure.Stop();
         // Bank what this run played, so a following Play continues the count.

--- a/src/NAudio.MacOS/Wave/ExtendedAudioFileWriter.cs
+++ b/src/NAudio.MacOS/Wave/ExtendedAudioFileWriter.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.IO;
 using System.Runtime.Versioning;
@@ -85,7 +85,7 @@ public unsafe partial class ExtendedAudioFileWriter : ExtendedAudioFileServicesW
     /// <exception cref="ArgumentException">The specified settings object does not define the minimal requirements for writing a file.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="url"/> and/or <paramref name="settings"/> are <see langword="null"/>.</exception>
     [SupportedOSPlatform("macos10.5")]
-    public static ExtendedAudioFileWriter CreateFromURL(
+    public static ExtendedAudioFileWriter CreateToURL(
         Uri url,
         ExtendedAudioFileWriterSettings settings,
         bool overwriteIfExists = false
@@ -138,7 +138,7 @@ public unsafe partial class ExtendedAudioFileWriter : ExtendedAudioFileServicesW
     /// <exception cref="ArgumentException">The specified settings object does not define the minimal requirements for writing a file.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="filePath"/> and/or <paramref name="settings"/> are <see langword="null"/>.</exception>
     [SupportedOSPlatform("macos10.5")]
-    public static ExtendedAudioFileWriter CreateFromFilePath(
+    public static ExtendedAudioFileWriter CreateToFilePath(
         string filePath,
         ExtendedAudioFileWriterSettings settings,
         bool overwriteIfExists = false
@@ -223,7 +223,7 @@ public unsafe partial class ExtendedAudioFileWriter : ExtendedAudioFileServicesW
     /// <see cref="MemoryStream"/> instance to make sure the writer can work with it,
     /// then copy the data written to it to your target stream.
     /// </remarks>
-    public static ExtendedAudioFileWriter CreateFromStream(
+    public static ExtendedAudioFileWriter CreateToStream(
         Stream writeableStream,
         ExtendedAudioFileWriterSettings settings
     )

--- a/src/NAudio.MacOS/Wave/MacAudioConverter.cs
+++ b/src/NAudio.MacOS/Wave/MacAudioConverter.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Threading;
 using System.Diagnostics;
@@ -252,7 +252,7 @@ public sealed unsafe class MacAudioConverter : IWaveProvider, IDisposable
     /// mapped to the output.
     /// </remarks>
     /// <param name="channelMap">
-    /// The array that contains channel map to assign.
+    /// The array that contains the channel map to assign.
     /// The length of this array must be the value of the <see cref="WaveFormat.Channels"/> property.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="channelMap"/> is <see langword="null"/>.</exception>

--- a/tests/NAudio.MacOS.Tests/ExtendedAudioFileServicesTests/ReaderSeekTests.cs
+++ b/tests/NAudio.MacOS.Tests/ExtendedAudioFileServicesTests/ReaderSeekTests.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.IO;
 
@@ -80,7 +80,7 @@ public class ReaderSeekTests
         ExtendedAudioFileServicesWriter writer = null;
         try
         {
-            writer = ExtendedAudioFileWriter.CreateFromFilePath(
+            writer = ExtendedAudioFileWriter.CreateToFilePath(
                 path,
                 new() { FileType = "audio/aac", ProvidingFormat = new(44100, 16, 1) },
                 true

--- a/tests/NAudio.MacOS.Tests/ExtendedAudioFileServicesTests/WriterTests.cs
+++ b/tests/NAudio.MacOS.Tests/ExtendedAudioFileServicesTests/WriterTests.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.IO;
 
@@ -37,7 +37,7 @@ public class WriterTests
         settings ??= new();
         settings.ProvidingFormat = sg.WaveFormat;
         var path = CreateRandomFileName();
-        var wr = ExtendedAudioFileWriter.CreateFromFilePath(path, settings, true);
+        var wr = ExtendedAudioFileWriter.CreateToFilePath(path, settings, true);
         WriteAndDisposeWriter(wr, sg);
         TryDeleteTheCreatedFile(path);
     }
@@ -58,7 +58,7 @@ public class WriterTests
 
         try
         {
-            var wr = ExtendedAudioFileWriter.CreateFromStream(fs, settings);
+            var wr = ExtendedAudioFileWriter.CreateToStream(fs, settings);
             WriteAndDisposeWriter(wr, sg);
         }
         finally


### PR DESCRIPTION
## Summary

Follow-up PR for the PR #1398.

This PR covers the documentation part of the original macOS wrappers PR, which that PR did not shipped.

It provides a full set of documentation for all the new API's provided by the macOS wrappers.
The TOC has also been updated.

Some API's were also renamed during this process so that the intent is better understood.

Additionally, the `Resampling.md` document has been updated to add the macOS resampler into the list of available resamplers to use.

## Release notes

- [ ] I've added a one-line bullet to the `### Unreleased` section of [RELEASE_NOTES.md](../RELEASE_NOTES.md)
- [X] This PR doesn't need a release-notes entry (internal refactor, test-only, or docs fix)
- [ ] Leave the release-notes entry for the maintainer to write

## Testing

No testing required, this just updates the documentation.